### PR TITLE
Better error handling for timing

### DIFF
--- a/tezos/new_context/src/timings.rs
+++ b/tezos/new_context/src/timings.rs
@@ -21,21 +21,21 @@ pub fn set_block(rt: &OCamlRuntime, block_hash: OCamlRef<Option<OCamlBlockHash>>
         None
     };
 
-    TIMING_CHANNEL
-        .send(TimingMessage::SetBlock {
-            block_hash,
-            timestamp,
-            instant,
-        })
-        .unwrap();
+    if let Err(e) = TIMING_CHANNEL.send(TimingMessage::SetBlock {
+        block_hash,
+        timestamp,
+        instant,
+    }) {
+        eprintln!("Timing set_block hook error = {:?}", e);
+    }
 }
 
 pub fn set_operation(rt: &OCamlRuntime, operation_hash: OCamlRef<Option<OCamlOperationHash>>) {
     let operation_hash: Option<OperationHash> = operation_hash.to_rust(rt);
 
-    TIMING_CHANNEL
-        .send(TimingMessage::SetOperation(operation_hash))
-        .unwrap();
+    if let Err(e) = TIMING_CHANNEL.send(TimingMessage::SetOperation(operation_hash)) {
+        eprintln!("Timing set_operation hook error = {:?}", e);
+    }
 }
 
 pub fn checkout(
@@ -48,13 +48,13 @@ pub fn checkout(
     let irmin_time = get_time(irmin_time);
     let tezedge_time = get_time(tezedge_time);
 
-    TIMING_CHANNEL
-        .send(TimingMessage::Checkout {
-            context_hash,
-            irmin_time,
-            tezedge_time,
-        })
-        .unwrap();
+    if let Err(e) = TIMING_CHANNEL.send(TimingMessage::Checkout {
+        context_hash,
+        irmin_time,
+        tezedge_time,
+    }) {
+        eprintln!("Timing checkout hook error = {:?}", e);
+    }
 }
 
 pub fn commit(
@@ -66,12 +66,12 @@ pub fn commit(
     let irmin_time = get_time(irmin_time);
     let tezedge_time = get_time(tezedge_time);
 
-    TIMING_CHANNEL
-        .send(TimingMessage::Commit {
-            irmin_time,
-            tezedge_time,
-        })
-        .unwrap();
+    if let Err(e) = TIMING_CHANNEL.send(TimingMessage::Commit {
+        irmin_time,
+        tezedge_time,
+    }) {
+        eprintln!("Timing commit hook error = {:?}", e);
+    }
 }
 
 pub fn context_action(
@@ -104,15 +104,17 @@ pub fn context_action(
         tezedge_time,
     };
 
-    TIMING_CHANNEL.send(TimingMessage::Action(action)).unwrap();
+    if let Err(e) = TIMING_CHANNEL.send(TimingMessage::Action(action)) {
+        eprintln!("Timing context_action hook error = {:?}", e);
+    }
 }
 
 pub fn init_timing(db_path: String) {
-    TIMING_CHANNEL
-        .send(TimingMessage::InitTiming {
-            db_path: Some(db_path.into()),
-        })
-        .unwrap();
+    if let Err(e) = TIMING_CHANNEL.send(TimingMessage::InitTiming {
+        db_path: Some(db_path.into()),
+    }) {
+        eprintln!("Timing init_timing hook error = {:?}", e);
+    }
 }
 
 fn get_time(time: f64) -> Option<f64> {

--- a/tezos/timing/src/schema_stats.sql
+++ b/tezos/timing/src/schema_stats.sql
@@ -40,10 +40,10 @@ CREATE TABLE IF NOT EXISTS actions (
   block_id INTEGER DEFAULT NULL,
   operation_id INTEGER DEFAULT NULL,
   context_id INTEGER DEFAULT NULL,
-  FOREIGN KEY(key_id) REFERENCES keys(id),
-  FOREIGN KEY(block_id) REFERENCES blocks(id),
-  FOREIGN KEY(operation_id) REFERENCES operations(id),
-  FOREIGN KEY(context_id) REFERENCES contexts(id)
+  FOREIGN KEY(key_id) REFERENCES keys(id) DEFERRABLE INITIALLY DEFERRED,
+  FOREIGN KEY(block_id) REFERENCES blocks(id) DEFERRABLE INITIALLY DEFERRED,
+  FOREIGN KEY(operation_id) REFERENCES operations(id) DEFERRABLE INITIALLY DEFERRED,
+  FOREIGN KEY(context_id) REFERENCES contexts(id) DEFERRABLE INITIALLY DEFERRED
 );
 
 CREATE TABLE IF NOT EXISTS block_action_stats (
@@ -79,7 +79,7 @@ CREATE TABLE IF NOT EXISTS block_action_stats (
   irmin_remove_time REAL DEFAULT NULL,
 
   block_id INTEGER DEFAULT NULL,
-  FOREIGN KEY(block_id) REFERENCES blocks(id)
+  FOREIGN KEY(block_id) REFERENCES blocks(id) DEFERRABLE INITIALLY DEFERRED
 );
 
 CREATE TABLE IF NOT EXISTS global_action_stats (


### PR DESCRIPTION
https://viablesystems.atlassian.net/browse/TE-527

Remove any `unwrap()` in the timing code.
This will log errors on stderr instead.

This also use a fixed capacity channel from the standard library instead of crossbeam.