### PR TITLE
Optimize the Staging Area Tree part of Context Storage

### DIFF
--- a/light_node/src/main.rs
+++ b/light_node/src/main.rs
@@ -3,7 +3,7 @@
 // #![forbid(unsafe_code)]
 
 use std::path::PathBuf;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use riker::actors::*;
@@ -524,7 +524,7 @@ fn main() {
     let sequences = Arc::new(Sequences::new(kv.clone(), 1000));
 
     // initialize merkle context
-    let merkle = Arc::new(RwLock::new(
+    let merkle = Arc::new(Mutex::new(
         initialize_merkle(
             &env.storage.context_kv_store,
             &main_chain,

--- a/shell/tests/chain_test.rs
+++ b/shell/tests/chain_test.rs
@@ -948,7 +948,7 @@ mod stats {
         // generate stats
         let m = persistent_storage.merkle();
         let merkle = m
-            .write()
+            .lock()
             .map_err(|e| failure::format_err!("Lock error: {:?}", e))?;
         let stats = merkle.get_merkle_stats()?;
 

--- a/storage/src/context/gc/mark_move_gced.rs
+++ b/storage/src/context/gc/mark_move_gced.rs
@@ -374,8 +374,9 @@ fn kvstore_gc_thread_fn<T: KeyValueStoreBackend<ContextKeyValueStoreSchema>>(
                 match entry {
                     Entry::Blob(_) => {}
                     Entry::Tree(tree) => {
-                        let children = tree.into_iter().map(|(_, node)| *node.entry_hash);
-                        todo_keys.extend(children);
+                        for node in tree.values() {
+                            todo_keys.push(node.entry_hash()?);
+                        }
                     }
                     Entry::Commit(commit) => {
                         todo_keys.push(commit.root_hash);

--- a/storage/src/context/gc/mod.rs
+++ b/storage/src/context/gc/mod.rs
@@ -85,8 +85,12 @@ pub fn collect_hashes(
                     // anywhere in the recursion paths. TODO: is revert possible?
                     let mut b = HashSet::new();
                     for (_, child_node) in tree.iter() {
-                        let entry = fetch_entry_from_store(store, *child_node.entry_hash)?;
-                        collect_hashes(&entry, &mut b, cache, store)?;
+                        let entry = &child_node
+                            .entry
+                            .try_borrow()
+                            .map_err(|_| HashingError::EntryBorrow)?;
+                        let entry = entry.as_ref().ok_or(HashingError::MissingEntry)?;
+                        collect_hashes(entry, &mut b, cache, store)?;
                     }
                     cache.insert(hash_entry(entry)?, b.clone());
                     batch.extend(b);

--- a/storage/src/context/merkle/hash/mod.rs
+++ b/storage/src/context/merkle/hash/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! A document describing the algorithm can be found [here](https://github.com/tarides/tezos-context-hash).
 
-use std::{array::TryFromSliceError, convert::TryInto, io};
+use std::{array::TryFromSliceError, convert::TryInto, io, sync::Arc};
 
 use blake2::digest::{InvalidOutputSize, Update, VariableOutput};
 use blake2::VarBlake2b;
@@ -36,6 +36,10 @@ pub enum HashingError {
     UnexpectedEmptyInode,
     #[fail(display = "Invalid hash value, reason: {}", _0)]
     InvalidHash(String),
+    #[fail(display = "Missing Entry")]
+    MissingEntry,
+    #[fail(display = "The Entry is borrowed more than once")]
+    EntryBorrow,
 }
 
 impl From<InvalidOutputSize> for HashingError {
@@ -59,7 +63,7 @@ impl From<io::Error> for HashingError {
 /// Inode representation used for hashing directories with >256 entries.
 enum Inode {
     Empty,
-    Value(Vec<(String, Node)>),
+    Value(Vec<(Arc<String>, Node)>),
     Tree {
         depth: u32,
         children: usize,
@@ -81,7 +85,7 @@ fn index(depth: u32, name: &str) -> u32 {
 // IMPORTANT: entries must be sorted in lexicographic order of the name
 // Because we use `OrdMap`, this holds true when we iterate the items, but this is
 // something to keep in mind if the representation of `Tree` changes.
-fn partition_entries(depth: u32, entries: &[(&String, &Node)]) -> Result<Inode, HashingError> {
+fn partition_entries(depth: u32, entries: &[(&Arc<String>, &Node)]) -> Result<Inode, HashingError> {
     if entries.is_empty() {
         Ok(Inode::Empty)
     } else if entries.len() <= 32 {
@@ -98,7 +102,7 @@ fn partition_entries(depth: u32, entries: &[(&String, &Node)]) -> Result<Inode, 
 
         // pointers = {p(i) | i <- [0..31], t(i) != Empty}
         for i in 0..=31 {
-            let entries_at_depth_and_index_i: Vec<(&String, &Node)> = entries
+            let entries_at_depth_and_index_i: Vec<(&Arc<String>, &Node)> = entries
                 .iter()
                 .filter(|(name, _)| index(depth, name) == i)
                 .cloned()
@@ -150,7 +154,7 @@ fn hash_long_inode(inode: &Inode) -> Result<EntryHash, HashingError> {
                     NodeKind::Leaf => hasher.update(&[1u8]),
                     NodeKind::NonLeaf => hasher.update(&[0u8]),
                 };
-                hasher.update(node.entry_hash.as_ref());
+                hasher.update(&node.entry_hash()?);
             }
         }
         Inode::Tree {
@@ -213,7 +217,7 @@ fn hash_short_inode(tree: &Tree) -> Result<EntryHash, HashingError> {
         leb128::write::unsigned(&mut hasher, k.len() as u64)?;
         hasher.update(k.as_bytes());
         hasher.update(&(ENTRY_HASH_LEN as u64).to_be_bytes());
-        hasher.update(&v.entry_hash.as_ref());
+        hasher.update(&v.entry_hash()?);
     }
 
     Ok(hasher.finalize_boxed().as_ref().try_into()?)
@@ -224,7 +228,8 @@ fn hash_short_inode(tree: &Tree) -> Result<EntryHash, HashingError> {
 pub(crate) fn hash_tree(tree: &Tree) -> Result<EntryHash, HashingError> {
     // If there are >256 entries, we need to partition the tree and hash the resulting inode
     if tree.len() > 256 {
-        let entries: Vec<(&String, &Node)> = tree.iter().map(|(s, n)| (s, n.as_ref())).collect();
+        let entries: Vec<(&Arc<String>, &Node)> =
+            tree.iter().map(|(s, n)| (s, n.as_ref())).collect();
         let inode = partition_entries(0, &entries)?;
         hash_long_inode(&inode)
     } else {
@@ -286,7 +291,7 @@ pub(crate) fn hash_entry(entry: &Entry) -> Result<EntryHash, HashingError> {
 #[cfg(test)]
 #[allow(unused_must_use)]
 mod tests {
-    use std::{env, fs::File, io::Read, path::Path, sync::Arc};
+    use std::{cell::RefCell, env, fs::File, io::Read, path::Path, sync::Arc};
 
     use flate2::read::GzDecoder;
 
@@ -402,9 +407,10 @@ mod tests {
         let mut dummy_tree = Tree::new();
         let node = Node {
             node_kind: NodeKind::Leaf,
-            entry_hash: Arc::new(hash_blob(&vec![1]).unwrap()), // 407f958990678e2e9fb06758bc6520dae46d838d39948a4c51a5b19bd079293d
+            entry_hash: RefCell::new(Some(hash_blob(&vec![1]).unwrap())),
+            entry: RefCell::new(None), // 407f958990678e2e9fb06758bc6520dae46d838d39948a4c51a5b19bd079293d
         };
-        dummy_tree.insert("a".to_string(), Arc::new(node));
+        dummy_tree.insert(Arc::new("a".to_string()), Arc::new(node));
 
         // hexademical representation of above tree:
         //
@@ -509,13 +515,14 @@ mod tests {
                     other => panic!("Got unexpected binding kind: {}", other),
                 };
                 let entry_hash = ContextHash::from_base58_check(&binding.hash).unwrap();
-                let entry_hash: Arc<EntryHash> =
-                    Arc::new(entry_hash.as_ref().as_slice().try_into().unwrap());
+                let entry_hash: RefCell<Option<EntryHash>> =
+                    RefCell::new(Some(entry_hash.as_ref().as_slice().try_into().unwrap()));
                 let node = Node {
                     node_kind,
                     entry_hash,
+                    entry: RefCell::new(None),
                 };
-                tree = tree.update(binding.name, Arc::new(node));
+                tree = tree.update(Arc::new(binding.name), Arc::new(node));
             }
 
             let expected_hash = ContextHash::from_base58_check(&test_case.hash).unwrap();

--- a/storage/src/context/merkle/mod.rs
+++ b/storage/src/context/merkle/mod.rs
@@ -1,12 +1,14 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::sync::Arc;
+use std::{cell::RefCell, sync::Arc};
 
 use serde::{Deserialize, Serialize};
 
 use crate::context::merkle::hash::EntryHash;
 use crate::context::ContextValue;
+
+use self::hash::{hash_entry, HashingError};
 
 pub mod hash;
 pub mod merkle_storage;
@@ -15,7 +17,7 @@ pub mod merkle_storage_stats;
 // Tree must be an ordered structure for consistent hash in hash_tree.
 // The entry names *must* be in lexicographical order, as required by the hashing algorithm.
 // Currently immutable OrdMap is used to allow cloning trees without too much overhead.
-pub type Tree = im::OrdMap<String, Arc<Node>>;
+pub type Tree = im::OrdMap<Arc<String>, Arc<Node>>;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum NodeKind {
@@ -26,7 +28,10 @@ pub enum NodeKind {
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct Node {
     pub node_kind: NodeKind,
-    pub entry_hash: Arc<EntryHash>,
+    #[serde(serialize_with = "ensure_non_null_entry_hash")]
+    pub entry_hash: RefCell<Option<EntryHash>>,
+    #[serde(skip)]
+    pub entry: RefCell<Option<Entry>>,
 }
 
 #[derive(Debug, Hash, Clone, Serialize, Deserialize, Eq, PartialEq)]
@@ -43,4 +48,43 @@ pub enum Entry {
     Tree(Tree),
     Blob(ContextValue),
     Commit(Commit),
+}
+
+impl Node {
+    pub fn entry_hash(&self) -> Result<EntryHash, hash::HashingError> {
+        match &mut *self
+            .entry_hash
+            .try_borrow_mut()
+            .map_err(|_| HashingError::EntryBorrow)?
+        {
+            Some(hash) => Ok(*hash),
+            entry_hash @ None => {
+                let hash = hash_entry(
+                    self.entry
+                        .try_borrow()
+                        .map_err(|_| HashingError::EntryBorrow)?
+                        .as_ref()
+                        .ok_or(HashingError::MissingEntry)?,
+                )?;
+                entry_hash.replace(hash);
+                Ok(hash)
+            }
+        }
+    }
+}
+
+// Make sure the node contains the entry hash when serializing
+fn ensure_non_null_entry_hash<S>(
+    entry_hash: &RefCell<Option<EntryHash>>,
+    s: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let entry_hash_ref = entry_hash.borrow();
+    let entry_hash = entry_hash_ref
+        .as_ref()
+        .ok_or_else(|| serde::ser::Error::custom("entry_hash missing in Node"))?;
+
+    s.serialize_some(entry_hash)
 }


### PR DESCRIPTION
This is a draft of my work on [TE-484], it's not finish yet.

This PR removes the hashmap `staged` from `MerkleStorage`.
Each `Node` now keeps the entry itself and its hash, the hash is computed only when necessary (when serializing).

It uses interior mutability to write the hash on the `Node`, let me know if interior mutability is not desirable.

I will update the PR with benchmarks results and a better description when I'm done with the code.

[TE-484]: https://simplestakingcom.atlassian.net/browse/TE-484