### PR TITLE
Add `--release --workspace` flags to cargo test run on GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,3 +55,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --release --workspace


### PR DESCRIPTION
These are used in drone, but not here (maybe one of the reasons why the test suite takes so much longer).