### PR TITLE
Make the timing database path configurable

### DIFF
--- a/light_node/etc/tezedge/tezedge.config
+++ b/light_node/etc/tezedge/tezedge.config
@@ -30,12 +30,12 @@
 # --bootstrap-db-path <PATH>
 --bootstrap-db-path=bootstrap_db
 
-# Path to timing database directory
+# Path to context-stats database directory
 # In case it starts with "./" or "../", it is relative path to the current dir, otherwise to the --tezos-data-dir
 # If directory does not exists, it will be created. If directory already exists, and contains valid database, node
 # will erase it and create a new database
-# --timing-db-path <PATH>
---timing-db-path=timing_db
+# --context-stats-db-path <PATH>
+--context-stats-db-path=context-stats_db
 
 #Max number of threads used by database configuration. If not specified, then number of threads equal to CPU cores.
 #--db-cfg-max-threads <NUM>

--- a/light_node/etc/tezedge/tezedge.config
+++ b/light_node/etc/tezedge/tezedge.config
@@ -30,6 +30,13 @@
 # --bootstrap-db-path <PATH>
 --bootstrap-db-path=bootstrap_db
 
+# Path to timing database directory
+# In case it starts with "./" or "../", it is relative path to the current dir, otherwise to the --tezos-data-dir
+# If directory does not exists, it will be created. If directory already exists, and contains valid database, node
+# will erase it and create a new database
+# --bootstrap-db-path <PATH>
+--timing-db-path=timing_db
+
 #Max number of threads used by database configuration. If not specified, then number of threads equal to CPU cores.
 #--db-cfg-max-threads <NUM>
 #--db-context-cfg-max-threads <NUM>
@@ -149,4 +156,3 @@
 
 # Enable or disable private node. Use --peers to set IP addresses of the peers you want to connect to.
 # --private-node=false
-

--- a/light_node/etc/tezedge/tezedge.config
+++ b/light_node/etc/tezedge/tezedge.config
@@ -34,7 +34,7 @@
 # In case it starts with "./" or "../", it is relative path to the current dir, otherwise to the --tezos-data-dir
 # If directory does not exists, it will be created. If directory already exists, and contains valid database, node
 # will erase it and create a new database
-# --bootstrap-db-path <PATH>
+# --timing-db-path <PATH>
 --timing-db-path=timing_db
 
 #Max number of threads used by database configuration. If not specified, then number of threads equal to CPU cores.

--- a/light_node/etc/tezedge/tezedge_drone.config
+++ b/light_node/etc/tezedge/tezedge_drone.config
@@ -30,12 +30,12 @@
 # --bootstrap-db-path <PATH>
 --bootstrap-db-path=/tmp/tezedge_developer/light-node
 
-# Path to timing database directory
+# Path to context-stats database directory
 # In case it starts with "./" or "../", it is relative path to the current dir, otherwise to the --tezos-data-dir
 # If directory does not exists, it will be created. If directory already exists, and contains valid database, node
 # will erase it and create a new database
-# --timing-db-path <PATH>
---timing-db-path=/tmp/tezedge_developer/timing-db
+# --context-stats-db-path <PATH>
+--context-stats-db-path=/tmp/tezedge_developer/context-stats-db
 
 # <Optional> A peers for dns lookup to get the peers to bootstrap the network from. Peers are delimited by a colon.
 # Default: used according to --network parameter see TezosEnvironment

--- a/light_node/etc/tezedge/tezedge_drone.config
+++ b/light_node/etc/tezedge/tezedge_drone.config
@@ -30,6 +30,13 @@
 # --bootstrap-db-path <PATH>
 --bootstrap-db-path=/tmp/tezedge_developer/light-node
 
+# Path to timing database directory
+# In case it starts with "./" or "../", it is relative path to the current dir, otherwise to the --tezos-data-dir
+# If directory does not exists, it will be created. If directory already exists, and contains valid database, node
+# will erase it and create a new database
+# --timing-db-path <PATH>
+--timing-db-path=/tmp/tezedge_developer/timing-db
+
 # <Optional> A peers for dns lookup to get the peers to bootstrap the network from. Peers are delimited by a colon.
 # Default: used according to --network parameter see TezosEnvironment
 # --bootstrap-lookup-address <bootstrap-lookup-address>

--- a/light_node/etc/tezedge_sandbox/tezedge_drone_sandbox.config
+++ b/light_node/etc/tezedge_sandbox/tezedge_drone_sandbox.config
@@ -29,6 +29,13 @@
 # --bootstrap-db-path <PATH>
 --bootstrap-db-path=/tmp/sandbox/light-node
 
+# Path to timing database directory
+# In case it starts with "./" or "../", it is relative path to the current dir, otherwise to the --tezos-data-dir
+# If directory does not exists, it will be created. If directory already exists, and contains valid database, node
+# will erase it and create a new database
+# --timing-db-path <PATH>
+--timing-db-path=/tmp/sandbox/timing-db
+
 # <Optional> A peers for dns lookup to get the peers to bootstrap the network from. Peers are delimited by a colon.
 # Default: used according to --network parameter see TezosEnvironment
 # --bootstrap-lookup-address <bootstrap-lookup-address>

--- a/light_node/etc/tezedge_sandbox/tezedge_drone_sandbox.config
+++ b/light_node/etc/tezedge_sandbox/tezedge_drone_sandbox.config
@@ -29,12 +29,12 @@
 # --bootstrap-db-path <PATH>
 --bootstrap-db-path=/tmp/sandbox/light-node
 
-# Path to timing database directory
+# Path to context-stats database directory
 # In case it starts with "./" or "../", it is relative path to the current dir, otherwise to the --tezos-data-dir
 # If directory does not exists, it will be created. If directory already exists, and contains valid database, node
 # will erase it and create a new database
-# --timing-db-path <PATH>
---timing-db-path=/tmp/sandbox/timing-db
+# --context-stats-db-path <PATH>
+--context-stats-db-path=/tmp/sandbox/context-stats-db
 
 # <Optional> A peers for dns lookup to get the peers to bootstrap the network from. Peers are delimited by a colon.
 # Default: used according to --network parameter see TezosEnvironment

--- a/light_node/etc/tezedge_sandbox/tezedge_sandbox.config
+++ b/light_node/etc/tezedge_sandbox/tezedge_sandbox.config
@@ -30,12 +30,12 @@
 # --bootstrap-db-path <PATH>
 --bootstrap-db-path=/tmp/tezedge_developer/light-node
 
-# Path to timing database directory
+# Path to context-stats database directory
 # In case it starts with "./" or "../", it is relative path to the current dir, otherwise to the --tezos-data-dir
 # If directory does not exists, it will be created. If directory already exists, and contains valid database, node
 # will erase it and create a new database
