### PR TITLE
Preserve frame pointer

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4025,6 +4025,21 @@ steps:
     password:
       from_secret: docker_hub_pswd
 
+- name: build-light-node-debug-image
+  image: plugins/docker
+  settings:
+    repo: simplestakingcom/tezedge
+    target: light-node
+    tag: latest-frame-pointers-enabled
+    dockerfile: docker/distroless/Dockerfile
+    build_args:
+      - SOURCE_BRANCH=develop
+      - RUSTFLAGS="-Cforce-frame-pointers=yes"
+    username:
+      from_secret: docker_hub_username
+    password:
+      from_secret: docker_hub_pswd
+
 - name: build-sandbox-image
   image: plugins/docker
   settings:
@@ -4083,6 +4098,23 @@ steps:
       dockerfile: docker/distroless/Dockerfile
       build_args:
         - SOURCE_BRANCH=${DRONE_TAG}
+      username:
+        from_secret: docker_hub_username
+      password:
+        from_secret: docker_hub_pswd
+
+  - name: build-light-node-debug-image
+    image: plugins/docker
+    settings:
+      repo: simplestakingcom/tezedge
+      target: light-node
+      tags:
+        - ${DRONE_TAG}
+        - latest-frame-pointers-enabled-release
+      dockerfile: docker/distroless/Dockerfile
+      build_args:
+        - SOURCE_BRANCH=${DRONE_TAG}
+        - RUSTFLAGS="-Cforce-frame-pointers=yes"
       username:
         from_secret: docker_hub_username
       password:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1924,7 +1924,7 @@ dependencies = [
 [[package]]
 name = "librocksdb-sys"
 version = "6.11.4"
-source = "git+https://github.com/tezedge/rust-rocksdb.git?branch=frame-pointer#8c2439a0edbf5e8448d0d0e64df59edbc7f07683"
+source = "git+https://github.com/tezedge/rust-rocksdb.git?branch=frame-pointer#479fe0851c3332c80fe7514b26be933ca6a82c0d"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.54.0"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c0bb6167449588ff70803f4127f0684f9063097eca5016f37eb52b92c2cf36"
+checksum = "75b13ce559e6433d360c26305643803cb52cfbabbc2b9c47ce04a58493dfb443"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -547,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "0.29.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6837df1d5cba2397b835c8530f51723267e16abbf83892e9e5af4f0e5dd10a"
+checksum = "853eda514c284c2287f4bf20ae614f8781f40a81d32ecda6e91449304dfe077c"
 dependencies = [
  "glob",
  "libc",
@@ -1913,19 +1913,18 @@ checksum = "3286f09f7d4926fc486334f28d8d2e6ebe4f7f9994494b6dab27ddfad2c9b11b"
 
 [[package]]
 name = "libloading"
-version = "0.5.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
+checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
 dependencies = [
- "cc",
+ "cfg-if 1.0.0",
  "winapi",
 ]
 
 [[package]]
 name = "librocksdb-sys"
 version = "6.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b56f651c204634b936be2f92dbb42c36867e00ff7fe2405591f3b9fa66f09"
+source = "git+https://github.com/tezedge/rust-rocksdb.git?branch=frame-pointer#8c2439a0edbf5e8448d0d0e64df59edbc7f07683"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,4 @@ members = [
 
 [patch.crates-io]
 ocaml-boxroot-sys = { git = "https://gitlab.com/bruno.deferrari/ocaml-boxroot.git", branch = "ocaml-410-headers" }
+librocksdb-sys = { git = "https://github.com/tezedge/rust-rocksdb.git", branch = "frame-pointer" }

--- a/apps/deploy_monitoring/docker-compose.deploy.latest-release.yml
+++ b/apps/deploy_monitoring/docker-compose.deploy.latest-release.yml
@@ -31,10 +31,8 @@ services:
       - "11001:11001/udp"  # debugger syslog port for tezos node
 
   tezedge-node:
-    image: simplestakingcom/tezedge:latest-release
+    image: simplestakingcom/tezedge:latest-frame-pointers-enabled-release
     command: ["--network", "${TEZOS_NETWORK}", "--log", "terminal", "file", "--log-file", "/tmp/tezedge/tezedge.log", "--one-context", "--actions-store-backend", "none", "--peer-thresh-low", "30", "--peer-thresh-high", "45"]
-    depends_on:
-      - "tezedge-memprof"
     logging:
       # Produce syslogs instead of terminal logs
       driver: "syslog"

--- a/apps/deploy_monitoring/docker-compose.deploy.latest.yml
+++ b/apps/deploy_monitoring/docker-compose.deploy.latest.yml
@@ -31,10 +31,8 @@ services:
       - "11001:11001/udp"  # debugger syslog port for tezos node
 
   tezedge-node:
-    image: simplestakingcom/tezedge:latest
+    image: simplestakingcom/tezedge:latest-frame-pointers-enabled
     command: ["--network", "${TEZOS_NETWORK}", "--log", "terminal", "file", "--log-file", "/tmp/tezedge/tezedge.log", "--one-context", "--actions-store-backend", "none", "--peer-thresh-low", "30", "--peer-thresh-high", "45"]
-    depends_on:
-      - "tezedge-memprof"
     logging:
       # Produce syslogs instead of terminal logs
       driver: "syslog"

--- a/apps/deploy_monitoring/docker-compose.localhost.yml
+++ b/apps/deploy_monitoring/docker-compose.localhost.yml
@@ -31,10 +31,8 @@ services:
       - "11001:11001/udp"  # debugger syslog port for tezos node
 
   tezedge-node:
-    image: simplestakingcom/tezedge:latest
+    image: simplestakingcom/tezedge:latest-frame-pointers-enabled
     command: ["--network", "${TEZOS_NETWORK}", "--actions-store-backend", "rocksdb", "file", "--log", "terminal", "file", "--log-file", "/tmp/tezedge/tezedge.log"]
-    depends_on:
-      - "tezedge-memprof"
     logging:
       # Produce syslogs instead of terminal logs
       driver: "syslog"

--- a/docker/distroless/Dockerfile
+++ b/docker/distroless/Dockerfile
@@ -12,7 +12,8 @@ ENV PATH=/home/appuser/.cargo/bin:$PATH
 ENV RUST_BACKTRACE=1
 ENV SODIUM_USE_PKG_CONFIG=1
 ENV OCAML_BUILD_CHAIN=remote
-RUN cd /home/appuser && git clone ${tezedge_git} --branch ${SOURCE_BRANCH} && cd tezedge && RUSTFLAGS="-Cforce-frame-pointers=yes" cargo build --release #5
+ARG RUSTFLAGS=""
+RUN cd /home/appuser && git clone ${tezedge_git} --branch ${SOURCE_BRANCH} && cd tezedge && RUSTFLAGS=${RUSTFLAGS} cargo build --release #5
 WORKDIR /home/appuser/tezedge
 RUN mkdir /tmp/tezedge
 RUN mkdir /tmp/tezedge/light-node

--- a/docker/distroless/Dockerfile
+++ b/docker/distroless/Dockerfile
@@ -12,7 +12,7 @@ ENV PATH=/home/appuser/.cargo/bin:$PATH
 ENV RUST_BACKTRACE=1
 ENV SODIUM_USE_PKG_CONFIG=1
 ENV OCAML_BUILD_CHAIN=remote
-RUN cd /home/appuser && git clone ${tezedge_git} --branch ${SOURCE_BRANCH} && cd tezedge && cargo build --release #5
+RUN cd /home/appuser && git clone ${tezedge_git} --branch ${SOURCE_BRANCH} && cd tezedge && RUSTFLAGS="-Cforce-frame-pointers=yes" cargo build --release #5
 WORKDIR /home/appuser/tezedge
 RUN mkdir /tmp/tezedge
 RUN mkdir /tmp/tezedge/light-node


### PR DESCRIPTION
- Patch rocksdb to preserve frame pointers.
- Add flag cargo build in distroless docker image to preserve frame pointers in our code.

