### PR TITLE
Fix duration of a block

### DIFF
--- a/tezos/new_context/src/timings.rs
+++ b/tezos/new_context/src/timings.rs
@@ -9,14 +9,14 @@ use tezos_api::ocaml_conv::{OCamlBlockHash, OCamlContextHash, OCamlOperationHash
 use tezos_timing::{Action, ActionKind, TimingMessage, TIMING_CHANNEL};
 
 pub fn set_block(rt: &OCamlRuntime, block_hash: OCamlRef<Option<OCamlBlockHash>>) {
+    let instant = Instant::now();
     let block_hash: Option<BlockHash> = block_hash.to_rust(rt);
 
-    let start_at = if block_hash.is_some() {
+    let timestamp = if block_hash.is_some() {
         let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or(Duration::new(0, 0));
-        let instant = Instant::now();
-        Some((timestamp, instant))
+        Some(timestamp)
     } else {
         None
     };
@@ -24,7 +24,8 @@ pub fn set_block(rt: &OCamlRuntime, block_hash: OCamlRef<Option<OCamlBlockHash>>
     TIMING_CHANNEL
         .send(TimingMessage::SetBlock {
             block_hash,
-            start_at,
+            timestamp,
+            instant,
         })
         .unwrap();
 }

--- a/tezos/new_context/src/working_tree/working_tree.rs
+++ b/tezos/new_context/src/working_tree/working_tree.rs
@@ -753,7 +753,7 @@ impl WorkingTree {
         let mut referenced_older_entries: HashSet<EntryHash> = HashSet::new();
         self.get_entries_recursively(
             &entry,
-            &commit_hash,
+            commit_hash,
             Some(root.as_ref()),
             &mut batch,
             &mut referenced_older_entries,
@@ -969,13 +969,13 @@ impl WorkingTree {
     fn get_entries_recursively(
         &self,
         entry: &Entry,
-        entry_hash: &EntryHash,
+        entry_hash: EntryHash,
         root: Option<&Tree>,
         batch: &mut Vec<(EntryHash, ContextValue)>,
         referenced_older_entries: &mut HashSet<EntryHash>,
     ) -> Result<(), MerkleError> {
         // add entry to batch
-        batch.push((entry_hash.clone(), bincode::serialize(entry)?));
+        batch.push((entry_hash, bincode::serialize(entry)?));
 
         match entry {
             Entry::Blob(_) => Ok(()),
@@ -999,7 +999,7 @@ impl WorkingTree {
                             None => Ok(()),
                             Some(entry) => self.get_entries_recursively(
                                 entry,
-                                &child_node.entry_hash.borrow().clone().unwrap(),
+                                child_node.entry_hash()?,
                                 None,
                                 batch,
                                 referenced_older_entries,
@@ -1017,7 +1017,13 @@ impl WorkingTree {
                     Some(root) => Entry::Tree(root.clone()),
                     None => self.get_entry_from_hash(&commit.root_hash)?,
                 };
-                self.get_entries_recursively(&entry, &commit.root_hash, None, batch, referenced_older_entries)
+                self.get_entries_recursively(
+                    &entry,
+                    commit.root_hash,
+                    None,
+                    batch,
+                    referenced_older_entries,
+                )
             }
         }
     }


### PR DESCRIPTION
- Call `Instant::now` at the hook call, not in the timing thread which
might be lagging behind
- Do not recompute hashes for the commit and root of the tree