-# --timing-db-path <PATH>
---timing-db-path=/tmp/tezedge_developer/timing-db
+# --context-stats-db-path <PATH>
+--context-stats-db-path=/tmp/tezedge_developer/context-stats-db
 
 # <Optional> A peers for dns lookup to get the peers to bootstrap the network from. Peers are delimited by a colon.
 # Default: used according to --network parameter see TezosEnvironment

--- a/light_node/etc/tezedge_sandbox/tezedge_sandbox.config
+++ b/light_node/etc/tezedge_sandbox/tezedge_sandbox.config
@@ -30,6 +30,13 @@
 # --bootstrap-db-path <PATH>
 --bootstrap-db-path=/tmp/tezedge_developer/light-node
 
+# Path to timing database directory
+# In case it starts with "./" or "../", it is relative path to the current dir, otherwise to the --tezos-data-dir
+# If directory does not exists, it will be created. If directory already exists, and contains valid database, node
+# will erase it and create a new database
+# --timing-db-path <PATH>
+--timing-db-path=/tmp/tezedge_developer/timing-db
+
 # <Optional> A peers for dns lookup to get the peers to bootstrap the network from. Peers are delimited by a colon.
 # Default: used according to --network parameter see TezosEnvironment
 # --bootstrap-lookup-address <bootstrap-lookup-address>

