### PR TITLE
Implement replay

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -251,6 +251,8 @@ steps:
     - mv usr/local/etc/tezedge-data/tezedge_27708_2021-05-26T12:45:48.076277293+00:00/_data /tmp/tezedge_developer/data
     - rust_libs=$(echo "`rustup show home`/toolchains/`rustup show active-toolchain | tr " " "\n" | head -1`/lib")
     - export LD_LIBRARY_PATH="$${BUILD_ARTIFACTS_PATH}/build_files/ffi:$rust_libs"
+    # light-node reads the path of `protocol-runner` from the config file, even if provided as argument.
+    # Copy the `protocol-runner` binary to the path specified in the config file.
     - mkdir -p target/release
     - cp $${BUILD_ARTIFACTS_PATH}/build_files/protocol-runner target/release/
     - $${BUILD_ARTIFACTS_PATH}/build_files/light-node replay --target-path=/tmp/replay --config-file "$${BUILD_ARTIFACTS_PATH}/build_files/tezedge/tezedge_drone.config" --network=mainnet --to-block BLUP2BFdCq4qkFh6Sry7AGwa21D5hJUv8yLyWnNVLMwnLgF8JnF --one-context --tezos-data-dir=/tmp/tezedge_developer/data --identity-file "$${BUILD_ARTIFACTS_PATH}/build_files/identities/identity_6.json" --bootstrap-db-path=bootstrap_db

--- a/.drone.yml
+++ b/.drone.yml
@@ -234,6 +234,27 @@ environment:
 
 steps:
 
+- name: replay-test
+  image: simplestakingcom/tezedge-ci-builder:latest
+  user: root
+  pull: if-not-exists
+  volumes:
+    - name: build
+      path: /artifacts
+    - name: tezedge-snapshots
+      path: /tmp/tezedge-snapshots
+    - name: tezedge-node-snapshotted-data
+      path: /tmp/tezedge_developer
+  commands:
+    - rm -rf /tmp/tezedge_developer/data
+    - unzip /tmp/tezedge-snapshots/tezedge_data_from_block_0_to_26907.zip # TODO: change this name (typo 26907 -> 27907)
+    - mv usr/local/etc/tezedge-data/tezedge_27708_2021-05-26T12:45:48.076277293+00:00/_data /tmp/tezedge_developer/data
+    - rust_libs=$(echo "`rustup show home`/toolchains/`rustup show active-toolchain | tr " " "\n" | head -1`/lib")
+    - export LD_LIBRARY_PATH="$${BUILD_ARTIFACTS_PATH}/build_files/ffi:$rust_libs"
+    - mkdir -p target/release
+    - cp $${BUILD_ARTIFACTS_PATH}/build_files/protocol-runner target/release/
+    - $${BUILD_ARTIFACTS_PATH}/build_files/light-node replay --target-path=/tmp/replay --config-file "$${BUILD_ARTIFACTS_PATH}/build_files/tezedge/tezedge_drone.config" --network=mainnet --to-block BLUP2BFdCq4qkFh6Sry7AGwa21D5hJUv8yLyWnNVLMwnLgF8JnF --one-context --tezos-data-dir=/tmp/tezedge_developer/data --identity-file "$${BUILD_ARTIFACTS_PATH}/build_files/identities/identity_6.json" --bootstrap-db-path=bootstrap_db
+
 - name: protocol-runner/pool-test
   image: simplestakingcom/tezedge-ci-builder:latest
   pull: if-not-exists
@@ -454,6 +475,7 @@ steps:
     - echo "... replay context action file with sled..."
     - $${BUILD_ARTIFACTS_PATH}/build_files/context-actions-replayer --input $${TARGET_ACTION_FILE} --output /tmp/context-replay_output --context-kv-store sled
 
+
 depends_on:
   - build
 
@@ -467,6 +489,12 @@ volumes:
   - name: tests
     host:
       path: /usr/local/etc/tezedge-ci/tests/
+  - name: tezedge-snapshots
+    host:
+      path: /usr/local/etc/tezedge-ci/data/tezedge-snapshots
+  - name: tezedge-node-snapshotted-data
+    host:
+      path: /tezedge-data
 
 trigger:
   branch:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2008,7 +2008,9 @@ name = "light-node"
 version = "1.5.0"
 dependencies = [
  "clap",
+ "crypto",
  "failure",
+ "fs_extra",
  "futures",
  "jemallocator",
  "logging",

--- a/crypto/src/hash.rs
+++ b/crypto/src/hash.rs
@@ -98,6 +98,14 @@ macro_rules! define_hash {
             }
         }
 
