### PR TITLE
Fix deploy monitoring alerts

### DIFF
--- a/apps/deploy_monitoring/README.md
+++ b/apps/deploy_monitoring/README.md
@@ -8,7 +8,7 @@ Set up slack channel with an app that has webhooks and file:write privilages.
 
 ### Build
 
-```cargo build --bin monitoring --release```
+```cargo build --bin deploy-monitoring --release```
 
 ### Runing
 
@@ -16,10 +16,9 @@ We need to set the *TEZEDGE_IMAGE_TAG* environment var to the desired version of
 Note that the debugger container needs root privilages. 
 
 ```
-sudo TEZOS_NETWORK=delphinet HOSTNAME=$(hostname) ./target/release/monitoring \
+sudo TEZOS_NETWORK=delphinet HOSTNAME=$(hostname) ./target/release/deploy-monitoring \
 --compose-file-path apps/monitoring/docker-compose.deploy.latest.yml
 --image-monitor-interval 60 \ 
---info-interval 21600 \
 --resource-monitor-interval 15 \
 --slack-url https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX \
 --slack-token "Bearer xoxb-xxxxxxxxxxxx-xxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxx" \

--- a/apps/deploy_monitoring/docker-compose.deploy.latest.yml
+++ b/apps/deploy_monitoring/docker-compose.deploy.latest.yml
@@ -20,7 +20,7 @@ services:
 
   tezedge-node:
     image: simplestakingcom/tezedge:latest
-    command: ["--network", "${TEZOS_NETWORK}", "--actions-store-backend", "rocksdb", "file", "--log", "terminal", "file", "--log-file", "/tmp/tezedge/tezedge.log"]
+    command: ["--network", "${TEZOS_NETWORK}", "--actions-store-backend", "rocksdb,file", "--log", "terminal", "file", "--log-file", "/tmp/tezedge/tezedge.log"]
     logging:
       # Produce syslogs instead of terminal logs
       driver: "syslog"

--- a/apps/deploy_monitoring/docker-compose.localhost.yml
+++ b/apps/deploy_monitoring/docker-compose.localhost.yml
@@ -1,0 +1,92 @@
+version: "3"
+
+services:
+  tezedge-debugger:
+    image: simplestakingcom/tezedge-debugger:latest
+    privileged: true
+    environment:
+      - RUST_BACKTRACE=1
+    volumes:
+      - "tezedge-shared-data:/tmp/volume/tezedge:ro"
+      - "ocaml-shared-data:/tmp/volume/tezos:ro"
+      - "./debugger-config.toml:/home/appuser/config.toml:ro"
+      - "/sys/kernel/debug:/sys/kernel/debug:rw"
+      - "/tmp/report:/tmp/report:rw"
+      - "debugger-data:/tmp/debugger_database"
+    ports:
+      - "17732:17732"      # debugger RPC port
+      - "10001:10001/udp"  # debugger syslog port for tezedge node
+      - "11001:11001/udp"  # debugger syslog port for tezos node
+
+  tezedge-node:
+    image: simplestakingcom/tezedge:latest
+    command: ["--network", "${TEZOS_NETWORK}", "--actions-store-backend", "rocksdb", "file", "--log", "terminal", "file", "--log-file", "/tmp/tezedge/tezedge.log"]
+    logging:
+      # Produce syslogs instead of terminal logs
+      driver: "syslog"
+      options:
+        # Send the logs to syslog (UDP only) server (running on debugger)
+        syslog-address: "udp://0.0.0.0:10001"  # Port must match debugger syslog port in 'ports' section
+        # Always in same RFC 5424 format (with microseconds precision)
+        syslog-format: "rfc5424micro"
+    volumes:
+      - "tezedge-shared-data:/tmp/tezedge"
+    ports:
+      - "4927:4927"       # node WS port (required only for tezedge)
+      - "9732:9732"       # node P2P port
+      - "18732:18732"     # node RPC port
+      - "3030:3030"       # sandbox launcher port
+
+  tezedge-sandbox:
+    image: simplestakingcom/tezedge:sandbox-latest
+    logging:
+      # Produce syslogs instead of terminal logs
+      driver: "syslog"
+      options:
+        # Send the logs to syslog (UDP only) server (running on debugger)
+        syslog-address: "udp://0.0.0.0:10001"  # Port must match debugger syslog port in 'ports' section
+        # Always in same RFC 5424 format (with microseconds precision)
+        syslog-format: "rfc5424micro"
+    volumes:
+      - "tezedge-shared-data:/tmp/tezedge"
+    ports:
+      - "4927:4927"       # node WS port (required only for tezedge)
+      - "9732:9732"       # node P2P port
+      - "18732:18732"     # node RPC port
+      - "3030:3030"       # sandbox launcher port
+
+  ocaml-node:
+    image: tezos/tezos:v8.1
+    entrypoint: sh -c "sleep 5 && /usr/local/bin/entrypoint.sh tezos-node --cors-header='content-type' --cors-origin='*' --rpc-addr=[::]:18733 --net-addr=[::]:9733 --history-mode archive --network ${TEZOS_NETWORK}"
+    logging:
+      # Produce syslogs instead of terminal logs
+      driver: "syslog"
+      options:
+        # Send the logs to syslog (UDP only) server (running on debugger)
+        syslog-address: "udp://0.0.0.0:11001"  # Port must match debugger syslog port in 'ports' section
+        # Always in same RFC 5424 format (with microseconds precision)
+        syslog-format: "rfc5424micro"
+    volumes:
+      - "ocaml-shared-data:/var/run/tezos/node"
+    ports:
+      # should be equal inside docker and outside, because the node tells this port in its connection message,
+      # that is how peers can connect to it later
+      - "9733:9733"
+      - "18733:18733"     # node RPC port
+
+  explorer:
+    image: simplestakingcom/tezedge-explorer:latest
+    environment:
+      - SANDBOX=http://localhost:3030
+      - DEBUGGER=http://localhost:17732
+      # need a better way to provide such information
+      - API=[{"id":"rust","name":"rust.localhost","http":"http://localhost:18732","ws":"ws://localhost:4927","monitoring":"http://localhost:38732/resources/tezedge","p2p_port":9732,"features":["MONITORING","RESOURCES","MEMPOOL_ACTION","STORAGE_BLOCK","NETWORK_ACTION","LOGS_ACTION"]},{"id":"ocaml","name":"ocaml.localhost","http":"http://localhost:18733","ws":false,"monitoring":"http://localhost:38732/resources/ocaml","p2p_port":9733,"features":["MONITORING","RESOURCES","MEMPOOL_ACTION","NETWORK_ACTION","LOGS_ACTION"]}]
+    ports:
+      - "80:80"
+volumes:
+  tezedge-shared-data:
+    external: false
+  ocaml-shared-data:
+    external: false
+  debugger-data:
+    external: false

--- a/apps/deploy_monitoring/src/configuration.rs
+++ b/apps/deploy_monitoring/src/configuration.rs
@@ -256,9 +256,11 @@ impl DeployMonitoringEnvironment {
         let alert_thresholds = AlertThresholds {
             memory: args
                 .value_of("alert-threshold-memory")
-                .unwrap_or("10737418240")
+                .unwrap_or("4096")
                 .parse::<u64>()
-                .expect("Was expecting number of bytes [u64]"),
+                .expect("Was expecting number of bytes [u64]")
+                * 1024
+                * 1024,
             disk: args
                 .value_of("alert-threshold-disk")
                 .unwrap_or("95")

--- a/apps/deploy_monitoring/src/monitors/deploy.rs
+++ b/apps/deploy_monitoring/src/monitors/deploy.rs
@@ -30,6 +30,7 @@ pub struct DeployMonitor {
     slack: Option<SlackServer>,
     log: Logger,
     cleanup: bool,
+    tezedge_only: bool,
 }
 
 impl DeployMonitor {
@@ -39,6 +40,7 @@ impl DeployMonitor {
         slack: Option<SlackServer>,
         log: Logger,
         cleanup: bool,
+        tezedge_only: bool,
     ) -> Self {
         Self {
             compose_file_path,
@@ -46,6 +48,7 @@ impl DeployMonitor {
             slack,
             log,
             cleanup,
+            tezedge_only,
         }
     }
 
@@ -138,7 +141,7 @@ impl DeployMonitor {
             // if debugger updated not need to restart explorer
             // if explorer updated, only need to restart explorer and so on...
             if node_updated || debugger_updated || explorer_updated {
-                shutdown_and_update(&compose_file_path, log, self.cleanup).await;
+                shutdown_and_update(&compose_file_path, log, self.cleanup, self.tezedge_only).await;
             } else {
                 // Do nothing, No update occurred
                 info!(self.log, "No image change detected");
@@ -152,7 +155,7 @@ impl DeployMonitor {
             }
 
             self.send_log_dump().await?;
-            restart_stack(&compose_file_path, log, self.cleanup).await;
+            restart_stack(&compose_file_path, log, self.cleanup, self.tezedge_only).await;
         };
 
         Ok(())

--- a/apps/deploy_monitoring/src/monitors/mod.rs
+++ b/apps/deploy_monitoring/src/monitors/mod.rs
@@ -129,12 +129,9 @@ pub async fn shutdown_and_cleanup(
 }
 
 pub async fn start_stack(
-    // compose_file_path: &PathBuf,
-    // alert_thresholds: AlertThresholds,
     env: &DeployMonitoringEnvironment,
     slack: Option<SlackServer>,
     log: &Logger,
-    // cleanup_data: bool,
 ) -> Result<(), failure::Error> {
     info!(log, "Starting tezedge stack");
 
@@ -261,6 +258,5 @@ pub async fn spawn_node_stack(
     let rpc_server_handle = rpc::spawn_rpc_server(env.rpc_port, log.clone(), storage_map.clone());
     handles.push(rpc_server_handle);
 
-    // vec![deploy_handle, resources_handle, rpc_server_handle]
     handles
 }

--- a/apps/deploy_monitoring/src/monitors/resource.rs
+++ b/apps/deploy_monitoring/src/monitors/resource.rs
@@ -331,7 +331,7 @@ async fn handle_alerts(
         )
         .await?;
 
-    if let Some(_) = alerts.thresholds().cpu {
+    if alerts.thresholds().cpu.is_some() {
         alerts
             .check_cpu_alert(
                 node_tag,

--- a/apps/deploy_monitoring/src/node.rs
+++ b/apps/deploy_monitoring/src/node.rs
@@ -30,13 +30,11 @@ impl DeployMonitoringContainer for TezedgeNode {
 impl TezedgeNode {
     pub fn collect_disk_data() -> Result<TezedgeDiskData, failure::Error> {
         // context actions DB is optional
-        let context_actions = match dir::get_size(&format!(
+        let context_actions = dir::get_size(&format!(
             "{}/{}",
             TEZEDGE_VOLUME_PATH, "bootstrap_db/context_actions"
-        )) {
-            Ok(size) => size,
-            Err(_) => 0,
-        };
+        ))
+        .unwrap_or(0);
 
         let disk_data = TezedgeDiskData::new(
             dir::get_size(&format!("{}/{}", DEBUGGER_VOLUME_PATH, "tezedge"))?,

--- a/apps/deploy_monitoring/src/node.rs
+++ b/apps/deploy_monitoring/src/node.rs
@@ -29,6 +29,15 @@ impl DeployMonitoringContainer for TezedgeNode {
 
 impl TezedgeNode {
     pub fn collect_disk_data() -> Result<TezedgeDiskData, failure::Error> {
+        // context actions DB is optional
+        let context_actions = match dir::get_size(&format!(
+            "{}/{}",
+            TEZEDGE_VOLUME_PATH, "bootstrap_db/context_actions"
+        )) {
+            Ok(size) => size,
+            Err(_) => 0,
+        };
+
         let disk_data = TezedgeDiskData::new(
             dir::get_size(&format!("{}/{}", DEBUGGER_VOLUME_PATH, "tezedge"))?,
             dir::get_size(&format!("{}/{}", TEZEDGE_VOLUME_PATH, "context"))?,
@@ -40,10 +49,7 @@ impl TezedgeNode {
                 "{}/{}",
                 TEZEDGE_VOLUME_PATH, "bootstrap_db/block_storage"
             ))?,
-            dir::get_size(&format!(
-                "{}/{}",
-                TEZEDGE_VOLUME_PATH, "bootstrap_db/context_actions"
-            ))?,
+            context_actions,
             dir::get_size(&format!("{}/{}", TEZEDGE_VOLUME_PATH, "bootstrap_db/db"))?,
         );
 
@@ -189,6 +195,4 @@ pub trait Node {
             .map(|(_, process)| process.cpu_usage())
             .sum::<f32>() as i32)
     }
-
-    // fn collect_disk_data() -> Result<DiskData, failure::Error>;
 }

--- a/apps/deploy_monitoring/src/rpc/filters.rs
+++ b/apps/deploy_monitoring/src/rpc/filters.rs
@@ -18,15 +18,23 @@ pub fn filters(
         .allow_methods(vec!["GET"]);
 
     // TODO: TE-499 - (multiple nodes) rework this to load from a config, where all the nodes all defined
-    let ocaml_resource_utilization_storage = resource_utilization_storage.get("ocaml").unwrap();
     let tezedge_resource_utilization_storage = resource_utilization_storage.get("tezedge").unwrap();
-
-    get_ocaml_measurements_filter(log.clone(), ocaml_resource_utilization_storage.clone())
-        .or(get_tezedge_measurements_filter(
-            log,
-            tezedge_resource_utilization_storage.clone(),
-        ))
-        .with(cors)
+    if let Some(ocaml_resource_utilization_storage) = resource_utilization_storage.get("ocaml") {
+        get_ocaml_measurements_filter(log.clone(), ocaml_resource_utilization_storage.clone())
+            .or(get_tezedge_measurements_filter(
+                log,
+                tezedge_resource_utilization_storage.clone(),
+            ))
+            .with(cors)
+    } else {
+        // This is just a hack to enable only tezedge node
+        get_ocaml_measurements_filter(log.clone(), ResourceUtilizationStorage::default())
+            .or(get_tezedge_measurements_filter(
+                log,
+                tezedge_resource_utilization_storage.clone(),
+            ))
+            .with(cors)
+    }
 }
 
 pub fn get_tezedge_measurements_filter(


### PR DESCRIPTION
- Fixes the node stuck alert
- CPU alerts are made optional due to their spamy nature
- Option to launch only the tezedge node
- Removed the alert sampling