--- a/light_node/src/configuration.rs
+++ b/light_node/src/configuration.rs
@@ -966,12 +966,12 @@ impl Environment {
                     .expect("Provided value cannot be converted to path");
                 let db_path = get_final_path(&tezos_data_dir, path);
 
-                let context_stats_db_path = args
-                    .value_of("context-stats-db-path")
-                    .map(|value| {
-                        let path = value.parse::<PathBuf>().expect("Provided value cannot be converted to path");
-                        get_final_path(&tezos_data_dir, path)
-                    });
+                let context_stats_db_path = args.value_of("context-stats-db-path").map(|value| {
+                    let path = value
+                        .parse::<PathBuf>()
+                        .expect("Provided value cannot be converted to path");
+                    get_final_path(&tezos_data_dir, path)
+                });
 
                 let db_threads_count = args.value_of("db-cfg-max-threads").map(|value| {
                     value

--- a/light_node/src/configuration.rs
+++ b/light_node/src/configuration.rs
@@ -180,7 +180,7 @@ pub trait MultipleValueArg: IntoEnumIterator {
 pub struct Storage {
     pub db: RocksDbConfig<DbsRocksDbTableInitializer>,
     pub db_path: PathBuf,
-    pub context_stats_db_path: PathBuf,
+    pub context_stats_db_path: Option<PathBuf>,
     pub context_storage_configuration: TezosContextStorageConfiguration,
     pub context_action_recorders: Vec<ContextActionStoreBackend>,
     pub compute_context_action_tree_hashes: bool,
@@ -690,7 +690,6 @@ fn validate_required_args(args: &clap::ArgMatches) {
         )),
     );
     validate_required_arg(args, "bootstrap-db-path", None);
-    validate_required_arg(args, "context-stats-db-path", None);
     validate_required_arg(args, "p2p-port", None);
     validate_required_arg(args, "protocol-runner", None);
     validate_required_arg(args, "rpc-port", None);
@@ -967,12 +966,12 @@ impl Environment {
                     .expect("Provided value cannot be converted to path");
                 let db_path = get_final_path(&tezos_data_dir, path);
 
-                let path = args
+                let context_stats_db_path = args
                     .value_of("context-stats-db-path")
-                    .unwrap_or("")
-                    .parse::<PathBuf>()
-                    .expect("Provided value cannot be converted to path");
-                let context_stats_db_path = get_final_path(&tezos_data_dir, path);
+                    .map(|value| {
+                        let path = value.parse::<PathBuf>().expect("Provided value cannot be converted to path");
+                        get_final_path(&tezos_data_dir, path)
+                    });
 
                 let db_threads_count = args.value_of("db-cfg-max-threads").map(|value| {
                     value

--- a/light_node/src/configuration.rs
+++ b/light_node/src/configuration.rs
@@ -180,7 +180,7 @@ pub trait MultipleValueArg: IntoEnumIterator {
 pub struct Storage {
     pub db: RocksDbConfig<DbsRocksDbTableInitializer>,
     pub db_path: PathBuf,
-    pub timing_db_path: PathBuf,
+    pub context_stats_db_path: PathBuf,
     pub context_storage_configuration: TezosContextStorageConfiguration,
     pub context_action_recorders: Vec<ContextActionStoreBackend>,
     pub compute_context_action_tree_hashes: bool,
@@ -972,7 +972,7 @@ impl Environment {
                     .unwrap_or("")
                     .parse::<PathBuf>()
                     .expect("Provided value cannot be converted to path");
-                let timing_db_path = get_final_path(&tezos_data_dir, path);
+                let context_stats_db_path = get_final_path(&tezos_data_dir, path);
 
                 let db_threads_count = args.value_of("db-cfg-max-threads").map(|value| {
                     value
@@ -1126,7 +1126,7 @@ impl Environment {
                     context_storage_configuration,
                     db,
                     db_path,
-                    timing_db_path,
+                    context_stats_db_path,
                     compute_context_action_tree_hashes,
                     context_action_recorders,
                     context_kv_store,

--- a/light_node/src/configuration.rs
+++ b/light_node/src/configuration.rs
@@ -354,11 +354,11 @@ pub fn tezos_app() -> App<'static, 'static> {
             .value_name("PATH")
             .help("Path to bootstrap database directory.
                        In case it starts with ./ or ../, it is relative path to the current dir, otherwise to the --tezos-data-dir"))
-        .arg(Arg::with_name("timing-db-path")
-            .long("timing-db-path")
+        .arg(Arg::with_name("context-stats-db-path")
+            .long("context-stats-db-path")
             .takes_value(true)
             .value_name("PATH")
-            .help("Path to timing database directory.
+            .help("Path to context-stats database directory.
                        In case it starts with ./ or ../, it is relative path to the current dir, otherwise to the --tezos-data-dir"))
         .arg(Arg::with_name("db-cfg-max-threads")
             .long("db-cfg-max-threads")
@@ -690,7 +690,7 @@ fn validate_required_args(args: &clap::ArgMatches) {
         )),
     );
     validate_required_arg(args, "bootstrap-db-path", None);
-    validate_required_arg(args, "timing-db-path", None);
+    validate_required_arg(args, "context-stats-db-path", None);
     validate_required_arg(args, "p2p-port", None);
     validate_required_arg(args, "protocol-runner", None);
     validate_required_arg(args, "rpc-port", None);
@@ -968,7 +968,7 @@ impl Environment {
                 let db_path = get_final_path(&tezos_data_dir, path);
 
                 let path = args
-                    .value_of("timing-db-path")
+                    .value_of("context-stats-db-path")
                     .unwrap_or("")
                     .parse::<PathBuf>()
                     .expect("Provided value cannot be converted to path");

--- a/light_node/src/configuration.rs
+++ b/light_node/src/configuration.rs
@@ -180,6 +180,7 @@ pub trait MultipleValueArg: IntoEnumIterator {
 pub struct Storage {
     pub db: RocksDbConfig<DbsRocksDbTableInitializer>,
     pub db_path: PathBuf,
+    pub timing_db_path: PathBuf,
     pub context_storage_configuration: TezosContextStorageConfiguration,
     pub context_action_recorders: Vec<ContextActionStoreBackend>,
     pub compute_context_action_tree_hashes: bool,
@@ -352,6 +353,12 @@ pub fn tezos_app() -> App<'static, 'static> {
             .takes_value(true)
             .value_name("PATH")
             .help("Path to bootstrap database directory.
+                       In case it starts with ./ or ../, it is relative path to the current dir, otherwise to the --tezos-data-dir"))
+        .arg(Arg::with_name("timing-db-path")
+            .long("timing-db-path")
+            .takes_value(true)
+            .value_name("PATH")
+            .help("Path to timing database directory.
                        In case it starts with ./ or ../, it is relative path to the current dir, otherwise to the --tezos-data-dir"))
         .arg(Arg::with_name("db-cfg-max-threads")
             .long("db-cfg-max-threads")
@@ -683,6 +690,7 @@ fn validate_required_args(args: &clap::ArgMatches) {
         )),
     );
     validate_required_arg(args, "bootstrap-db-path", None);
+    validate_required_arg(args, "timing-db-path", None);
     validate_required_arg(args, "p2p-port", None);
     validate_required_arg(args, "protocol-runner", None);
     validate_required_arg(args, "rpc-port", None);
@@ -959,6 +967,13 @@ impl Environment {
                     .expect("Provided value cannot be converted to path");
                 let db_path = get_final_path(&tezos_data_dir, path);
 
+                let path = args
+                    .value_of("timing-db-path")
+                    .unwrap_or("")
+                    .parse::<PathBuf>()
+                    .expect("Provided value cannot be converted to path");
+                let timing_db_path = get_final_path(&tezos_data_dir, path);
+
                 let db_threads_count = args.value_of("db-cfg-max-threads").map(|value| {
                     value
                         .parse::<usize>()
@@ -1111,6 +1126,7 @@ impl Environment {
                     context_storage_configuration,
                     db,
                     db_path,
+                    timing_db_path,
                     compute_context_action_tree_hashes,
                     context_action_recorders,
                     context_kv_store,

--- a/light_node/src/main.rs
+++ b/light_node/src/main.rs
@@ -578,7 +578,7 @@ fn main() {
             &env.storage.context_storage_configuration,
             &env.storage.patch_context,
             env.storage.one_context,
-            Some(env.storage.context_stats_db_path.clone()),
+            &env.storage.context_stats_db_path,
             &log,
         ) {
             Ok(init_data) => {

--- a/light_node/src/main.rs
+++ b/light_node/src/main.rs
@@ -578,6 +578,7 @@ fn main() {
             &env.storage.context_storage_configuration,
             &env.storage.patch_context,
             env.storage.one_context,
+            &env.storage.timing_db_path,
             &log,
         ) {
             Ok(init_data) => {

--- a/light_node/src/main.rs
+++ b/light_node/src/main.rs
@@ -578,7 +578,7 @@ fn main() {
             &env.storage.context_storage_configuration,
             &env.storage.patch_context,
             env.storage.one_context,
-            &env.storage.timing_db_path,
+            Some(env.storage.context_stats_db_path.clone()),
             &log,
         ) {
             Ok(init_data) => {

--- a/rpc/src/rpc_actor.rs
+++ b/rpc/src/rpc_actor.rs
@@ -101,7 +101,7 @@ impl RpcServer {
                 init_storage_data.genesis_block_header_hash.clone(),
                 shared_state,
                 init_storage_data.one_context,
-                init_storage_data.timing_db_path.clone(),
+                init_storage_data.context_stats_db_path.clone(),
                 &sys.log(),
             );
             let inner_log = sys.log();

--- a/rpc/src/rpc_actor.rs
+++ b/rpc/src/rpc_actor.rs
@@ -101,6 +101,7 @@ impl RpcServer {
                 init_storage_data.genesis_block_header_hash.clone(),
                 shared_state,
                 init_storage_data.one_context,
+                init_storage_data.timing_db_path.clone(),
                 &sys.log(),
             );
             let inner_log = sys.log();

--- a/rpc/src/server/dev_handler.rs
+++ b/rpc/src/server/dev_handler.rs
@@ -200,7 +200,7 @@ pub async fn context_stats(
     env: RpcServiceEnvironment,
 ) -> ServiceResult {
     let context_name = query.get_str("context_name").unwrap_or("tezedge");
-    let db_path = env.timing_db_path.as_path();
+    let db_path = env.context_stats_db_path.as_ref();
 
     result_to_json_response(
         context::make_context_stats(db_path, context_name),
@@ -216,7 +216,7 @@ pub async fn block_actions(
 ) -> ServiceResult {
     let chain_id = parse_chain_id(required_param!(params, "chain_id")?, &env)?;
     let block_hash = parse_block_hash(&chain_id, required_param!(params, "block_id")?, &env)?;
-    let db_path = env.timing_db_path.as_path();
+    let db_path = env.context_stats_db_path.as_ref();
 
     result_option_to_json_response(context::make_block_stats(db_path, block_hash), env.log())
 }

--- a/rpc/src/server/dev_handler.rs
+++ b/rpc/src/server/dev_handler.rs
@@ -197,7 +197,12 @@ pub async fn context_stats(
     env: RpcServiceEnvironment,
 ) -> ServiceResult {
     let context_name = query.get_str("context_name").unwrap_or("tezedge");
-    result_to_json_response(context::make_context_stats(context_name), env.log())
+    let db_path = env.timing_db_path.as_path();
+
+    result_to_json_response(
+        context::make_context_stats(db_path, context_name),
+        env.log(),
+    )
 }
 
 pub async fn block_actions(
@@ -208,8 +213,9 @@ pub async fn block_actions(
 ) -> ServiceResult {
     let chain_id = parse_chain_id(required_param!(params, "chain_id")?, &env)?;
     let block_hash = parse_block_hash(&chain_id, required_param!(params, "block_id")?, &env)?;
+    let db_path = env.timing_db_path.as_path();
 
-    result_to_json_response(context::make_block_stats(block_hash), env.log())
+    result_to_json_response(context::make_block_stats(db_path, block_hash), env.log())
 }
 
 /// Get the version string

--- a/rpc/src/server/dev_handler.rs
+++ b/rpc/src/server/dev_handler.rs
@@ -5,10 +5,13 @@ use failure::format_err;
 use hyper::{Body, Request};
 use slog::warn;
 
-use crate::helpers::{parse_block_hash, parse_chain_id, SlimBlockData, MAIN_CHAIN_ID};
 use crate::server::{HasSingleValue, Params, Query, RpcServiceEnvironment};
 use crate::services::{base_services, context, dev_services};
 use crate::{empty, make_json_response, required_param, result_to_json_response, ServiceResult};
+use crate::{
+    helpers::{parse_block_hash, parse_chain_id, SlimBlockData, MAIN_CHAIN_ID},
+    result_option_to_json_response,
+};
 
 pub async fn dev_blocks(
     _: Request<Body>,
@@ -215,7 +218,7 @@ pub async fn block_actions(
     let block_hash = parse_block_hash(&chain_id, required_param!(params, "block_id")?, &env)?;
     let db_path = env.timing_db_path.as_path();
 
-    result_to_json_response(context::make_block_stats(db_path, block_hash), env.log())
+    result_option_to_json_response(context::make_block_stats(db_path, block_hash), env.log())
 }
 
 /// Get the version string

--- a/rpc/src/server/mod.rs
+++ b/rpc/src/server/mod.rs
@@ -73,7 +73,7 @@ pub struct RpcServiceEnvironment {
     #[get = "pub(crate)"]
     tezos_without_context_api: Arc<TezosApiConnectionPool>,
     #[get = "pub(crate)"]
-    timing_db_path: PathBuf,
+    context_stats_db_path: Option<PathBuf>,
 
     // TODO: TE-447 - remove one_context when integration done
     pub one_context: bool,
@@ -98,7 +98,7 @@ impl RpcServiceEnvironment {
         main_chain_genesis_hash: BlockHash,
         state: RpcCollectedStateRef,
         one_context: bool,
-        timing_db_path: PathBuf,
+        context_stats_db_path: Option<PathBuf>,
         log: &Logger,
     ) -> Self {
         Self {
@@ -119,7 +119,7 @@ impl RpcServiceEnvironment {
             tezos_readonly_prevalidation_api,
             tezos_without_context_api,
             one_context,
-            timing_db_path,
+            context_stats_db_path,
         }
     }
 }

--- a/rpc/src/server/mod.rs
+++ b/rpc/src/server/mod.rs
@@ -1,11 +1,14 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+};
 
 use getset::Getters;
 use hyper::service::{make_service_fn, service_fn};
@@ -69,6 +72,8 @@ pub struct RpcServiceEnvironment {
     tezos_readonly_prevalidation_api: Arc<TezosApiConnectionPool>,
     #[get = "pub(crate)"]
     tezos_without_context_api: Arc<TezosApiConnectionPool>,
+    #[get = "pub(crate)"]
+    timing_db_path: PathBuf,
 
     // TODO: TE-447 - remove one_context when integration done
     pub one_context: bool,
@@ -93,6 +98,7 @@ impl RpcServiceEnvironment {
         main_chain_genesis_hash: BlockHash,
         state: RpcCollectedStateRef,
         one_context: bool,
+        timing_db_path: PathBuf,
         log: &Logger,
     ) -> Self {
         Self {
@@ -113,6 +119,7 @@ impl RpcServiceEnvironment {
             tezos_readonly_prevalidation_api,
             tezos_without_context_api,
             one_context,
+            timing_db_path,
         }
     }
 }

--- a/rpc/src/services/context.rs
+++ b/rpc/src/services/context.rs
@@ -1,7 +1,7 @@
 use crypto::hash::BlockHash;
 use rusqlite::{named_params, Connection, OptionalExtension};
 use serde::Serialize;
-use std::{collections::HashMap, path::Path};
+use std::{collections::HashMap, path::PathBuf};
 
 use tezos_timing::{
     hash_to_string, ActionData, ActionStats, ActionStatsWithRange, RangeStats, FILENAME_DB,
@@ -27,22 +27,34 @@ pub(crate) struct ContextStats {
 }
 
 pub(crate) fn make_block_stats(
-    db_path: &Path,
+    db_path: Option<&PathBuf>,
     block_hash: BlockHash,
 ) -> Result<Option<BlockStats>, failure::Error> {
-    let mut db_path = db_path.to_path_buf();
-    db_path.push(FILENAME_DB);
+    let db_path = match db_path {
+        Some(db_path) => {
+            let mut db_path = db_path.to_path_buf();
+            db_path.push(FILENAME_DB);
+            db_path
+        }
+        None => PathBuf::from(FILENAME_DB)
+    };
 
     let sql = Connection::open(db_path)?;
     make_block_stats_impl(&sql, block_hash)
 }
 
 pub(crate) fn make_context_stats(
-    db_path: &Path,
+    db_path: Option<&PathBuf>,
     context_name: &str,
 ) -> Result<ContextStats, failure::Error> {
-    let mut db_path = db_path.to_path_buf();
-    db_path.push(FILENAME_DB);
+    let db_path = match db_path {
+        Some(db_path) => {
+            let mut db_path = db_path.to_path_buf();
+            db_path.push(FILENAME_DB);
+            db_path
+        }
+        None => PathBuf::from(FILENAME_DB)
+    };
 
     let sql = Connection::open(db_path)?;
     make_context_stats_impl(&sql, context_name)

--- a/rpc/src/services/context.rs
+++ b/rpc/src/services/context.rs
@@ -36,7 +36,7 @@ pub(crate) fn make_block_stats(
             db_path.push(FILENAME_DB);
             db_path
         }
-        None => PathBuf::from(FILENAME_DB)
+        None => PathBuf::from(FILENAME_DB),
     };
 
     let sql = Connection::open(db_path)?;
@@ -53,7 +53,7 @@ pub(crate) fn make_context_stats(
             db_path.push(FILENAME_DB);
             db_path
         }
-        None => PathBuf::from(FILENAME_DB)
+        None => PathBuf::from(FILENAME_DB),
     };
 
     let sql = Connection::open(db_path)?;

--- a/rpc/src/services/context.rs
+++ b/rpc/src/services/context.rs
@@ -1,10 +1,10 @@
 use crypto::hash::BlockHash;
 use rusqlite::{named_params, Connection};
 use serde::Serialize;
-use std::collections::HashMap;
+use std::{collections::HashMap, path::Path};
 
 use tezos_timing::{
-    hash_to_string, ActionData, ActionStats, ActionStatsWithRange, RangeStats, DB_PATH,
+    hash_to_string, ActionData, ActionStats, ActionStatsWithRange, RangeStats, FILENAME_DB,
 };
 
 #[derive(Debug, Serialize, Default)]
@@ -26,13 +26,25 @@ pub(crate) struct ContextStats {
     operations_context: Vec<ActionStatsWithRange>,
 }
 
-pub(crate) fn make_block_stats(block_hash: BlockHash) -> Result<BlockStats, failure::Error> {
-    let sql = Connection::open(DB_PATH)?;
+pub(crate) fn make_block_stats(
+    db_path: &Path,
+    block_hash: BlockHash,
+) -> Result<BlockStats, failure::Error> {
+    let mut db_path = db_path.to_path_buf();
+    db_path.push(FILENAME_DB);
+
+    let sql = Connection::open(db_path)?;
     make_block_stats_impl(&sql, block_hash)
 }
 
-pub(crate) fn make_context_stats(context_name: &str) -> Result<ContextStats, failure::Error> {
-    let sql = Connection::open(DB_PATH)?;
+pub(crate) fn make_context_stats(
+    db_path: &Path,
+    context_name: &str,
+) -> Result<ContextStats, failure::Error> {
+    let mut db_path = db_path.to_path_buf();
+    db_path.push(FILENAME_DB);
+
+    let sql = Connection::open(db_path)?;
     make_context_stats_impl(&sql, context_name)
 }
 

--- a/shell/src/chain_feeder.rs
+++ b/shell/src/chain_feeder.rs
@@ -1065,7 +1065,7 @@ pub(crate) fn initialize_protocol_context(
     let context_init_info = protocol_controller.init_protocol_for_write(
         need_commit_genesis,
         &init_storage_data.patch_context,
-        init_storage_data.timing_db_path.as_path(),
+        init_storage_data.context_stats_db_path.clone(),
     )?;
 
     let protocol_call_elapsed = protocol_call_timer.elapsed();

--- a/shell/src/chain_feeder.rs
+++ b/shell/src/chain_feeder.rs
@@ -619,6 +619,7 @@ fn feed_chain_to_protocol(
     log: &Logger,
 ) -> Result<(), FeedChainError> {
     // at first we initialize protocol runtime and ffi context
+
     initialize_protocol_context(
         &apply_block_run,
         chain_current_head_manager,
@@ -1061,8 +1062,12 @@ pub(crate) fn initialize_protocol_context(
 
     // initialize protocol context runtime
     let protocol_call_timer = Instant::now();
-    let context_init_info = protocol_controller
-        .init_protocol_for_write(need_commit_genesis, &init_storage_data.patch_context)?;
+    let context_init_info = protocol_controller.init_protocol_for_write(
+        need_commit_genesis,
+        &init_storage_data.patch_context,
+        init_storage_data.timing_db_path.as_path(),
+    )?;
+
     let protocol_call_elapsed = protocol_call_timer.elapsed();
     info!(log, "Protocol context initialized"; "context_init_info" => format!("{:?}", &context_init_info), "need_commit_genesis" => need_commit_genesis);
 

--- a/shell/tests/common/infra.rs
+++ b/shell/tests/common/infra.rs
@@ -109,6 +109,7 @@ impl NodeInfrastructure {
             &context_storage_configuration,
             &patch_context,
             false,
+            None,
             &log,
         )
         .expect("Failed to resolve init storage chain data");

--- a/shell/tests/common/infra.rs
+++ b/shell/tests/common/infra.rs
@@ -109,7 +109,7 @@ impl NodeInfrastructure {
             &context_storage_configuration,
             &patch_context,
             false,
-            None,
+            &None,
             &log,
         )
         .expect("Failed to resolve init storage chain data");

--- a/shell/tests/protocol_runner_test.rs
+++ b/shell/tests/protocol_runner_test.rs
@@ -67,7 +67,7 @@ fn test_mutliple_protocol_runners_with_one_write_multiple_read_init_context(
                         if flag_readonly {
                             proto.init_protocol_for_read()?
                         } else {
-                            proto.init_protocol_for_write(false, &None)?
+                            proto.init_protocol_for_write(false, &None, None)?
                         }
                     }),
                     Err(e) => Err(format_err!("{:?}", e)),
@@ -203,7 +203,7 @@ fn test_readonly_protocol_runner_connection_pool() -> Result<(), failure::Error>
 
     let mut write_api = write_context_commands.try_accept(Duration::from_secs(3))?;
     let genesis_context_hash = write_api
-        .init_protocol_for_write(true, &None)?
+        .init_protocol_for_write(true, &None, None)?
         .genesis_commit_hash
         .expect("Genesis context_hash should be commited!");
     write_api.shutdown()?;

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -212,7 +212,7 @@ pub struct StorageInitInfo {
     pub chain_id: ChainId,
     pub genesis_block_header_hash: BlockHash,
     pub patch_context: Option<PatchContext>,
-    pub timing_db_path: PathBuf,
+    pub context_stats_db_path: Option<PathBuf>,
 
     // TODO: TE-447 - remove one_context when integration done
     pub one_context: bool,
@@ -225,7 +225,7 @@ pub fn resolve_storage_init_chain_data(
     context_storage_configuration: &TezosContextStorageConfiguration,
     patch_context: &Option<PatchContext>,
     one_context: bool,
-    timing_db_path: &Path,
+    context_stats_db_path: Option<PathBuf>,
     log: &Logger,
 ) -> Result<StorageInitInfo, StorageError> {
     let init_data = StorageInitInfo {
@@ -233,7 +233,7 @@ pub fn resolve_storage_init_chain_data(
         genesis_block_header_hash: tezos_env.genesis_header_hash()?,
         patch_context: patch_context.clone(),
         one_context,
-        timing_db_path: timing_db_path.to_owned(),
+        context_stats_db_path: context_stats_db_path.clone(),
     };
 
     info!(
@@ -244,7 +244,7 @@ pub fn resolve_storage_init_chain_data(
         "init_data.genesis_header" => format!("{:?}", init_data.genesis_block_header_hash.to_base58_check()),
         "storage_db_path" => format!("{:?}", storage_db_path),
         "context_storage_configuration" => format!("{:?}", context_storage_configuration),
-        "timing_db_path" => format!("{:?}", timing_db_path),
+        "context_stats_db_path" => format!("{:?}", context_stats_db_path),
         "one_context" => one_context,
         "patch_context" => match patch_context {
                 Some(pc) => format!("{:?}", pc),

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -8,9 +8,12 @@
 
 // TODO - TE-261: from this crate, remove everything related to "context"
 
-use std::convert::{TryFrom, TryInto};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
+use std::{
+    convert::{TryFrom, TryInto},
+    path::PathBuf,
+};
 
 use failure::Fail;
 use rocksdb::{Cache, DB};
@@ -209,6 +212,7 @@ pub struct StorageInitInfo {
     pub chain_id: ChainId,
     pub genesis_block_header_hash: BlockHash,
     pub patch_context: Option<PatchContext>,
+    pub timing_db_path: PathBuf,
 
     // TODO: TE-447 - remove one_context when integration done
     pub one_context: bool,
@@ -221,6 +225,7 @@ pub fn resolve_storage_init_chain_data(
     context_storage_configuration: &TezosContextStorageConfiguration,
     patch_context: &Option<PatchContext>,
     one_context: bool,
+    timing_db_path: &Path,
     log: &Logger,
 ) -> Result<StorageInitInfo, StorageError> {
     let init_data = StorageInitInfo {
@@ -228,6 +233,7 @@ pub fn resolve_storage_init_chain_data(
         genesis_block_header_hash: tezos_env.genesis_header_hash()?,
         patch_context: patch_context.clone(),
         one_context,
+        timing_db_path: timing_db_path.to_owned(),
     };
 
     info!(
@@ -238,6 +244,7 @@ pub fn resolve_storage_init_chain_data(
         "init_data.genesis_header" => format!("{:?}", init_data.genesis_block_header_hash.to_base58_check()),
         "storage_db_path" => format!("{:?}", storage_db_path),
         "context_storage_configuration" => format!("{:?}", context_storage_configuration),
+        "timing_db_path" => format!("{:?}", timing_db_path),
         "one_context" => one_context,
         "patch_context" => match patch_context {
                 Some(pc) => format!("{:?}", pc),

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -225,7 +225,7 @@ pub fn resolve_storage_init_chain_data(
     context_storage_configuration: &TezosContextStorageConfiguration,
     patch_context: &Option<PatchContext>,
     one_context: bool,
-    context_stats_db_path: Option<PathBuf>,
+    context_stats_db_path: &Option<PathBuf>,
     log: &Logger,
 ) -> Result<StorageInitInfo, StorageError> {
     let init_data = StorageInitInfo {

--- a/storage/tests/storage_for_shell.rs
+++ b/storage/tests/storage_for_shell.rs
@@ -70,7 +70,7 @@ fn test_storage() -> Result<(), Error> {
         &context_storage_configuration,
         &None,
         false,
-        None,
+        &None,
         &log,
     );
     assert!(init_data.is_ok());

--- a/storage/tests/storage_for_shell.rs
+++ b/storage/tests/storage_for_shell.rs
@@ -70,7 +70,7 @@ fn test_storage() -> Result<(), Error> {
         &context_storage_configuration,
         &None,
         false,
-        Path::new(""),
+        None,
         &log,
     );
     assert!(init_data.is_ok());

--- a/storage/tests/storage_for_shell.rs
+++ b/storage/tests/storage_for_shell.rs
@@ -70,6 +70,7 @@ fn test_storage() -> Result<(), Error> {
         &context_storage_configuration,
         &None,
         false,
+        Path::new(""),
         &log,
     );
     assert!(init_data.is_ok());

--- a/tezos/api/src/ffi.rs
+++ b/tezos/api/src/ffi.rs
@@ -1,9 +1,9 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::fmt::Debug;
 /// Rust implementation of messages required for Rust <-> OCaml FFI communication.
 use std::{convert::TryFrom, fmt};
+use std::{fmt::Debug, path::PathBuf};
 
 use derive_builder::Builder;
 use failure::Fail;
@@ -133,6 +133,7 @@ pub struct TezosContextConfiguration {
     pub enable_testchain: bool,
     pub readonly: bool,
     pub sandbox_json_patch_context: Option<PatchContext>,
+    pub timing_db_path: Option<PathBuf>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Builder, PartialEq)]

--- a/tezos/api/src/ffi.rs
+++ b/tezos/api/src/ffi.rs
@@ -133,7 +133,7 @@ pub struct TezosContextConfiguration {
     pub enable_testchain: bool,
     pub readonly: bool,
     pub sandbox_json_patch_context: Option<PatchContext>,
-    pub timing_db_path: Option<PathBuf>,
+    pub context_stats_db_path: Option<PathBuf>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Builder, PartialEq)]

--- a/tezos/client/tests/bootstrap_storage_protocol_v1_test.rs
+++ b/tezos/client/tests/bootstrap_storage_protocol_v1_test.rs
@@ -54,6 +54,7 @@ fn init_test_protocol_context(
         enable_testchain: false,
         readonly: false,
         sandbox_json_patch_context: tezos_env.patch_context_genesis_parameters.clone(),
+        context_stats_db_path: None,
     };
     let result = client::init_protocol_context(context_config).unwrap();
 

--- a/tezos/client/tests/bootstrap_storage_test.rs
+++ b/tezos/client/tests/bootstrap_storage_test.rs
@@ -55,6 +55,7 @@ fn init_test_protocol_context(
         enable_testchain: false,
         readonly: false,
         sandbox_json_patch_context: None,
+        context_stats_db_path: None,
     };
 
     let result = client::init_protocol_context(context_config).unwrap();

--- a/tezos/client/tests/ffi_rpc_router_test.rs
+++ b/tezos/client/tests/ffi_rpc_router_test.rs
@@ -63,6 +63,7 @@ fn init_test_protocol_context(
         enable_testchain: false,
         readonly: false,
         sandbox_json_patch_context: Some(test_data::get_patch_context()),
+        context_stats_db_path: None,
     };
 
     let result = client::init_protocol_context(context_config).unwrap();

--- a/tezos/client/tests/ffi_tests.rs
+++ b/tezos/client/tests/ffi_tests.rs
@@ -127,6 +127,7 @@ fn prepare_protocol_context(
         enable_testchain: false,
         readonly: false,
         sandbox_json_patch_context: None,
+        context_stats_db_path: None,
     };
 
     ffi::init_protocol_context(context_config).unwrap()

--- a/tezos/client/tests/init_storage_tests.rs
+++ b/tezos/client/tests/init_storage_tests.rs
@@ -54,6 +54,7 @@ fn test_init_empty_context_for_all_enviroment_nets() {
             enable_testchain: false,
             readonly: false,
             sandbox_json_patch_context: None,
+            context_stats_db_path: None,
         };
 
         match client::init_protocol_context(context_config) {
@@ -120,6 +121,7 @@ fn test_init_empty_context_for_sandbox_with_patch_json() -> Result<(), failure::
         enable_testchain: false,
         readonly: false,
         sandbox_json_patch_context: Some(patch_context),
+        context_stats_db_path: None,
     };
 
     match client::init_protocol_context(context_config) {
@@ -175,6 +177,7 @@ fn test_init_empty_context_for_sandbox_without_patch_json() -> Result<(), failur
         enable_testchain: false,
         readonly: false,
         sandbox_json_patch_context: None,
+        context_stats_db_path: None,
     };
 
     match client::init_protocol_context(context_config) {

--- a/tezos/client/tests/prevalidator_mempool_protocol_v1_test.rs
+++ b/tezos/client/tests/prevalidator_mempool_protocol_v1_test.rs
@@ -43,6 +43,7 @@ fn init_test_protocol_context(
         enable_testchain: false,
         readonly: false,
         sandbox_json_patch_context: tezos_env.patch_context_genesis_parameters.clone(),
+        context_stats_db_path: None,
     };
     let result = client::init_protocol_context(context_config).unwrap();
 

--- a/tezos/client/tests/prevalidator_mempool_test.rs
+++ b/tezos/client/tests/prevalidator_mempool_test.rs
@@ -53,6 +53,7 @@ fn init_test_protocol_context(
         enable_testchain: false,
         readonly: false,
         sandbox_json_patch_context: None,
+        context_stats_db_path: None,
     };
 
     let result = client::init_protocol_context(context_config).unwrap();

--- a/tezos/new_context/src/ffi.rs
+++ b/tezos/new_context/src/ffi.rs
@@ -649,6 +649,14 @@ ocaml_export! {
         timings::context_action(rt, action_name, key, irmin_time, tezedge_time);
         OCaml::unit()
     }
+
+    fn tezedge_timing_init(
+        rt,
+        db_path: OCamlRef<String>,
+    ) {
+        timings::init_timing(rt, db_path);
+        OCaml::unit()
+    }
 }
 
 unsafe impl ToOCaml<DynBox<WorkingTreeFFI>> for WorkingTreeFFI {
@@ -717,6 +725,7 @@ pub fn initialize_callbacks() {
             tezedge_timing_set_operation,
             tezedge_timing_commit,
             tezedge_timing_context_action,
+            tezedge_timing_init,
         );
     }
 }

--- a/tezos/new_context/src/ffi.rs
+++ b/tezos/new_context/src/ffi.rs
@@ -654,7 +654,9 @@ ocaml_export! {
         rt,
         db_path: OCamlRef<String>,
     ) {
-        timings::init_timing(rt, db_path);
+        let db_path: String = db_path.to_rust(rt);
+
+        timings::init_timing(db_path);
         OCaml::unit()
     }
 }

--- a/tezos/new_context/src/lib.rs
+++ b/tezos/new_context/src/lib.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 #![feature(hash_set_entry)]
-
 // #![forbid(unsafe_code)]
 
 //! Implementation of the TezEdge context for the Tezos economic protocol

--- a/tezos/new_context/src/tezedge_context.rs
+++ b/tezos/new_context/src/tezedge_context.rs
@@ -1,7 +1,11 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::{cell::{Ref, RefCell}, collections::HashSet, convert::TryInto};
+use std::{
+    cell::{Ref, RefCell},
+    collections::HashSet,
+    convert::TryInto,
+};
 use std::{convert::TryFrom, rc::Rc};
 
 use crypto::hash::ContextHash;
@@ -90,7 +94,7 @@ impl IndexApi<TezedgeContext> for TezedgeIndex {
 
 #[derive(Default)]
 pub struct StringInterner {
-    strings: HashSet<Rc<str>>
+    strings: HashSet<Rc<str>>,
 }
 
 impl StringInterner {
@@ -99,9 +103,7 @@ impl StringInterner {
             return Rc::from(s);
         }
 
-        self.strings.get_or_insert_with(s, |s| {
-            Rc::from(s)
-        }).clone()
+        self.strings.get_or_insert_with(s, |s| Rc::from(s)).clone()
     }
 }
 

--- a/tezos/new_context/src/timings.rs
+++ b/tezos/new_context/src/timings.rs
@@ -82,3 +82,13 @@ pub fn context_action(
 
     TIMING_CHANNEL.send(TimingMessage::Action(action)).unwrap();
 }
+
+pub fn init_timing(rt: &OCamlRuntime, db_path: OCamlRef<String>) {
+    let db_path: String = db_path.to_rust(rt);
+
+    TIMING_CHANNEL
+        .send(TimingMessage::InitTiming {
+            db_path: Some(db_path.into()),
+        })
+        .unwrap();
+}

--- a/tezos/new_context/src/timings.rs
+++ b/tezos/new_context/src/timings.rs
@@ -83,9 +83,7 @@ pub fn context_action(
     TIMING_CHANNEL.send(TimingMessage::Action(action)).unwrap();
 }
 
-pub fn init_timing(rt: &OCamlRuntime, db_path: OCamlRef<String>) {
-    let db_path: String = db_path.to_rust(rt);
-
+pub fn init_timing(db_path: String) {
     TIMING_CHANNEL
         .send(TimingMessage::InitTiming {
             db_path: Some(db_path.into()),

--- a/tezos/new_context/src/working_tree/working_tree.rs
+++ b/tezos/new_context/src/working_tree/working_tree.rs
@@ -695,7 +695,7 @@ impl WorkingTree {
             Some(new_node) => {
                 let last = self.index.get_str(last);
                 tree.insert(last.into(), Rc::new(new_node))
-            },
+            }
         };
 
         if tree.is_empty() {

--- a/tezos/sys/src/lib.rs
+++ b/tezos/sys/src/lib.rs
@@ -57,6 +57,7 @@ extern "C" {
         tezedge_timing_set_operation: unsafe extern "C" fn(isize) -> isize,
         tezedge_timing_commit: unsafe extern "C" fn(isize, f64, f64) -> isize,
         tezedge_timing_context_action: unsafe extern "C" fn(isize, isize, f64, f64) -> isize,
+        tezedge_timing_init: unsafe extern "C" fn(isize) -> isize,
     );
 }
 

--- a/tezos/timing/src/lib.rs
+++ b/tezos/timing/src/lib.rs
@@ -262,7 +262,6 @@ pub static TIMING_CHANNEL: Lazy<Sender<TimingMessage>> = Lazy::new(|| {
 });
 
 fn start_timing(recv: Receiver<TimingMessage>) {
-    let mut msgs = Vec::new();
     let mut db_path: Option<PathBuf> = None;
 
     for msg in &recv {
@@ -271,13 +270,13 @@ fn start_timing(recv: Receiver<TimingMessage>) {
                 db_path = path.clone();
                 break;
             }
-            msg => msgs.push(msg),
+            _ => {},
         }
     }
 
     let mut timing = Timing::new(db_path);
 
-    for msg in msgs.into_iter().chain(recv) {
+    for msg in recv {
         if let Err(_err) = timing.process_msg(msg) {
             // TODO: log error, and retry
         }

--- a/tezos/timing/src/lib.rs
+++ b/tezos/timing/src/lib.rs
@@ -270,7 +270,7 @@ fn start_timing(recv: Receiver<TimingMessage>) {
                 db_path = path.clone();
                 break;
             }
-            _ => {},
+            _ => {}
         }
     }
 

--- a/tezos/timing/src/lib.rs
+++ b/tezos/timing/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf};
 
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use crypto::hash::{BlockHash, ContextHash, OperationHash};
@@ -9,7 +9,7 @@ use once_cell::sync::Lazy;
 use rusqlite::{named_params, Batch, Connection, Error as SQLError};
 use serde::Serialize;
 
-pub const DB_PATH: &str = "context_stats.db";
+pub const FILENAME_DB: &str = "context_stats.db";
 
 #[derive(Debug)]
 pub enum ActionKind {
@@ -50,6 +50,9 @@ pub enum TimingMessage {
         tezedge_time: f64,
     },
     Action(Action),
+    InitTiming {
+        db_path: Option<PathBuf>,
+    },
 }
 
 // Id of the hash in the database
@@ -259,11 +262,10 @@ pub static TIMING_CHANNEL: Lazy<Sender<TimingMessage>> = Lazy::new(|| {
 });
 
 fn start_timing(recv: Receiver<TimingMessage>) {
-    #[cfg(not(test))]
-    let db_path = Some(DB_PATH.into());
-
-    #[cfg(test)]
-    let db_path = None;
+    let db_path = match recv.recv().unwrap() {
+        TimingMessage::InitTiming { db_path } => db_path,
+        _ => return,
+    };
 
     let mut timing = Timing::new(db_path);
 
@@ -286,7 +288,7 @@ pub fn hash_to_string(hash: &[u8]) -> String {
 }
 
 impl Timing {
-    fn new(db_path: Option<String>) -> Timing {
+    fn new(db_path: Option<PathBuf>) -> Timing {
         let sql = Self::init_sqlite(db_path).unwrap();
 
         Timing {
@@ -322,6 +324,7 @@ impl Timing {
                 irmin_time,
                 tezedge_time,
             } => self.insert_commit(irmin_time, tezedge_time),
+            TimingMessage::InitTiming { .. } => Ok(()),
         }
     }
 
@@ -843,11 +846,17 @@ impl Timing {
         Ok(())
     }
 
-    fn init_sqlite(db_path: Option<String>) -> Result<Connection, SQLError> {
-        let connection = match db_path.as_ref() {
-            Some(path) => {
-                std::fs::remove_file(path).ok();
-                Connection::open(path)?
+    fn init_sqlite(db_path: Option<PathBuf>) -> Result<Connection, SQLError> {
+        let connection = match db_path {
+            Some(mut path) => {
+                if !path.is_dir() {
+                    std::fs::create_dir_all(&path).ok();
+                }
+
+                path.push(FILENAME_DB);
+
+                std::fs::remove_file(&path).ok();
+                Connection::open(&path)?
             }
             None => Connection::open_in_memory()?,
         };
@@ -912,6 +921,9 @@ mod tests {
         let block_hash = BlockHash::try_from_bytes(&vec![1; 32]).unwrap();
         let context_hash = ContextHash::try_from_bytes(&vec![2; 32]).unwrap();
 
+        TIMING_CHANNEL
+            .send(TimingMessage::InitTiming { db_path: None })
+            .unwrap();
         TIMING_CHANNEL
             .send(TimingMessage::SetBlock(Some(block_hash)))
             .unwrap();

--- a/tezos/wrapper/src/service.rs
+++ b/tezos/wrapper/src/service.rs
@@ -66,7 +66,7 @@ struct InitProtocolContextParams {
     readonly: bool,
     turn_off_context_raw_inspector: bool,
     patch_context: Option<PatchContext>,
-    timing_db_path: Option<PathBuf>,
+    context_stats_db_path: Option<PathBuf>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -171,7 +171,7 @@ pub fn process_protocol_commands<Proto: ProtocolApi, P: AsRef<Path>, SDC: Fn(&Lo
                     enable_testchain: params.enable_testchain,
                     readonly: params.readonly,
                     sandbox_json_patch_context: params.patch_context,
-                    timing_db_path: params.timing_db_path,
+                    context_stats_db_path: params.context_stats_db_path,
                 };
                 let res = Proto::init_protocol_context(context_config);
                 tx.send(&NodeMessage::InitProtocolContextResult(res))?;
@@ -643,7 +643,7 @@ impl ProtocolController {
         enable_testchain: bool,
         readonly: bool,
         patch_context: Option<PatchContext>,
-        timing_db_path: Option<PathBuf>,
+        context_stats_db_path: Option<PathBuf>,
     ) -> Result<InitProtocolContextResult, ProtocolServiceError> {
         // try to check if was at least one write success, other words, if context was already created on file system
         {
@@ -678,7 +678,7 @@ impl ProtocolController {
                 readonly,
                 turn_off_context_raw_inspector: self.configuration.event_server_path.is_none(),
                 patch_context,
-                timing_db_path,
+                context_stats_db_path,
             },
         ))?;
 
@@ -743,7 +743,7 @@ impl ProtocolController {
         &self,
         commit_genesis: bool,
         patch_context: &Option<PatchContext>,
-        timing_db_path: &Path,
+        context_stats_db_path: Option<PathBuf>,
     ) -> Result<InitProtocolContextResult, ProtocolServiceError> {
         self.change_runtime_configuration(self.configuration.runtime_configuration.clone())?;
         self.init_protocol_context(
@@ -753,7 +753,7 @@ impl ProtocolController {
             self.configuration.enable_testchain,
             false,
             patch_context.clone(),
-            Some(timing_db_path.to_owned()),
+            context_stats_db_path,
         )
     }
 

--- a/tezos/wrapper/src/service.rs
+++ b/tezos/wrapper/src/service.rs
@@ -66,6 +66,7 @@ struct InitProtocolContextParams {
     readonly: bool,
     turn_off_context_raw_inspector: bool,
     patch_context: Option<PatchContext>,
+    timing_db_path: Option<PathBuf>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -170,6 +171,7 @@ pub fn process_protocol_commands<Proto: ProtocolApi, P: AsRef<Path>, SDC: Fn(&Lo
                     enable_testchain: params.enable_testchain,
                     readonly: params.readonly,
                     sandbox_json_patch_context: params.patch_context,
+                    timing_db_path: params.timing_db_path,
                 };
                 let res = Proto::init_protocol_context(context_config);
                 tx.send(&NodeMessage::InitProtocolContextResult(res))?;
@@ -641,6 +643,7 @@ impl ProtocolController {
         enable_testchain: bool,
         readonly: bool,
         patch_context: Option<PatchContext>,
+        timing_db_path: Option<PathBuf>,
     ) -> Result<InitProtocolContextResult, ProtocolServiceError> {
         // try to check if was at least one write success, other words, if context was already created on file system
         {
@@ -675,6 +678,7 @@ impl ProtocolController {
                 readonly,
                 turn_off_context_raw_inspector: self.configuration.event_server_path.is_none(),
                 patch_context,
+                timing_db_path,
             },
         ))?;
 
@@ -739,6 +743,7 @@ impl ProtocolController {
         &self,
         commit_genesis: bool,
         patch_context: &Option<PatchContext>,
+        timing_db_path: &Path,
     ) -> Result<InitProtocolContextResult, ProtocolServiceError> {
         self.change_runtime_configuration(self.configuration.runtime_configuration.clone())?;
         self.init_protocol_context(
@@ -748,6 +753,7 @@ impl ProtocolController {
             self.configuration.enable_testchain,
             false,
             patch_context.clone(),
+            Some(timing_db_path.to_owned()),
         )
     }
 
@@ -762,6 +768,7 @@ impl ProtocolController {
             false,
             self.configuration.enable_testchain,
             true,
+            None,
             None,
         )
     }


### PR DESCRIPTION
- Add a new parameter to the node: `timing-db-path`, it is the directory of the timing database.
- A new function `tezedge_timing_init` should be called from ocaml, before any other hooks, to set the db path
- RPC: Return a 404 HTTP response when block is not found