### PR TITLE
Compute entry hash when necessary

### DIFF
--- a/tezos/new_context/src/ffi.rs
+++ b/tezos/new_context/src/ffi.rs
@@ -156,13 +156,12 @@ ocaml_export! {
         rt,
         context: OCamlRef<TezedgeContext>,
         key: OCamlRef<OCamlList<String>>,
-    ) -> OCaml<Result<bool, String>> {
+    ) -> OCaml<bool> {
         let context_ptr: OCamlToRustPointer<TezedgeContext> = context.to_rust(rt);
         let context = context_ptr.as_ref();
         let key: ContextKey = key.to_rust(rt);
 
-        let result = context.mem_tree(&key)
-            .map_err(|err| format!("{:?}", err));
+        let result = context.mem_tree(&key);
 
         result.to_ocaml(rt)
     }
@@ -312,7 +311,7 @@ ocaml_export! {
         let tree_ptr: OCamlToRustPointer<WorkingTreeRc> = tree.to_rust(rt);
         let tree = tree_ptr.as_ref();
 
-        let result = match tree.get_staged_root_hash()  {
+        let result = match tree.get_working_tree_root_hash()  {
             Err(err) => Err(format!("{:?}", err)),
             Ok(hash) => ContextHash::try_from(hash.as_ref()).map_err(|err| format!("{:?}", err))
         };
@@ -349,13 +348,13 @@ ocaml_export! {
         rt,
         tree: OCamlRef<WorkingTreeRc>,
         key: OCamlRef<OCamlList<String>>,
-    ) -> OCaml<Result<bool, String>> {
+    //) -> OCaml<Result<bool, String>> {
+    ) -> OCaml<bool> {
         let tree_ptr: OCamlToRustPointer<WorkingTreeRc> = tree.to_rust(rt);
         let tree = tree_ptr.as_ref();
         let key: ContextKey = key.to_rust(rt);
 
-        let result = tree.mem_tree(&key)
-            .map_err(|err| format!("{:?}", err));
+        let result = tree.mem_tree(&key);
 
         result.to_ocaml(rt)
     }

--- a/tezos/new_context/src/gc/mark_move_gced.rs
+++ b/tezos/new_context/src/gc/mark_move_gced.rs
@@ -371,8 +371,9 @@ fn kvstore_gc_thread_fn<T: KeyValueStoreBackend<ContextKeyValueStoreSchema>>(
                 match entry {
                     Entry::Blob(_) => {}
                     Entry::Tree(tree) => {
-                        let children = tree.into_iter().map(|(_, node)| *node.entry_hash);
-                        todo_keys.extend(children);
+                        for node in tree.values() {
+                            todo_keys.push(node.entry_hash()?);
+                        }
                     }
                     Entry::Commit(commit) => {
                         todo_keys.push(commit.root_hash);

--- a/tezos/new_context/src/gc/mod.rs
+++ b/tezos/new_context/src/gc/mod.rs
@@ -85,7 +85,7 @@ pub fn collect_hashes(
                     // anywhere in the recursion paths. TODO: is revert possible?
                     let mut b = HashSet::new();
                     for (_, child_node) in tree.iter() {
-                        let entry = fetch_entry_from_store(store, *child_node.entry_hash)?;
+                        let entry = fetch_entry_from_store(store, child_node.entry_hash()?)?;
                         collect_hashes(&entry, &mut b, cache, store)?;
                     }
                     cache.insert(hash_entry(entry)?, b.clone());

--- a/tezos/new_context/src/lib.rs
+++ b/tezos/new_context/src/lib.rs
@@ -21,9 +21,9 @@ pub fn force_libtezos_linking() {
     tezos_sys::force_libtezos_linking();
 }
 
-use std::array::TryFromSliceError;
 use std::collections::BTreeMap;
 use std::num::TryFromIntError;
+use std::{array::TryFromSliceError, rc::Rc};
 
 use failure::Fail;
 use gc::GarbageCollectionError;
@@ -56,7 +56,7 @@ pub type ContextValue = Vec<u8>;
 pub type TreeId = i32;
 
 /// Tree in String form needed for JSON RPCs
-pub type StringTreeMap = BTreeMap<String, StringTreeEntry>;
+pub type StringTreeMap = BTreeMap<Rc<String>, StringTreeEntry>;
 
 /// Tree in String form needed for JSON RPCs
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -87,7 +87,7 @@ where
     // mem - check if value exists
     fn mem(&self, key: &ContextKey) -> Result<bool, ContextError>;
     // mem_tree - check if directory exists
-    fn mem_tree(&self, key: &ContextKey) -> Result<bool, ContextError>;
+    fn mem_tree(&self, key: &ContextKey) -> bool;
 
     fn get_merkle_root(&self) -> Result<EntryHash, ContextError>;
 }


### PR DESCRIPTION
This apply the changes from https://github.com/tezedge/tezedge/pull/527 into https://github.com/tezedge/tezedge/pull/529.

There is no difference except that it uses `Rc` instead of `Arc`.

Note that the signature of `ProtocolContextApi::get` and `ProtocolContextApi::dirmem` can be changed to:
```rust
fn get(&self, key: &ContextKey) -> ContextValue;
fn dirmem(&self, key: &ContextKey) -> bool;
```

But I am not sure how to return those types to ocaml here:
https://github.com/tezedge/tezedge/blob/protocol-runner-storage/tezos/new_context/src/ffi.rs#L178