### PR TITLE
Add POW checking [TE-414]

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -354,6 +354,42 @@ steps:
   commands:
     - /artifacts/p2p_test --nocapture --ignored test_peer_threshold
 
+- name: p2p-pow-test-ok
+  image: simplestakingcom/tezedge-ci-builder:latest
+  pull: if-not-exists
+  user: root
+  volumes:
+    - name: build
+      path: /artifacts
+  environment:
+    RUST_BACKTRACE: 1
+    LOG_LEVEL: debug
+    OCAML_LOG_ENABLED: false
+    LD_LIBRARY_PATH: /artifacts/ffi
+    PROTOCOL_RUNNER: /artifacts/protocol-runner
+    CARGO_MANIFEST_DIR: /artifacts/test_data
+    OUT_DIR: .
+  commands:
+    - /artifacts/p2p_test --nocapture --ignored test_proof_of_work_ok
+
+- name: p2p-pow-test-fail
+  image: simplestakingcom/tezedge-ci-builder:latest
+  pull: if-not-exists
+  user: root
+  volumes:
+    - name: build
+      path: /artifacts
+  environment:
+    RUST_BACKTRACE: 1
+    LOG_LEVEL: debug
+    OCAML_LOG_ENABLED: false
+    LD_LIBRARY_PATH: /artifacts/ffi
+    PROTOCOL_RUNNER: /artifacts/protocol-runner
+    CARGO_MANIFEST_DIR: /artifacts/test_data
+    OUT_DIR: .
+  commands:
+    - /artifacts/p2p_test --nocapture --ignored test_proof_of_work_fail
+
 - name: record/replay-context-action-file-test
   image: simplestakingcom/tezedge-ci-builder:latest
   pull: if-not-exists

--- a/light_node/src/main.rs
+++ b/light_node/src/main.rs
@@ -378,6 +378,7 @@ fn block_on_actors(
         identity,
         shell_compatibility_version,
         env.p2p,
+        env.identity.expected_pow,
     )
     .expect("Failed to create peer manager");
 

