### PR TITLE
Avoid one indirection in KeyFragment and use string interning

### DIFF
--- a/tezos/new_context/src/ffi.rs
+++ b/tezos/new_context/src/ffi.rs
@@ -354,7 +354,7 @@ ocaml_export! {
             .map_err(|err| format!("{:?}", err))
             .map(|v| {
                 v.into_iter()
-                    .map(|(s, tree)| ((*s).clone(), tree))
+                    .map(|(s, tree)| (s.to_string(), tree))
                     .collect::<Vec<_>>()
             });
 
@@ -594,7 +594,7 @@ ocaml_export! {
             .map_err(|err| format!("{:?}", err))
             .map(|v| {
                 v.into_iter()
-                    .map(|(s, tree)| ((*s).clone(), tree))
+                    .map(|(s, tree)| (s.to_string(), tree))
                     .collect::<Vec<_>>()
             });
 

--- a/tezos/new_context/src/hash/mod.rs
+++ b/tezos/new_context/src/hash/mod.rs
@@ -423,7 +423,7 @@ mod tests {
             entry: RefCell::new(None),
             commited: Cell::new(false),
         };
-        dummy_tree.insert(Rc::new("a".to_string()).into(), Rc::new(node));
+        dummy_tree.insert("a".into(), Rc::new(node));
 
         // hexademical representation of above tree:
         //
@@ -536,7 +536,7 @@ mod tests {
                     entry: RefCell::new(None),
                     commited: Cell::new(false),
                 };
-                tree = tree.update(Rc::new(binding.name.clone()).into(), Rc::new(node));
+                tree = tree.update(binding.name.as_str().into(), Rc::new(node));
             }
 
             let expected_hash = ContextHash::from_base58_check(&test_case.hash).unwrap();

--- a/tezos/new_context/src/lib.rs
+++ b/tezos/new_context/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
+#![feature(hash_set_entry)]
+
 // #![forbid(unsafe_code)]
 
 //! Implementation of the TezEdge context for the Tezos economic protocol

--- a/tezos/new_context/src/working_tree/mod.rs
+++ b/tezos/new_context/src/working_tree/mod.rs
@@ -28,16 +28,6 @@ impl std::ops::Deref for KeyFragment {
     }
 }
 
-impl KeyFragment {
-    pub(crate) fn as_bytes(&self) -> &[u8] {
-        self.0.as_bytes()
-    }
-
-    pub(crate) fn to_string(&self) -> String {
-        self.0.to_string()
-    }
-}
-
 impl Borrow<str> for KeyFragment {
     fn borrow(&self) -> &str {
         &self.0

--- a/tezos/new_context/src/working_tree/mod.rs
+++ b/tezos/new_context/src/working_tree/mod.rs
@@ -12,34 +12,46 @@ use serde::{Deserialize, Serialize};
 use crate::hash::{hash_entry, EntryHash, HashingError};
 use crate::ContextValue;
 
+use self::working_tree::MerkleError;
+
 pub mod working_tree;
 pub mod working_tree_stats;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
-pub struct KeyFragment(Rc<String>);
+pub struct KeyFragment(Rc<str>);
 
 impl std::ops::Deref for KeyFragment {
-    type Target = String;
+    type Target = str;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl Borrow<str> for KeyFragment {
-    fn borrow(&self) -> &str {
-        self.0.as_str()
+impl KeyFragment {
+    pub(crate) fn as_bytes(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+
+    pub(crate) fn to_string(&self) -> String {
+        self.0.to_string()
     }
 }
 
-impl Borrow<String> for KeyFragment {
-    fn borrow(&self) -> &String {
+impl Borrow<str> for KeyFragment {
+    fn borrow(&self) -> &str {
         &self.0
     }
 }
 
-impl From<Rc<String>> for KeyFragment {
-    fn from(value: Rc<String>) -> Self {
+impl From<&str> for KeyFragment {
+    fn from(value: &str) -> Self {
+        KeyFragment(Rc::from(value))
+    }
+}
+
+impl From<Rc<str>> for KeyFragment {
+    fn from(value: Rc<str>) -> Self {
         KeyFragment(value)
     }
 }
@@ -115,6 +127,24 @@ impl Node {
                 Ok(hash)
             }
         }
+    }
+
+    pub fn get_hash(&self) -> Result<EntryHash, MerkleError> {
+        self.entry_hash
+            .try_borrow()
+            .map_err(|_| MerkleError::InvalidState("The Entry hash is borrowed more than once"))?
+            .as_ref()
+            .copied()
+            .ok_or(MerkleError::InvalidState("Missing entry hash"))
+    }
+
+    fn set_entry(&self, entry: &Entry) -> Result<(), MerkleError> {
+        self.entry
+            .try_borrow_mut()
+            .map_err(|_| MerkleError::InvalidState("The Entry is borrowed more than once"))?
+            .replace(entry.clone());
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
- `KeyFragment(Rc<String>)` becomes `KeyFragment(Rc<str>)` to remove 1 pointer indirection
- Use string interning to reduce allocation