### PR TITLE
Make the context backend used by docker-compose runs configurable

### DIFF
--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -19,7 +19,7 @@ services:
 
   tezedge-node:
     image: simplestakingcom/tezedge:latest-release
-    command: ["--network", "${TEZOS_NETWORK-mainnet}", "--p2p-port=9732", "--rpc-port=18732", "--websocket-address=0.0.0.0:4927", "--log", "terminal", "file", "--log-file", "/tmp/tezedge/tezedge.log", "--peer-thresh-low", "30", "--peer-thresh-high", "45"]
+    command: ["--network", "${TEZOS_NETWORK-mainnet}", "--p2p-port=9732", "--rpc-port=18732", "--websocket-address=0.0.0.0:4927", "--log", "terminal", "file", "--log-file", "/tmp/tezedge/tezedge.log", "--peer-thresh-low", "30", "--peer-thresh-high", "45", "--tezos-context-storage=${TEZOS_CONTEXT_STORAGE:-irmin}"]
     logging:
       # Produce syslogs instead of terminal logs
       driver: "syslog"

--- a/docker-compose.latest.yml
+++ b/docker-compose.latest.yml
@@ -4,7 +4,7 @@ services:
 
   node:
     image: simplestakingcom/tezedge:latest
-    command: ["--network=mainnet", "--p2p-port=9732", "--rpc-port=18732", "--websocket-address=0.0.0.0:4927", "--peer-thresh-low", "30", "--peer-thresh-high", "45"]
+    command: ["--network=mainnet", "--p2p-port=9732", "--rpc-port=18732", "--websocket-address=0.0.0.0:4927", "--peer-thresh-low", "30", "--peer-thresh-high", "45", "--tezos-context-storage=${TEZOS_CONTEXT_STORAGE:-irmin}"]
     hostname: node
     ports:
       - "4927:4927"
@@ -18,7 +18,7 @@ services:
     image: simplestakingcom/tezedge-explorer:latest
     hostname: explorer
     environment:
-      API: '[{"id":"localhost","name":"rust.dev.mainnet.localhost","http":"http://localhost:18732", "monitoring":"", "debugger":"", "ws":"ws://localhost:4927", "features":["MONITORING","MEMPOOL_ACTION","STORAGE_BLOCK"]}]'
+      API: '[{"id":"localhost","name":"rust.dev.mainnet.localhost","http":"http://localhost:18732", "monitoring":"", "debugger":"", "ws":"ws://localhost:4927", "features":["MONITORING","MEMPOOL_ACTION","STORAGE_BLOCK","RESOURCES"],"resources":["storage"]}]'
     ports:
       - "80:80"
       - "8080:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   node:
     image: simplestakingcom/tezedge:latest-release
-    command: ["--network=mainnet", "--p2p-port=9732", "--rpc-port=18732", "--websocket-address=0.0.0.0:4927", "--peer-thresh-low", "30", "--peer-thresh-high", "45"]
+    command: ["--network=mainnet", "--p2p-port=9732", "--rpc-port=18732", "--websocket-address=0.0.0.0:4927", "--peer-thresh-low", "30", "--peer-thresh-high", "45", "--tezos-context-storage=${TEZOS_CONTEXT_STORAGE:-irmin}"]
     hostname: node
     ports:
       - "4927:4927"
@@ -18,7 +18,7 @@ services:
     image: simplestakingcom/tezedge-explorer:latest-release
     hostname: explorer
     environment:
-      API: '[{"id":"localhost","name":"rust.dev.mainnet.localhost","http":"http://localhost:18732", "monitoring":"", "debugger":"", "ws":"ws://localhost:4927", "features":["MONITORING","MEMPOOL_ACTION","STORAGE_BLOCK"]}]'
+      API: '[{"id":"localhost","name":"rust.dev.mainnet.localhost","http":"http://localhost:18732", "monitoring":"", "debugger":"", "ws":"ws://localhost:4927", "features":["MONITORING","MEMPOOL_ACTION","STORAGE_BLOCK","RESOURCES"],"resources":["storage"]}]'
     ports:
       - "80:80"
       - "8080:80"


### PR DESCRIPTION
It is set by the TEZOS_CONTEXT_BACKEND environment variable and defaults to Irmin.

Also enables the "resources" tab because it is needed to show the storage stats, even if monitoring is not enabled.