--- a/networking/src/lib.rs
+++ b/networking/src/lib.rs
@@ -52,6 +52,8 @@ pub struct LocalPeerInfo {
     identity: Arc<Identity>,
     /// version of shell/network protocol which we are compatible with
     version: Arc<ShellCompatibilityVersion>,
+    /// Target number for proof-of-work
+    pow_target: f64,
 }
 
 impl LocalPeerInfo {
@@ -59,11 +61,13 @@ impl LocalPeerInfo {
         listener_port: u16,
         identity: Arc<Identity>,
         version: Arc<ShellCompatibilityVersion>,
+        pow_target: f64,
     ) -> Self {
         LocalPeerInfo {
             listener_port,
             identity,
             version,
+            pow_target,
         }
     }
 

--- a/networking/src/p2p/peer.rs
+++ b/networking/src/p2p/peer.rs
@@ -16,14 +16,18 @@ use tokio::net::TcpStream;
 use tokio::runtime::Handle;
 use tokio::time::timeout;
 
-use crypto::nonce::{self, Nonce, NoncePair};
 use crypto::{
     blake2b::Blake2bError,
     crypto_box::{CryptoKey, PrecomputedKey, PublicKey},
+    proof_of_work::PowError,
 };
 use crypto::{
     crypto_box::PublicKeyError,
     hash::{CryptoboxPublicKeyHash, Hash},
+};
+use crypto::{
+    nonce::{self, Nonce, NoncePair},
+    proof_of_work::check_proof_of_work,
 };
 use tezos_encoding::{
     binary_reader::{BinaryReaderError, BinaryReaderErrorKind},
@@ -67,6 +71,8 @@ pub enum PeerError {
     CryptoError { error: crypto::CryptoError },
     #[fail(display = "Public key error: {}", _0)]
     PublicKeyError(PublicKeyError),
+    #[fail(display = "Not enough proof of work: {}", _0)]
+    PowError(PowError),
 }
 
 impl From<BinaryWriterError> for PeerError {
@@ -431,6 +437,26 @@ pub async fn bootstrap(
     let connection_message =
         ConnectionMessage::from_bytes(received_connection_message_bytes.content())?;
 
+    // create PublicKey from received bytes from remote peer
+    let peer_public_key = PublicKey::from_bytes(connection_message.public_key())?;
+
+    let connecting_to_self = peer_public_key == info.identity.public_key;
+    if connecting_to_self {
+        warn!(log, "Detected self connection");
+        // treat as if nack was received
+        return Err(PeerError::NackWithMotiveReceived {
+            nack_info: NackInfo::new(NackMotive::AlreadyConnected, &[]),
+        });
+    }
+
+    // make sure the peer performed enough crypto calculations
+    if let Err(e) = check_proof_of_work(
+        &received_connection_message_bytes.raw()[4..60],
+        info.pow_target,
+    ) {
+        return Err(PeerError::PowError(e));
+    }
+
     // generate local and remote nonce
     let NoncePair {
         local: nonce_local,
@@ -441,9 +467,6 @@ pub async fn bootstrap(
         msg.incoming,
     )?;
 
-    // create PublicKey from received bytes from remote peer
-    let peer_public_key = PublicKey::from_bytes(connection_message.public_key())?;
-
     // pre-compute encryption key
     let precomputed_key = PrecomputedKey::precompute(&peer_public_key, &info.identity.secret_key);
 
@@ -453,19 +476,9 @@ pub async fn bootstrap(
     let log = log.new(o!("peer_id" => peer_id_marker.clone()));
 
     // from now on all messages will be encrypted
-    let mut msg_tx =
-        EncryptedMessageWriter::new(msg_tx, precomputed_key.clone(), nonce_local, log.clone());
     let mut msg_rx =
-        EncryptedMessageReader::new(msg_rx, precomputed_key, nonce_remote, log.clone());
-
-    let connecting_to_self = peer_public_key == info.identity.public_key;
-    if connecting_to_self {
-        debug!(log, "Detected self connection");
-        // treat as if nack was received
-        return Err(PeerError::NackWithMotiveReceived {
-            nack_info: NackInfo::new(NackMotive::AlreadyConnected, &[]),
-        });
-    }
+        EncryptedMessageReader::new(msg_rx, precomputed_key.clone(), nonce_remote, log.clone());
+    let mut msg_tx = EncryptedMessageWriter::new(msg_tx, precomputed_key, nonce_local, log.clone());
 
     // send metadata
     let metadata = MetadataMessage::new(msg.disable_mempool, msg.private_node);
@@ -475,15 +488,14 @@ pub async fn bootstrap(
     let metadata_received = timeout(IO_TIMEOUT, msg_rx.read_message::<MetadataMessage>()).await??;
     debug!(log, "Received remote peer metadata"; "disable_mempool" => metadata_received.disable_mempool(), "private_node" => metadata_received.private_node());
 
+    let peer_version = connection_message.version();
+
     let compatible_network_version =
-        match supported_protocol_version.choose_compatible_version(connection_message.version()) {
+        match supported_protocol_version.choose_compatible_version(peer_version) {
             Ok(compatible_version) => compatible_version,
             Err(nack_motive) => {
                 // send nack
-                if connection_message
-                    .version()
-                    .supports_nack_with_list_and_motive()
-                {
+                if peer_version.supports_nack_with_list_and_motive() {
                     timeout(
                         IO_TIMEOUT,
                         msg_tx.write_message(&AckMessage::Nack(NackInfo::new(nack_motive, &[]))),
@@ -502,9 +514,9 @@ pub async fn bootstrap(
                     ),
                     incompatible_version: format!(
                         "{}/distributed_db_version {}/p2p_version {}",
-                        connection_message.version().chain_name(),
-                        connection_message.version().distributed_db_version(),
-                        connection_message.version().p2p_version()
+                        peer_version.chain_name(),
+                        peer_version.distributed_db_version(),
+                        peer_version.p2p_version()
                     ),
                 });
             }

--- a/shell/src/peer_manager.rs
+++ b/shell/src/peer_manager.rs
@@ -192,6 +192,7 @@ impl PeerManager {
         identity: Arc<Identity>,
         shell_compatibility_version: Arc<ShellCompatibilityVersion>,
         p2p_config: P2p,
+        pow_target: f64,
     ) -> Result<PeerManagerRef, CreateError> {
         sys.actor_of_props::<PeerManager>(
             PeerManager::name(),
@@ -202,6 +203,7 @@ impl PeerManager {
                 identity,
                 shell_compatibility_version,
                 p2p_config,
+                pow_target,
             )),
         )
     }
@@ -491,6 +493,7 @@ impl
         Arc<Identity>,
         Arc<ShellCompatibilityVersion>,
         P2p,
+        f64,
     )> for PeerManager
 {
     fn create_args(
@@ -501,6 +504,7 @@ impl
             identity,
             shell_compatibility_version,
             p2p_config,
+            pow_target,
         ): (
             NetworkChannelRef,
             ShellChannelRef,
@@ -508,6 +512,7 @@ impl
             Arc<Identity>,
             Arc<ShellCompatibilityVersion>,
             P2p,
+            f64,
         ),
     ) -> Self {
         // resolve all bootstrap addresses
@@ -536,6 +541,7 @@ impl
                 p2p_config.listener_port,
                 identity,
                 shell_compatibility_version,
+                pow_target,
             )),
             listener_address: p2p_config.listener_address,
             disable_mempool: p2p_config.disable_mempool,

--- a/shell/tests/chain_test.rs
+++ b/shell/tests/chain_test.rs
@@ -35,6 +35,8 @@ use tezos_messages::p2p::encoding::prelude::Mempool;
 
 pub mod common;
 
+pub const SIMPLE_POW_TARGET: f64 = 0f64;
+
 lazy_static! {
     pub static ref SHELL_COMPATIBILITY_VERSION: ShellCompatibilityVersion = ShellCompatibilityVersion::new("TEST_CHAIN".to_string(), vec![0], vec![0]);
     pub static ref NODE_P2P_PORT: u16 = 1234; // TODO: maybe some logic to verify and get free port
@@ -51,7 +53,8 @@ lazy_static! {
         },
         SHELL_COMPATIBILITY_VERSION.clone(),
     );
-    pub static ref NODE_IDENTITY: Identity = tezos_identity::Identity::generate(0f64).unwrap();
+    pub static ref NODE_IDENTITY: Identity = tezos_identity::Identity::generate(SIMPLE_POW_TARGET).unwrap();
+    pub static ref PEER_IDENTITY: Identity = tezos_identity::Identity::generate(SIMPLE_POW_TARGET).unwrap();
 }
 
 #[ignore]
@@ -76,6 +79,7 @@ fn test_process_current_branch_on_level3_then_current_head_level4() -> Result<()
         None,
         Some(NODE_P2P_CFG.clone()),
         NODE_IDENTITY.clone(),
+        SIMPLE_POW_TARGET,
         (log, log_level),
         vec![],
         (false, false),
@@ -94,7 +98,8 @@ fn test_process_current_branch_on_level3_then_current_head_level4() -> Result<()
         "TEST_PEER_NODE".to_string(),
         NODE_P2P_CFG.0.listener_port,
         NODE_P2P_CFG.1.clone(),
-        tezos_identity::Identity::generate(0f64)?,
+        PEER_IDENTITY.clone(),
+        SIMPLE_POW_TARGET,
         node.log.clone(),
         &node.tokio_runtime,
         common::test_cases_data::current_branch_on_level_3::serve_data,
@@ -178,6 +183,7 @@ fn test_process_reorg_with_different_current_branches() -> Result<(), failure::E
         patch_context,
         Some(NODE_P2P_CFG.clone()),
         NODE_IDENTITY.clone(),
+        SIMPLE_POW_TARGET,
         (log, log_level),
         vec![],
         (false, false),
@@ -197,7 +203,8 @@ fn test_process_reorg_with_different_current_branches() -> Result<(), failure::E
         "TEST_PEER_NODE_BRANCH_1".to_string(),
         NODE_P2P_CFG.0.listener_port,
         NODE_P2P_CFG.1.clone(),
-        tezos_identity::Identity::generate(0f64)?,
+        PEER_IDENTITY.clone(),
+        SIMPLE_POW_TARGET,
         node.log.clone(),
         &node.tokio_runtime,
         common::test_cases_data::sandbox_branch_1_level3::serve_data,
@@ -218,7 +225,8 @@ fn test_process_reorg_with_different_current_branches() -> Result<(), failure::E
         "TEST_PEER_NODE_BRANCH_2".to_string(),
         NODE_P2P_CFG.0.listener_port,
         NODE_P2P_CFG.1.clone(),
-        tezos_identity::Identity::generate(0f64)?,
+        PEER_IDENTITY.clone(),
+        SIMPLE_POW_TARGET,
         node.log.clone(),
         &node.tokio_runtime,
         common::test_cases_data::sandbox_branch_2_level4::serve_data,
@@ -323,6 +331,7 @@ fn test_process_current_heads_to_level3() -> Result<(), failure::Error> {
         None,
         Some(NODE_P2P_CFG.clone()),
         NODE_IDENTITY.clone(),
+        SIMPLE_POW_TARGET,
         (log, log_level),
         vec![],
         (false, false),
@@ -340,7 +349,8 @@ fn test_process_current_heads_to_level3() -> Result<(), failure::Error> {
         "TEST_PEER_NODE".to_string(),
         NODE_P2P_CFG.0.listener_port,
         NODE_P2P_CFG.1.clone(),
-        tezos_identity::Identity::generate(0f64)?,
+        PEER_IDENTITY.clone(),
+        SIMPLE_POW_TARGET,
         node.log.clone(),
         &node.tokio_runtime,
         common::test_cases_data::dont_serve_current_branch_messages::serve_data,
@@ -432,6 +442,7 @@ fn test_process_current_head_with_malformed_blocks_and_check_blacklist(
         None,
         Some(NODE_P2P_CFG.clone()),
         NODE_IDENTITY.clone(),
+        SIMPLE_POW_TARGET,
         (log, log_level),
         vec![],
         (false, false),
@@ -453,12 +464,13 @@ fn test_process_current_head_with_malformed_blocks_and_check_blacklist(
     )?;
 
     // connect mocked node peer with test data set
-    let test_node_identity = tezos_identity::Identity::generate(0f64)?;
+    let test_node_identity = PEER_IDENTITY.clone();
     let mut mocked_peer_node = common::test_node_peer::TestNodePeer::connect(
         "TEST_PEER_NODE-1".to_string(),
         NODE_P2P_CFG.0.listener_port,
         NODE_P2P_CFG.1.clone(),
         test_node_identity.clone(),
+        SIMPLE_POW_TARGET,
         node.log.clone(),
         &node.tokio_runtime,
         common::test_cases_data::current_branch_on_level_3::serve_data,
@@ -503,6 +515,7 @@ fn test_process_current_head_with_malformed_blocks_and_check_blacklist(
         NODE_P2P_CFG.0.listener_port,
         NODE_P2P_CFG.1.clone(),
         test_node_identity.clone(),
+        SIMPLE_POW_TARGET,
         node.log.clone(),
         &node.tokio_runtime,
         common::test_cases_data::current_branch_on_level_3::serve_data,
@@ -522,6 +535,7 @@ fn test_process_current_head_with_malformed_blocks_and_check_blacklist(
         NODE_P2P_CFG.0.listener_port,
         NODE_P2P_CFG.1.clone(),
         test_node_identity,
+        SIMPLE_POW_TARGET,
         node.log.clone(),
         &node.tokio_runtime,
         common::test_cases_data::current_branch_on_level_3::serve_data,
@@ -598,6 +612,7 @@ fn process_bootstrap_level1324_and_mempool_for_level1325(
         None,
         Some(NODE_P2P_CFG.clone()),
         NODE_IDENTITY.clone(),
+        SIMPLE_POW_TARGET,
         (log, log_level),
         context_action_recorders,
         (true, false),
@@ -619,7 +634,8 @@ fn process_bootstrap_level1324_and_mempool_for_level1325(
         "TEST_PEER_NODE".to_string(),
         NODE_P2P_CFG.0.listener_port,
         NODE_P2P_CFG.1.clone(),
-        tezos_identity::Identity::generate(0f64)?,
+        PEER_IDENTITY.clone(),
+        SIMPLE_POW_TARGET,
         node.log.clone(),
         &node.tokio_runtime,
         common::test_cases_data::current_branch_on_level_1324::serve_data,
@@ -827,6 +843,7 @@ fn test_process_bootstrap_level1324_and_generate_action_file() -> Result<(), fai
         None,
         Some(NODE_P2P_CFG.clone()),
         NODE_IDENTITY.clone(),
+        SIMPLE_POW_TARGET,
         (log, log_level),
         context_action_recorders,
         (true, true),
@@ -848,7 +865,8 @@ fn test_process_bootstrap_level1324_and_generate_action_file() -> Result<(), fai
         "TEST_PEER_NODE".to_string(),
         NODE_P2P_CFG.0.listener_port,
         NODE_P2P_CFG.1.clone(),
-        tezos_identity::Identity::generate(0f64)?,
+        PEER_IDENTITY.clone(),
+        SIMPLE_POW_TARGET,
         node.log.clone(),
         &node.tokio_runtime,
         common::test_cases_data::current_branch_on_level_1324::serve_data,

--- a/shell/tests/common/infra.rs
+++ b/shell/tests/common/infra.rs
@@ -68,6 +68,7 @@ impl NodeInfrastructure {
         patch_context: Option<PatchContext>,
         p2p: Option<(P2p, ShellCompatibilityVersion)>,
         identity: Identity,
+        pow_target: f64,
         (log, log_level): (Logger, Level),
         context_action_recorders: Vec<Box<dyn ActionRecorder + Send>>,
         (record_also_readonly_context_action, compute_context_action_tree_hashes): (bool, bool),
@@ -243,6 +244,7 @@ impl NodeInfrastructure {
                 identity,
                 Arc::new(shell_compatibility_version),
                 p2p_config,
+                pow_target,
             )
             .expect("Failed to create peer manager");
             Some(peer_manager)

--- a/shell/tests/common/test_cases_data.rs
+++ b/shell/tests/common/test_cases_data.rs
@@ -134,6 +134,39 @@ pub mod sandbox_branch_1_level3 {
     }
 }
 
+pub mod sandbox_branch_1_no_level {
+    use std::sync::Once;
+
+    use lazy_static::lazy_static;
+    use slog::{info, Logger};
+
+    use tezos_api::environment::TezosEnvironment;
+    use tezos_api::ffi::PatchContext;
+
+    use crate::common::samples::read_data_zip;
+    use crate::common::test_data::Db;
+
+    lazy_static! {
+        pub static ref DB: Db = Db::init_db(read_data_zip(
+            "sandbox_branch_1_level3.zip",
+            TezosEnvironment::Sandbox
+        ),);
+    }
+
+    pub fn init_data(log: &Logger) -> (&'static Db, Option<PatchContext>) {
+        static INIT_DATA: Once = Once::new();
+        INIT_DATA.call_once(|| {
+            info!(log, "Initializing test data sandbox_branch_1_no_level...");
+            let _ = DB.block_hash(1);
+            info!(log, "Test data sandbox_branch_1_no_level initialized!");
+        });
+        (
+            &DB,
+            Some(super::read_patch_context("sandbox-patch-context.json")),
+        )
+    }
+}
+
 pub mod sandbox_branch_2_level4 {
     use std::sync::Once;
 

--- a/shell/tests/p2p_test.rs
+++ b/shell/tests/p2p_test.rs
@@ -20,9 +20,12 @@ use shell::peer_manager::P2p;
 use shell::PeerConnectionThreshold;
 use storage::tests_common::TmpStorage;
 use tezos_api::environment::{TezosEnvironmentConfiguration, TEZOS_ENV};
-use tezos_identity::Identity;
 
 pub mod common;
+
+pub const TRIVIAL_POW_TARGET: f64 = 0f64;
+pub const MINIMAL_POW_TARGET: f64 = 8f64;
+pub const DEFAULT_POW_TARGET: f64 = crypto::proof_of_work::ProofOfWork::DEFAULT_TARGET;
 
 lazy_static! {
     pub static ref SHELL_COMPATIBILITY_VERSION: ShellCompatibilityVersion = ShellCompatibilityVersion::new("TEST_CHAIN".to_string(), vec![0], vec![0]);
@@ -40,7 +43,90 @@ lazy_static! {
         },
         SHELL_COMPATIBILITY_VERSION.clone(),
     );
-    pub static ref NODE_IDENTITY: Identity = tezos_identity::Identity::generate(0f64).unwrap();
+}
+
+#[ignore]
+#[test]
+#[serial]
+fn test_proof_of_work_ok() -> Result<(), failure::Error> {
+    test_proof_of_work("pow_ok", MINIMAL_POW_TARGET, MINIMAL_POW_TARGET, true)
+}
+
+#[ignore]
+#[test]
+#[serial]
+fn test_proof_of_work_fail() -> Result<(), failure::Error> {
+    test_proof_of_work("pow_fail", MINIMAL_POW_TARGET, TRIVIAL_POW_TARGET, false)
+}
+
+fn test_proof_of_work(
+    name: &str,
+    node_pow_target: f64,
+    peer_pow_target: f64,
+    should_succeed: bool,
+) -> Result<(), failure::Error> {
+    // logger
+    let log_level = common::log_level();
+    let log = common::create_logger(log_level);
+    let node_log = log.new(slog::o!("role" => "NODE"));
+    let peer_log = log.new(slog::o!("role" => "PEER"));
+
+    // prepare env data
+    let (tezos_env, patch_context) = {
+        let (db, patch_context) =
+            common::test_cases_data::sandbox_branch_1_no_level::init_data(&log);
+        (db.tezos_env, patch_context)
+    };
+    let tezos_env: &TezosEnvironmentConfiguration = TEZOS_ENV
+        .get(&tezos_env)
+        .expect("no environment configuration");
+
+    // start node
+    slog::info!(node_log, "Generating node identity..."; "pow_target" => node_pow_target);
+    let node_identity = tezos_identity::Identity::generate(node_pow_target)?;
+    slog::info!(node_log, "Node identity generated");
+    let node = common::infra::NodeInfrastructure::start(
+        TmpStorage::create(common::prepare_empty_dir(&format!("__test_{}", name)))?,
+        &common::prepare_empty_dir(&format!("__test_{}_context", name)),
+        "test_peer_threshold",
+        &tezos_env,
+        patch_context,
+        Some(NODE_P2P_CFG.clone()),
+        node_identity,
+        node_pow_target,
+        (node_log, log_level),
+        vec![],
+        (false, false),
+    )?;
+
+    // wait for storage initialization to genesis
+    node.wait_for_new_current_head(
+        "genesis",
+        node.tezos_env.genesis_header_hash()?,
+        (Duration::from_secs(5), Duration::from_millis(250)),
+    )?;
+
+    slog::info!(peer_log, "Generating peer identity..."; "pow_target" => peer_pow_target);
+    let peer_identity = tezos_identity::Identity::generate(peer_pow_target)?;
+    slog::info!(peer_log, "Peer identity generated");
+    let result = common::test_node_peer::TestNodePeer::try_connect(
+        "TEST_PEER",
+        NODE_P2P_CFG.0.listener_port,
+        NODE_P2P_CFG.1.clone(),
+        peer_identity,
+        peer_pow_target,
+        peer_log.clone(),
+        &node.tokio_runtime,
+    );
+
+    if should_succeed {
+        result.expect("Expected connection to succeed");
+    } else {
+        result.expect_err("Expected connection to fail");
+    }
+    slog::info!(peer_log, "Done connecting");
+
+    Ok(())
 }
 
 fn p2p_cfg_with_threshold(
@@ -85,7 +171,8 @@ fn test_peer_threshold() -> Result<(), failure::Error> {
             0,
             peer_threshold_high,
         )),
-        NODE_IDENTITY.clone(),
+        tezos_identity::Identity::generate(TRIVIAL_POW_TARGET)?,
+        TRIVIAL_POW_TARGET,
         (log, log_level),
         vec![],
         (false, false),
@@ -114,7 +201,9 @@ fn test_peer_threshold() -> Result<(), failure::Error> {
                 peer_name,
                 NODE_P2P_CFG.0.listener_port,
                 NODE_P2P_CFG.1.clone(),
-                tezos_identity::Identity::generate(0f64).expect("failed to generate identity"),
+                tezos_identity::Identity::generate(TRIVIAL_POW_TARGET)
+                    .expect("failed to generate identity"),
+                TRIVIAL_POW_TARGET,
                 node.log.clone(),
                 &node.tokio_runtime,
                 common::test_cases_data::sandbox_branch_1_level3::serve_data,


### PR DESCRIPTION
- `Peer` actor now checks proof of work right after receiving `ConnectionMessage`
- Two new tests are added to the `p2p_test`, one with non-zero POW target and another one with a peer with zero POW connecting to a node with non-zero one.

@bkontur I have to add a timeout at the end of the test, otherwise it looks like infrastructure initialization is not complete by the time it is dropped, and that cause consequent tests to fail.