### PR TITLE
Avoid serializing a node twice

### DIFF
--- a/tezos/new_context/src/hash/mod.rs
+++ b/tezos/new_context/src/hash/mod.rs
@@ -296,7 +296,15 @@ pub(crate) fn hash_entry(entry: &Entry) -> Result<EntryHash, HashingError> {
 #[cfg(test)]
 #[allow(unused_must_use)]
 mod tests {
-    use std::{cell::RefCell, env, fs::File, io::Read, path::Path, rc::Rc, sync::Arc};
+    use std::{
+        cell::{Cell, RefCell},
+        env,
+        fs::File,
+        io::Read,
+        path::Path,
+        rc::Rc,
+        sync::Arc,
+    };
 
     use flate2::read::GzDecoder;
 
@@ -414,6 +422,7 @@ mod tests {
             node_kind: NodeKind::Leaf,
             entry_hash: RefCell::new(Some(hash_blob(&vec![1]).unwrap())), // 407f958990678e2e9fb06758bc6520dae46d838d39948a4c51a5b19bd079293d
             entry: RefCell::new(None),
+            commited: Cell::new(false),
         };
         dummy_tree.insert(Rc::new("a".to_string()), Rc::new(node));
 
@@ -526,6 +535,7 @@ mod tests {
                     node_kind,
                     entry_hash: RefCell::new(Some(*entry_hash)),
                     entry: RefCell::new(None),
+                    commited: Cell::new(false),
                 };
                 tree = tree.update(Rc::new(binding.name.clone()), Rc::new(node));
             }

--- a/tezos/new_context/src/working_tree/mod.rs
+++ b/tezos/new_context/src/working_tree/mod.rs
@@ -1,7 +1,10 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::{cell::RefCell, rc::Rc};
+use std::{
+    cell::{Cell, RefCell},
+    rc::Rc,
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -30,10 +33,20 @@ pub enum NodeKind {
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct Node {
     pub node_kind: NodeKind,
+    /// True when the entry has already been commited.
+    /// We don't need to serialize it twice.
+    #[serde(skip)]
+    #[serde(default = "node_serialized")]
+    pub commited: Cell<bool>,
     #[serde(serialize_with = "ensure_non_null_entry_hash")]
     pub entry_hash: RefCell<Option<EntryHash>>,
     #[serde(skip)]
     pub entry: RefCell<Option<Entry>>,
+}
+
+fn node_serialized() -> Cell<bool> {
+    // Deserializing the Node means it was already serialized
+    Cell::new(true)
 }
 
 #[derive(Debug, Hash, Clone, Serialize, Deserialize, Eq, PartialEq)]

--- a/tezos/new_context/src/working_tree/working_tree.rs
+++ b/tezos/new_context/src/working_tree/working_tree.rs
@@ -47,7 +47,12 @@
 //! ``
 //!
 //! Reference: https://git-scm.com/book/en/v2/Git-Internals-Git-Objects
-use std::{array::TryFromSliceError, borrow::Cow, cell::RefCell, rc::Rc};
+use std::{
+    array::TryFromSliceError,
+    borrow::Cow,
+    cell::{Cell, RefCell},
+    rc::Rc,
+};
 
 use failure::Fail;
 use serde::Deserialize;
@@ -779,6 +784,11 @@ impl WorkingTree {
                 // anywhere in the recursion paths. TODO: is revert possible?
                 tree.iter()
                     .map(|(_, child_node)| {
+                        if child_node.commited.get() {
+                            return Ok(());
+                        }
+                        child_node.commited.set(true);
+
                         match child_node
                             .entry
                             .try_borrow()
@@ -877,6 +887,7 @@ impl WorkingTree {
             node_kind: NodeKind::NonLeaf,
             entry_hash: RefCell::new(None),
             entry: RefCell::new(Some(entry)),
+            commited: Cell::new(false),
         }
     }
 
@@ -885,6 +896,7 @@ impl WorkingTree {
             node_kind: NodeKind::Leaf,
             entry_hash: RefCell::new(None),
             entry: RefCell::new(Some(entry)),
+            commited: Cell::new(false),
         }
     }
 


### PR DESCRIPTION
This improves slightly the performance, while the memory usage doesn't change much.

Data when the replayer reaches the block 10000
|  | without this PR | with this PR
| --- | --- | --- |
| time | 53s | 41s
| memory | 2115 MB | 2110 MB

I checked the number of entries in [this hashtable](https://github.com/tezedge/tezedge/blob/protocol-runner-storage/tezos/new_context/src/kv_store/in_memory_backend.rs#L18) after having processed 10000 blocks, and it's the same with and without this PR