+        impl std::str::FromStr for $name {
+            type Err = FromBase58CheckError;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                Self::from_base58_check(s)
+            }
+        }
+
         impl HashTrait for $name {
             fn hash_type() -> HashType {
                 HashType::$name

--- a/light_node/Cargo.toml
+++ b/light_node/Cargo.toml
@@ -8,6 +8,7 @@ default-run = "light-node"
 [dependencies]
 clap = "2.33"
 failure = "0.1"
+fs_extra = "1.2.0"
 futures = "0.3"
 jemallocator = "0.3.2"
 riker = "0.4"
@@ -21,6 +22,7 @@ strum = "0.20"
 strum_macros = "0.20"
 tokio = { version = "1.2", features = ["rt-multi-thread", "signal"] }
 # Local dependencies
+crypto = { path = "../crypto" }
 logging = { path = "../logging" }
 tezos_api = { path = "../tezos/api" }
 tezos_identity = { path = "../tezos/identity" }

--- a/light_node/etc/tezedge/tezedge.config
+++ b/light_node/etc/tezedge/tezedge.config
@@ -35,7 +35,7 @@
 # If directory does not exists, it will be created. If directory already exists, and contains valid database, node
 # will erase it and create a new database
 # --context-stats-db-path <PATH>
---context-stats-db-path=context-stats_db
+--context-stats-db-path=context_stats_db
 
 #Max number of threads used by database configuration. If not specified, then number of threads equal to CPU cores.
 #--db-cfg-max-threads <NUM>

--- a/light_node/etc/tezedge/tezedge_drone.config
+++ b/light_node/etc/tezedge/tezedge_drone.config
@@ -35,7 +35,7 @@
 # If directory does not exists, it will be created. If directory already exists, and contains valid database, node
 # will erase it and create a new database
 # --context-stats-db-path <PATH>
---context-stats-db-path=/tmp/tezedge_developer/context-stats-db
+--context-stats-db-path=/tmp/tezedge_developer/context_stats_db
 
 # <Optional> A peers for dns lookup to get the peers to bootstrap the network from. Peers are delimited by a colon.
 # Default: used according to --network parameter see TezosEnvironment

--- a/light_node/etc/tezedge_sandbox/tezedge_drone_sandbox.config
+++ b/light_node/etc/tezedge_sandbox/tezedge_drone_sandbox.config
@@ -34,7 +34,7 @@
 # If directory does not exists, it will be created. If directory already exists, and contains valid database, node
 # will erase it and create a new database
 # --context-stats-db-path <PATH>
---context-stats-db-path=/tmp/sandbox/context-stats-db
+--context-stats-db-path=/tmp/sandbox/context_stats_db
 
 # <Optional> A peers for dns lookup to get the peers to bootstrap the network from. Peers are delimited by a colon.
 # Default: used according to --network parameter see TezosEnvironment

--- a/light_node/etc/tezedge_sandbox/tezedge_sandbox.config
+++ b/light_node/etc/tezedge_sandbox/tezedge_sandbox.config
@@ -35,7 +35,7 @@
 # If directory does not exists, it will be created. If directory already exists, and contains valid database, node
 # will erase it and create a new database
 # --context-stats-db-path <PATH>
---context-stats-db-path=/tmp/tezedge_developer/context-stats-db
+--context-stats-db-path=/tmp/tezedge_developer/context_stats_db
 
 # <Optional> A peers for dns lookup to get the peers to bootstrap the network from. Peers are delimited by a colon.
 # Default: used according to --network parameter see TezosEnvironment

--- a/light_node/src/configuration.rs
+++ b/light_node/src/configuration.rs
@@ -21,6 +21,7 @@ use slog::{Drain, Duplicate, Logger, Never, SendSyncRefUnwindSafeDrain};
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
+use crypto::hash::BlockHash;
 use logging::detailed_json;
 use logging::file::FileAppenderBuilder;
 use shell::peer_manager::P2p;
@@ -34,7 +35,7 @@ use storage::initializer::{
     ContextActionsRocksDbTableInitializer, ContextKvStoreConfiguration,
     ContextRocksDbTableInitializer, DbsRocksDbTableInitializer, RocksDbConfig,
 };
-use storage::PersistentStorage;
+use storage::{PersistentStorage, Replay};
 use tezos_api::environment;
 use tezos_api::environment::{TezosEnvironment, ZcashParams};
 use tezos_api::ffi::{
@@ -263,6 +264,7 @@ pub struct Environment {
     pub storage: Storage,
     pub identity: Identity,
     pub ffi: Ffi,
+    pub replay: Option<Replay>,
 
     pub tezos_network: TezosEnvironment,
     pub enable_testchain: bool,
@@ -301,21 +303,25 @@ pub fn tezos_app() -> App<'static, 'static> {
         .setting(clap::AppSettings::AllArgsOverrideSelf)
         .arg(Arg::with_name("validate-cfg-identity-and-stop")
             .long("validate-cfg-identity-and-stop")
+            .global(true)
             .takes_value(false)
             .help("Validate configuration and generated identity, than just stops application"))
         .arg(Arg::with_name("config-file")
             .long("config-file")
+            .global(true)
             .takes_value(true)
             .value_name("PATH")
             .help("Configuration file with start-up arguments (same format as cli arguments)")
             .validator(|v| if Path::new(&v).exists() { Ok(()) } else { Err(format!("Configuration file not found at '{}'", v)) }))
         .arg(Arg::with_name("tezos-context-storage")
             .long("tezos-context-storage")
+            .global(true)
             .takes_value(true)
             .value_name("NAME")
             .help("Context storage to use (irmin/tezedge/both)"))
         .arg(Arg::with_name("tezos-data-dir")
             .long("tezos-data-dir")
+            .global(true)
             .takes_value(true)
             .value_name("PATH")
             .help("A directory for Tezos OCaml runtime storage (context/store)")
@@ -338,59 +344,69 @@ pub fn tezos_app() -> App<'static, 'static> {
             }))
         .arg(Arg::with_name("identity-file")
             .long("identity-file")
+            .global(true)
             .takes_value(true)
             .value_name("PATH")
             .help("Path to the json identity file with peer-id, public-key, secret-key and pow-stamp.
                        In case it starts with ./ or ../, it is relative path to the current dir, otherwise to the --tezos-data-dir"))
         .arg(Arg::with_name("identity-expected-pow")
             .long("identity-expected-pow")
+            .global(true)
             .takes_value(true)
             .value_name("NUM")
             .help("Expected power of identity for node. It is used to generate new identity. Default: 26.0")
             .validator(parse_validator_fn!(f64, "Value must be a valid f64 number for expected_pow")))
         .arg(Arg::with_name("bootstrap-db-path")
             .long("bootstrap-db-path")
+            .global(true)
             .takes_value(true)
             .value_name("PATH")
             .help("Path to bootstrap database directory.
                        In case it starts with ./ or ../, it is relative path to the current dir, otherwise to the --tezos-data-dir"))
         .arg(Arg::with_name("context-stats-db-path")
             .long("context-stats-db-path")
+            .global(true)
             .takes_value(true)
             .value_name("PATH")
             .help("Path to context-stats database directory.
                        In case it starts with ./ or ../, it is relative path to the current dir, otherwise to the --tezos-data-dir"))
         .arg(Arg::with_name("db-cfg-max-threads")
             .long("db-cfg-max-threads")
+            .global(true)
             .takes_value(true)
             .value_name("NUM")
             .help("Max number of threads used by database configuration. If not specified, then number of threads equal to CPU cores.")
             .validator(parse_validator_fn!(usize, "Value must be a valid number")))
         .arg(Arg::with_name("db-context-cfg-max-threads")
             .long("db-context-cfg-max-threads")
+            .global(true)
             .takes_value(true)
             .value_name("NUM")
             .help("Max number of threads used by database configuration. If not specified, then number of threads equal to CPU cores.")
             .validator(parse_validator_fn!(usize, "Value must be a valid number")))
         .arg(Arg::with_name("db-context-actions-cfg-max-threads")
             .long("db-context-actions-cfg-max-threads")
+            .global(true)
             .takes_value(true)
             .value_name("NUM")
             .help("Max number of threads used by database configuration. If not specified, then number of threads equal to CPU cores.")
             .validator(parse_validator_fn!(usize, "Value must be a valid number")))
         .arg(Arg::with_name("bootstrap-lookup-address")
             .long("bootstrap-lookup-address")
+            .global(true)
             .takes_value(true)
             .conflicts_with("peers")
             .conflicts_with("private-node")
             .help("A peers for dns lookup to get the peers to bootstrap the network from. Peers are delimited by a colon. Default: used according to --network parameter see TezosEnvironment"))
         .arg(Arg::with_name("disable-bootstrap-lookup")
             .long("disable-bootstrap-lookup")
+            .global(true)
             .takes_value(false)
             .conflicts_with("bootstrap-lookup-address")
             .help("Disables dns lookup to get the peers to bootstrap the network from. Default: false"))
         .arg(Arg::with_name("log")
             .long("log")
+            .global(true)
             .takes_value(true)
             .multiple(true)
             .value_name("STRING")
@@ -398,31 +414,37 @@ pub fn tezos_app() -> App<'static, 'static> {
             .help("Set the logger target. Default: terminal"))
         .arg(Arg::with_name("log-file")
             .long("log-file")
+            .global(true)
             .takes_value(true)
             .value_name("PATH")
             .help("Path to the log file. If provided, logs are displayed the log file, otherwise in terminal.
                        In case it starts with ./ or ../, it is relative path to the current dir, otherwise to the --tezos-data-dir"))
         .arg(Arg::with_name("log-format")
             .long("log-format")
+            .global(true)
             .takes_value(true)
             .possible_values(&["json", "simple"])
             .help("Set output format of the log"))
         .arg(Arg::with_name("log-level")
             .long("log-level")
+            .global(true)
             .takes_value(true)
             .value_name("LEVEL")
             .possible_values(&["critical", "error", "warn", "info", "debug", "trace"])
             .help("Set log level"))
         .arg(Arg::with_name("ocaml-log-enabled")
             .long("ocaml-log-enabled")
+            .global(true)
             .takes_value(true)
             .value_name("BOOL")
             .help("Flag for turn on/off logging in Tezos OCaml runtime"))
         .arg(Arg::with_name("disable-mempool")
             .long("disable-mempool")
+            .global(true)
             .help("Enable or disable mempool"))
         .arg(Arg::with_name("private-node")
             .long("private-node")
+            .global(true)
             .takes_value(true)
             .value_name("BOOL")
             .requires("peers")
@@ -430,35 +452,41 @@ pub fn tezos_app() -> App<'static, 'static> {
             .help("Enable or disable private node. Use peers to set IP addresses of the peers you want to connect to"))
         .arg(Arg::with_name("network")
             .long("network")
+            .global(true)
             .takes_value(true)
             .possible_values(&TezosEnvironment::possible_values())
             .help("Choose the Tezos environment")
         )
         .arg(Arg::with_name("p2p-port")
             .long("p2p-port")
+            .global(true)
             .takes_value(true)
             .value_name("PORT")
             .help("Socket listening port for p2p for communication with tezos world")
             .validator(parse_validator_fn!(u16, "Value must be a valid port number")))
         .arg(Arg::with_name("rpc-port")
             .long("rpc-port")
+            .global(true)
             .takes_value(true)
             .value_name("PORT")
             .help("Rust server RPC port for communication with rust node")
             .validator(parse_validator_fn!(u16, "Value must be a valid port number")))
         .arg(Arg::with_name("enable-testchain")
             .long("enable-testchain")
+            .global(true)
             .takes_value(true)
             .value_name("BOOL")
             .help("Flag for enable/disable test chain switching for block applying. Default: false"))
         .arg(Arg::with_name("websocket-address")
             .long("websocket-address")
+            .global(true)
             .takes_value(true)
             .value_name("IP:PORT")
             .help("Websocket address where various node metrics and statistics are available")
             .validator(parse_validator_fn!(SocketAddr, "Value must be a valid IP:PORT")))
         .arg(Arg::with_name("peers")
             .long("peers")
+            .global(true)
             .takes_value(true)
             .value_name("IP:PORT")
             .help("A peer to bootstrap the network from. Peers are delimited by a colon. Format: IP1:PORT1,IP2:PORT2,IP3:PORT3")
@@ -475,24 +503,28 @@ pub fn tezos_app() -> App<'static, 'static> {
             }))
         .arg(Arg::with_name("peer-thresh-low")
             .long("peer-thresh-low")
+            .global(true)
             .takes_value(true)
             .value_name("NUM")
             .help("Minimal number of peers to connect to")
             .validator(parse_validator_fn!(usize, "Value must be a valid number")))
         .arg(Arg::with_name("peer-thresh-high")
             .long("peer-thresh-high")
+            .global(true)
             .takes_value(true)
             .value_name("NUM")
             .help("Maximal number of peers to connect to")
             .validator(parse_validator_fn!(usize, "Value must be a valid number")))
         .arg(Arg::with_name("synchronization-thresh")
             .long("synchronization-thresh")
+            .global(true)
             .takes_value(true)
             .value_name("NUM")
             .help("Maximal number of peers to connect to")
             .validator(parse_validator_fn!(usize, "Value must be a valid number")))
         .arg(Arg::with_name("protocol-runner")
             .long("protocol-runner")
+            .global(true)
             .takes_value(true)
             .value_name("PATH")
             .help("Path to a tezos protocol runner executable")
@@ -501,24 +533,28 @@ pub fn tezos_app() -> App<'static, 'static> {
             &[
                 Arg::with_name("ffi-pool-max-connections")
                     .long("ffi-pool-max-connections")
+                    .global(true)
                     .takes_value(true)
                     .value_name("NUM")
                     .help("Number of max ffi pool connections, default: 10")
                     .validator(parse_validator_fn!(u8, "Value must be a valid number")),
                 Arg::with_name("ffi-pool-connection-timeout-in-secs")
                     .long("ffi-pool-connection-timeout-in-secs")
+                    .global(true)
                     .takes_value(true)
                     .value_name("NUM")
                     .help("Number of seconds to wait for connection, default: 60")
                     .validator(parse_validator_fn!(u16, "Value must be a valid number")),
                 Arg::with_name("ffi-pool-max-lifetime-in-secs")
                     .long("ffi-pool-max-lifetime-in-secs")
+                    .global(true)
                     .takes_value(true)
                     .value_name("NUM")
                     .help("Number of seconds to remove protocol_runner from pool, default: 21600 means 6 hours")
                     .validator(parse_validator_fn!(u64, "Value must be a valid number")),
                 Arg::with_name("ffi-pool-idle-timeout-in-secs")
                     .long("ffi-pool-idle-timeout-in-secs")
+                    .global(true)
                     .takes_value(true)
                     .value_name("NUM")
                     .help("Number of seconds to remove unused protocol_runner from pool, default: 1800 means 30 minutes")
@@ -528,24 +564,28 @@ pub fn tezos_app() -> App<'static, 'static> {
             &[
                 Arg::with_name("ffi-trpap-pool-max-connections")
                     .long("ffi-trpap-pool-max-connections")
+                    .global(true)
                     .takes_value(true)
                     .value_name("NUM")
                     .help("Number of max ffi pool connections, default: 10")
                     .validator(parse_validator_fn!(u8, "Value must be a valid number")),
                 Arg::with_name("ffi-trpap-pool-connection-timeout-in-secs")
                     .long("ffi-trpap-pool-connection-timeout-in-secs")
+                    .global(true)
                     .takes_value(true)
                     .value_name("NUM")
                     .help("Number of seconds to wait for connection, default: 60")
                     .validator(parse_validator_fn!(u16, "Value must be a valid number")),
                 Arg::with_name("ffi-trpap-pool-max-lifetime-in-secs")
                     .long("ffi-trpap-pool-max-lifetime-in-secs")
+                    .global(true)
                     .takes_value(true)
                     .value_name("NUM")
                     .help("Number of seconds to remove protocol_runner from pool, default: 21600 means 6 hours")
                     .validator(parse_validator_fn!(u64, "Value must be a valid number")),
                 Arg::with_name("ffi-trpap-pool-idle-timeout-in-secs")
                     .long("ffi-trpap-pool-idle-timeout-in-secs")
+                    .global(true)
                     .takes_value(true)
                     .value_name("NUM")
                     .help("Number of seconds to remove unused protocol_runner from pool, default: 1800 means 30 minutes")
@@ -555,24 +595,28 @@ pub fn tezos_app() -> App<'static, 'static> {
             &[
                 Arg::with_name("ffi-twcap-pool-max-connections")
                     .long("ffi-twcap-pool-max-connections")
+                    .global(true)
                     .takes_value(true)
                     .value_name("NUM")
                     .help("Number of max ffi pool connections, default: 10")
                     .validator(parse_validator_fn!(u8, "Value must be a valid number")),
                 Arg::with_name("ffi-twcap-pool-connection-timeout-in-secs")
                     .long("ffi-twcap-pool-connection-timeout-in-secs")
+                    .global(true)
                     .takes_value(true)
                     .value_name("NUM")
                     .help("Number of seconds to wait for connection, default: 60")
                     .validator(parse_validator_fn!(u16, "Value must be a valid number")),
                 Arg::with_name("ffi-twcap-pool-max-lifetime-in-secs")
                     .long("ffi-twcap-pool-max-lifetime-in-secs")
+                    .global(true)
                     .takes_value(true)
                     .value_name("NUM")
                     .help("Number of seconds to remove protocol_runner from pool, default: 21600 means 6 hours")
                     .validator(parse_validator_fn!(u64, "Value must be a valid number")),
                 Arg::with_name("ffi-twcap-pool-idle-timeout-in-secs")
                     .long("ffi-twcap-pool-idle-timeout-in-secs")
+                    .global(true)
                     .takes_value(true)
                     .value_name("NUM")
                     .help("Number of seconds to remove unused protocol_runner from pool, default: 1800 means 30 minutes")
@@ -580,24 +624,28 @@ pub fn tezos_app() -> App<'static, 'static> {
             ])
         .arg(Arg::with_name("init-sapling-spend-params-file")
             .long("init-sapling-spend-params-file")
+            .global(true)
             .takes_value(true)
             .value_name("PATH")
             .help("Path to a init file for sapling-spend.params")
         )
         .arg(Arg::with_name("init-sapling-output-params-file")
             .long("init-sapling-output-params-file")
+            .global(true)
             .takes_value(true)
             .value_name("PATH")
             .help("Path to a init file for sapling-output.params")
         )
         .arg(Arg::with_name("tokio-threads")
             .long("tokio-threads")
+            .global(true)
             .takes_value(true)
             .value_name("NUM")
             .help("Number of threads spawned by a tokio thread pool. If value is zero, then number of threads equal to CPU cores is spawned.")
             .validator(parse_validator_fn!(usize, "Value must be a valid number")))
         .arg(Arg::with_name("actions-store-backend")
             .long("actions-store-backend")
+            .global(true)
             .takes_value(true)
             // TODO: hard to override, do as single atribute commanseparated
             // .multiple(true)
@@ -606,26 +654,87 @@ pub fn tezos_app() -> App<'static, 'static> {
             .help("Activate recording of context storage actions"))
         .arg(Arg::with_name("one-context")
             .long("one-context")
+            .global(true)
             .takes_value(false)
             .help("TODO: TE-447 - temp/hack argument to turn off TezEdge second context"))
         .arg(Arg::with_name("context-kv-store")
             .long("context-kv-store")
+            .global(true)
             .takes_value(true)
             .value_name("STRING")
             .possible_values(&SupportedContextKeyValueStore::possible_values())
             .help("Choose the merkle storege backend - supported backends: 'rocksdb', 'sled', 'inmem', 'inmem-gc', 'btree'"))
         .arg(Arg::with_name("compute-context-action-tree-hashes")
             .long("compute-context-action-tree-hashes")
+            .global(true)
             .takes_value(true)
             .value_name("BOOL")
             .help("Activate the computation of tree hashes when applying context actions"))
         .arg(Arg::with_name("sandbox-patch-context-json-file")
             .long("sandbox-patch-context-json-file")
+            .global(true)
             .takes_value(true)
             .value_name("PATH")
             .required(false)
             .help("Path to the json file with key-values, which will be added to empty context on startup and commit genesis.")
-            .validator(|v| if Path::new(&v).exists() { Ok(()) } else { Err(format!("Sandbox patch-context json file not found at '{}'", v)) }));
+            .validator(|v| if Path::new(&v).exists() { Ok(()) } else { Err(format!("Sandbox patch-context json file not found at '{}'", v)) }))
+        .subcommand(
+            clap::SubCommand::with_name("replay")
+                .arg(Arg::with_name("from-block")
+                     .long("from-block")
+                     .takes_value(true)
+                     .value_name("HASH")
+                     .display_order(0)
+                     .help("Block from which we start the replay")
+                     .validator(|value| {
+                         value.parse::<BlockHash>().map(|_| ()).map_err(|_| format!("Block hash not valid"))
+                     })
+                )
+                .arg(Arg::with_name("to-block")
+                     .long("to-block")
+                     .takes_value(true)
+                     .value_name("HASH")
+                     .display_order(0)
+                     .required(true)
+                     .help("Replay until this block")
+                     .validator(|value| {
+                         value.parse::<BlockHash>().map(|_| ()).map_err(|_| format!("Block hash not valid"))
+                     })
+                )
+                .arg(Arg::with_name("target-path")
+                     .long("target-path")
+                     .takes_value(true)
+                     .value_name("PATH")
+                     .display_order(1)
+                     .required(true)
+                     .help("A directory for the replay")
+                     .validator(|v| {
+                         let dir = Path::new(&v);
+                         if dir.exists() {
+                             if dir.is_dir() {
+                                 Ok(())
+                             } else {
+                                 Err(format!("Required replay data dir '{}' exists, but is not a directory!", v))
+                             }
+                         } else {
+                             // Tezos data dir does not exists, try to create it
+                             if let Err(e) = fs::create_dir_all(dir) {
+                                 Err(format!("Unable to create required replay data dir '{}': {} ", v, e))
+                             } else {
+                                 Ok(())
+                             }
+                         }
+                     }))
+                .arg(Arg::with_name("fail-above")
+                     .long("fail-above")
+                     .takes_value(true)
+                     .value_name("NUM")
+                     .display_order(1)
+                     .required(false)
+                     .help("Panic if the block application took longer than this number of milliseconds")
+                     .validator(parse_validator_fn!(u64, "Value must be a valid number"))
+                )
+        );
     app
 }
 
@@ -813,11 +922,51 @@ impl Environment {
             .unwrap_or("both")
             .parse::<TezosContextStorageChoice>()
             .expect("Provided value cannot be converted to a context storage option");
-        let tezos_data_dir: PathBuf = args
+        let mut tezos_data_dir: PathBuf = args
             .value_of("tezos-data-dir")
             .unwrap_or("")
             .parse::<PathBuf>()
             .expect("Provided value cannot be converted to path");
+
+        let replay = args.subcommand_matches("replay").map(|args| {
+            let target_path = args
+                .value_of("target-path")
+                .unwrap()
+                .parse::<PathBuf>()
+                .expect("Provided value cannot be converted to path");
+
+            let to_block = args
+                .value_of("to-block")
+                .unwrap()
+                .parse::<BlockHash>()
+                .expect("Provided value cannot be converted to BlockHash");
+
+            let from_block = args.value_of("from-block").map(|b| {
+                b.parse::<BlockHash>()
+                    .expect("Provided value cannot be converted to BlockHash")
+            });
+
+            let fail_above = std::time::Duration::from_millis(
+                args.value_of("fail-above")
+                    .unwrap_or(&format!("{}", u64::MAX))
+                    .parse::<u64>()
+                    .expect("Provided value cannot be converted to number"),
+            );
+
+            let mut options = fs_extra::dir::CopyOptions::default();
+            options.content_only = true;
+            options.overwrite = true;
+
+            fs_extra::dir::copy(tezos_data_dir.as_path(), target_path.as_path(), &options).unwrap();
+
+            tezos_data_dir = target_path;
+
+            Replay {
+                from_block,
+                to_block,
+                fail_above,
+            }
+        });
 
         let log_targets: HashSet<String> = match args.values_of("log") {
             Some(v) => v.map(String::from).collect(),
@@ -964,7 +1113,7 @@ impl Environment {
                     .unwrap_or("")
                     .parse::<PathBuf>()
                     .expect("Provided value cannot be converted to path");
-                let db_path = get_final_path(&tezos_data_dir, path);
+                let db_path = get_final_path(&tezos_data_dir, path.clone());
 
                 let context_stats_db_path = args.value_of("context-stats-db-path").map(|value| {
                     let path = value
@@ -1220,6 +1369,7 @@ impl Environment {
                         .expect("Provided value cannot be converted to path"),
                 },
             },
+            replay,
             tokio_threads: args
                 .value_of("tokio-threads")
                 .unwrap_or("0")

--- a/light_node/src/main.rs
+++ b/light_node/src/main.rs
@@ -2,21 +2,18 @@
 // SPDX-License-Identifier: MIT
 // #![forbid(unsafe_code)]
 
-use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+use std::{path::PathBuf, sync::Condvar};
 
 use riker::actors::*;
 use slog::{debug, error, info, warn, Logger};
 
+use crypto::hash::BlockHash;
 use monitoring::{Monitor, WebsocketHandler};
 use networking::p2p::network_channel::NetworkChannel;
 use networking::ShellCompatibilityVersion;
 use rpc::rpc_actor::RpcServer;
-use shell::chain_current_head_manager::ChainCurrentHeadManager;
-use shell::chain_feeder::ChainFeeder;
-use shell::chain_manager::ChainManager;
-use shell::context_listener::ContextListener;
 use shell::mempool::init_mempool_state_storage;
 use shell::mempool::mempool_channel::MempoolChannel;
 use shell::mempool::mempool_prevalidator::MempoolPrevalidator;
@@ -24,12 +21,19 @@ use shell::peer_manager::PeerManager;
 use shell::shell_channel::{ShellChannel, ShellChannelTopic, ShuttingDown};
 use shell::state::head_state::init_current_head_state;
 use shell::state::synchronization_state::init_synchronization_bootstrap_state_storage;
+use shell::{chain_current_head_manager::ChainCurrentHeadManager, chain_feeder::ChainFeederRef};
+use shell::{chain_feeder::ApplyBlock, chain_manager::ChainManager};
+use shell::{chain_feeder::ChainFeeder, state::ApplyBlockBatch};
+use shell::{context_listener::ContextListener, shell_channel::ShellChannelRef};
 use storage::context::TezedgeContext;
-use storage::initializer::{
-    initialize_merkle, initialize_rocksdb, GlobalRocksDbCacheHolder, MainChain, RocksDbCache,
-};
 use storage::persistent::sequence::Sequences;
 use storage::persistent::{open_cl, CommitLogSchema};
+use storage::{
+    initializer::{
+        initialize_merkle, initialize_rocksdb, GlobalRocksDbCacheHolder, MainChain, RocksDbCache,
+    },
+    BlockMetaStorage, Replay,
+};
 use storage::{resolve_storage_init_chain_data, BlockStorage, PersistentStorage, StorageInitInfo};
 use tezos_api::environment;
 use tezos_api::environment::TezosEnvironmentConfiguration;
@@ -167,6 +171,7 @@ fn block_on_actors(
     identity: Arc<Identity>,
     persistent_storage: PersistentStorage,
     tezedge_context: TezedgeContext,
+    mut blocks_replay: Option<Vec<Arc<BlockHash>>>,
     log: Logger,
 ) {
     // if feeding is started, than run chain manager
@@ -302,7 +307,7 @@ fn block_on_actors(
     .expect("Failed to create chain feeder");
     let _ = ChainManager::actor(
         &actor_system,
-        block_applier,
+        block_applier.clone(),
         network_channel.clone(),
         shell_channel.clone(),
         mempool_channel.clone(),
@@ -370,21 +375,31 @@ fn block_on_actors(
     )
     .expect("Failed to create RPC server");
 
-    // TODO: TE-386 - controlled startup
-    std::thread::sleep(std::time::Duration::from_secs(2));
+    if let Some(blocks) = blocks_replay.take() {
+        return schedule_replay_blocks(
+            blocks,
+            &init_storage_data,
+            block_applier,
+            shell_channel.clone(),
+            log.clone(),
+        );
+    } else {
+        // TODO: TE-386 - controlled startup
+        std::thread::sleep(std::time::Duration::from_secs(2));
 
-    // and than open p2p and others
-    let _ = PeerManager::actor(
-        &actor_system,
-        network_channel,
-        shell_channel.clone(),
-        tokio_runtime.handle().clone(),
-        identity,
-        shell_compatibility_version,
-        env.p2p,
-        env.identity.expected_pow,
-    )
-    .expect("Failed to create peer manager");
+        // and than open p2p and others
+        let _ = PeerManager::actor(
+            &actor_system,
+            network_channel,
+            shell_channel.clone(),
+            tokio_runtime.handle().clone(),
+            identity,
+            shell_compatibility_version,
+            env.p2p,
+            env.identity.expected_pow,
+        )
+        .expect("Failed to create peer manager");
+    }
 
     info!(log, "Actors initialized");
 
@@ -434,6 +449,131 @@ fn check_deprecated_network(env: &Environment, log: &Logger) {
     if let Some(deprecation_notice) = env.tezos_network.check_deprecated_network() {
         warn!(log, "Deprecated network: {}", deprecation_notice);
     }
+}
+
+fn schedule_replay_blocks(
+    blocks: Vec<Arc<BlockHash>>,
+    init_storage_data: &StorageInitInfo,
+    block_applier: ChainFeederRef,
+    shell_channel: ShellChannelRef,
+    log: Logger,
+) {
+    let chain_id = Arc::new(init_storage_data.chain_id.clone());
+    let pair = Arc::new((Mutex::new(None), Condvar::new()));
+    let fail_above = init_storage_data.replay.as_ref().unwrap().fail_above;
+    let nblocks = blocks.len();
+
+    for (index, block) in blocks.into_iter().enumerate() {
+        let batch = ApplyBlockBatch::one((&*block).clone());
+        let result_callback = Some(Arc::clone(&pair));
+
+        let now = std::time::Instant::now();
+        block_applier.tell(
+            ApplyBlock::new(Arc::clone(&chain_id), batch, result_callback, None, None),
+            None,
+        );
+
+        let (lock, cvar) = &*pair;
+        let lock = lock.lock().unwrap();
+        let result = cvar.wait(lock).unwrap();
+        let time = now.elapsed();
+
+        let hash = block.to_base58_check();
+        let percent = (index as f64 / nblocks as f64) * 100.0;
+
+        if let Some(Err(_)) = &*result {
+            replay_shutdown(shell_channel);
+            panic!(
+                "{:.5}% Block {} failed in {:?}. Result={:?}",
+                percent, hash, time, result
+            );
+        } else if time > fail_above && index > 0 {
+            replay_shutdown(shell_channel);
+            panic!(
+                "{:.5}% Block {} processed in {:?} (more than {:?}). Result={:?}",
+                percent, hash, time, fail_above, result
+            );
+        } else {
+            info!(
+                log,
+                "{:.5}% Block {} applied in {:?}. Result={:?}", percent, hash, time, result
+            );
+        }
+    }
+
+    info!(log, "Replayer successfully applied {} blocks", nblocks);
+
+    replay_shutdown(shell_channel);
+}
+
+fn replay_shutdown(shell_channel: ShellChannelRef) {
+    shell_channel.tell(
+        Publish {
+            msg: ShuttingDown.into(),
+            topic: ShellChannelTopic::ShellShutdown.into(),
+        },
+        None,
+    );
+
+    // give actors some time to shut down
+    std::thread::sleep(Duration::from_secs(2));
+}
+
+fn collect_replayed_blocks(
+    persistent_storage: &PersistentStorage,
+    replay: &Replay,
+    log: &Logger,
+) -> Vec<Arc<BlockHash>> {
+    let block_meta_storage = BlockMetaStorage::new(&persistent_storage);
+    let from_block = replay.from_block.as_ref();
+    let mut block_hash = replay.to_block.clone();
+    let mut blocks = Vec::new();
+    let mut first_block_reached = false;
+
+    info!(log, "Replayer is collecting blocks");
+
+    if block_meta_storage
+        .get(&block_hash)
+        .map(|h| h.is_none())
+        .unwrap_or(true)
+    {
+        panic!("Unable to find block {:?}", block_hash.to_base58_check());
+    }
+
+    while let Ok(Some(block_meta)) = block_meta_storage.get(&block_hash) {
+        blocks.push(Arc::new(block_hash.clone()));
+
+        first_block_reached = block_meta.level() == 1;
+        if from_block == Some(&block_hash) || first_block_reached {
+            break;
+        }
+
+        block_hash = match block_meta.predecessor() {
+            Some(block) => block.clone(),
+            None => {
+                panic!(
+                    "Unable to find predecessor of level={:?} block_hash={:?}",
+                    block_meta.level(),
+                    block_hash.to_base58_check()
+                );
+            }
+        }
+    }
+
+    blocks.reverse();
+    match (from_block, blocks.get(0)) {
+        (Some(block), first) if blocks.is_empty() || block != &**first.unwrap() => {
+            panic!("Unable to find block {:?}", block);
+        }
+        (None, _) if !first_block_reached => {
+            panic!("Unable to find first block");
+        }
+        _ => {}
+    }
+
+    info!(log, "Replayer will apply {} blocks", blocks.len());
+
+    blocks
 }
 
 fn main() {
@@ -580,9 +720,15 @@ fn main() {
             &env.storage.patch_context,
             env.storage.one_context,
             &env.storage.context_stats_db_path,
+            &env.replay,
             &log,
         ) {
             Ok(init_data) => {
+                let blocks_replay = env
+                    .replay
+                    .as_ref()
+                    .map(|replay| collect_replayed_blocks(&persistent_storage, replay, &log));
+
                 info!(log, "Databases loaded successfully");
                 block_on_actors(
                     env,
@@ -591,6 +737,7 @@ fn main() {
                     Arc::new(tezos_identity),
                     persistent_storage,
                     tezedge_context,
+                    blocks_replay,
                     log,
                 )
             }

--- a/shell/tests/common/infra.rs
+++ b/shell/tests/common/infra.rs
@@ -111,6 +111,7 @@ impl NodeInfrastructure {
             &patch_context,
             false,
             &None,
+            &None,
             &log,
         )
         .expect("Failed to resolve init storage chain data");

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -206,6 +206,13 @@ impl slog::Value for StorageError {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Replay {
+    pub from_block: Option<BlockHash>,
+    pub to_block: BlockHash,
+    pub fail_above: std::time::Duration,
+}
+
 /// Struct represent init information about storage on startup
 #[derive(Clone, Serialize, Deserialize)]
 pub struct StorageInitInfo {
@@ -213,6 +220,7 @@ pub struct StorageInitInfo {
     pub genesis_block_header_hash: BlockHash,
     pub patch_context: Option<PatchContext>,
     pub context_stats_db_path: Option<PathBuf>,
+    pub replay: Option<Replay>,
 
     // TODO: TE-447 - remove one_context when integration done
     pub one_context: bool,
@@ -226,6 +234,7 @@ pub fn resolve_storage_init_chain_data(
     patch_context: &Option<PatchContext>,
     one_context: bool,
     context_stats_db_path: &Option<PathBuf>,
+    replay: &Option<Replay>,
     log: &Logger,
 ) -> Result<StorageInitInfo, StorageError> {
     let init_data = StorageInitInfo {
@@ -233,6 +242,7 @@ pub fn resolve_storage_init_chain_data(
         genesis_block_header_hash: tezos_env.genesis_header_hash()?,
         patch_context: patch_context.clone(),
         one_context,
+        replay: replay.clone(),
         context_stats_db_path: context_stats_db_path.clone(),
     };
 

--- a/storage/tests/storage_for_shell.rs
+++ b/storage/tests/storage_for_shell.rs
@@ -71,6 +71,7 @@ fn test_storage() -> Result<(), Error> {
         &None,
         false,
         &None,
+        &None,
         &log,
     );
     assert!(init_data.is_ok());


### PR DESCRIPTION
https://viablesystems.atlassian.net/browse/TE-516

This adds the subcommand `replay` to `light-node` with 4 new arguments `--from-block`, `--to-block`, `--target-path` and `--fail-above`

Usage example:
```sh
cargo run --bin light-node replay --target-path=/tmp/replay --config-file ./light_node/etc/tezedge/tezedge.config --network=edo2net --to-block BMf2TQSuyJrsE7JQjEBj1ztfspoVaFChEmVg6DsUYHxinsEVEeW --one-context --fail-above 1000
```

Note that `--from-block` will not work until the tezedge context supports persistent storage