### PR TITLE
Bootstrapping memory consumption test

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5162,7 +5162,6 @@ steps:
   user: root
   commands:
     - git remote add -f upstream https://github.com/tezedge/tezedge.git
-    - apt-get update && apt-get install -y valgrind
     - cd tezos/messages
     - cargo build --message-format json --test decode_stream |  jq --raw-output '.executable // empty' > source.cmd
     - valgrind --tool=exp-dhat --show-top-n=1 $(cat source.cmd) 2>&1 | tee dhat-source.out | sed '/======== ORDERED BY/Q'
@@ -5662,6 +5661,185 @@ depends_on:
   - corr/real-time-environment-cyclictest-latencies
 
 
+---
+##############################################################################################################
+# This pipeline bootstraps a tezedge node to 1000 and measures memory allocation peaks during that
+##############################################################################################################
+kind: pipeline
+name: perf/memory-allocation-bootstrap-009-florence
+
+depends_on:
+  - build-tezedge-binaries
+
+trigger:
+  branches:
+    - master
+    - develop
+
+volumes:
+  - name: identities
+    host:
+      path: /usr/local/etc/tezedge-ci/build/build_${DRONE_BUILD_NUMBER}/build_files/identities
+  - name: snapshots
+    host:
+      path: /usr/local/etc/tezedge-ci/data/
+  - name: tools
+    host:
+      path: /usr/local/etc/tezedge-ci/tools
+  - name: cache
+    host:
+      path: /usr/local/etc/tezedge-ci/data/cache/build_${DRONE_BUILD_NUMBER}/${DRONE_STAGE_NAME}
+
+steps:
+
+  - name: octez-node
+    image: tezos/tezos:v9-release
+    detach: true
+    environment:
+      TEZOS_NODE_DIR: /home/tezos/data
+    volumes:
+      - name: identities
+        path: /identities
+      - name: snapshots
+        path: /snapshots
+    commands:
+      - tezos-node config init --network florencenet
+      - cp /identities/identity_1.json $${TEZOS_NODE_DIR}/identity.json
+      - tezos-node snapshot import /snapshots/octez-009-florence-1000.snapshot --block BKqNZHy5CFYLD6v6BjDLrEavrkK4qH39hhrsD7QtbWcdnnwoYub
+      - tezos-node run --no-bootstrap-peers
+
+  - name: tezedge-new-node
+    image: tezedge/tezedge-ci-builder
+    user: root
+    volumes:
+      - name: identities
+        path: /identities
+      - name: tools
+        path: /tools
+    commands:
+      - OCTEZ_IP=$(perl -e 'use Socket; my $a = gethostbyname("octez-node"); print inet_ntoa($a)')
+      - echo $${OCTEZ_IP}
+      # use alloc instead of jemalloc by commenting out lines between these two
+      - >
+        awk '
+        /extern crate jemallocator;/,/static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;/ { print "//" $0; next }
+        { print }
+        '
+        light_node/src/main.rs > /tmp/main.rs && mv /tmp/main.rs light_node/src/main.rs
+      - cargo build --package light-node --package protocol-runner
+      - export LD_LIBRARY_PATH=tezos/sys/lib_tezos/artifacts/
+      - >
+        valgrind --tool=massif --massif-out-file=new-node.massif.out
+        target/debug/light-node --protocol-runner target/debug/protocol-runner
+        --network florencenet --peers $${OCTEZ_IP}:9732
+        --config-file light_node/etc/tezedge/tezedge_drone.config
+        --identity-file /identities/identity_2.json --rpc-port 18732
+        --peer-thresh-low 1 --peer-thresh-high 1 --synchronization-thresh=0
+        --init-sapling-spend-params-file ./tezos/sys/lib_tezos/artifacts/sapling-spend.params
+        --init-sapling-output-params-file ./tezos/sys/lib_tezos/artifacts/sapling-output.params &
+        echo $! > /var/run/tezedge.pid
+      # this command waits the node to be on level 1000
+      - |
+        sh -c '
+        block=0
+        while [ $block -lt 1000 ]; do
+          sleep 5
+          b=$(curl -s localhost:18732/chains/main/blocks/head | jq .header.level)
+          block=$${b:-$block}
+          echo "===> Block level $block"
+        done
+        '
+      - echo "Bootstrapped. Killind the node and waiting for 10 seconds."
+      # terminate the node gracefully and wait to allow `valgrind` dump data
+      - kill -INT $(cat /var/run/tezedge.pid) && sleep 10
+      # convert `massif` output to human-readable form
+      - ms_print new-node.massif.out > new-node.msp.out
+
+  - name: tezedge-old-node
+    image: tezedge/tezedge-ci-builder
+    user: root
+    volumes:
+      - name: identities
+        path: /identities
+      - name: tools
+        path: /tools
+    commands:
+      - OCTEZ_IP=$(perl -e 'use Socket; my $a = gethostbyname("octez-node"); print inet_ntoa($a)')
+      - git reset --hard origin/${DRONE_TARGET_BRANCH}
+      - rm -rf ./tezos-node-data ./light-node-data
+      # use alloc instead of jemalloc
+      - >
+        awk '
+        /extern crate jemallocator;/,/static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;/ { print "//" $0; next }
+        { print }
+        '
+        light_node/src/main.rs > /tmp/main.rs && mv /tmp/main.rs light_node/src/main.rs
+      - cargo clean && cargo build --package light-node --package protocol-runner
+      - export LD_LIBRARY_PATH=tezos/sys/lib_tezos/artifacts/
+      - >
+        valgrind --tool=massif --massif-out-file=old-node.massif.out
+        target/debug/light-node --protocol-runner target/debug/protocol-runner
+        --network florencenet --peers $${OCTEZ_IP}:9732
+        --config-file light_node/etc/tezedge/tezedge_drone.config
+        --identity-file /identities/identity_2.json --rpc-port 18732
+        --peer-thresh-low 1 --peer-thresh-high 1 --synchronization-thresh=0
+        --init-sapling-spend-params-file ./tezos/sys/lib_tezos/artifacts/sapling-spend.params
+        --init-sapling-output-params-file ./tezos/sys/lib_tezos/artifacts/sapling-output.params &
+        echo $! > /var/run/tezedge.pid
+      - sleep 10
+      # this command waits the node to be on level 1000
+      - |
+        sh -c '
+        block=0
+        while [ $block -lt 1000 ]; do
+          sleep 5
+          b=$(curl -s localhost:18732/chains/main/blocks/head | jq .header.level)
+          block=$${b:-$block}
+          echo "===> Block level $block"
+        done
+        '
+      - echo "Bootstrapped. Killind the node and waiting for 10 seconds."
+      # terminate the node gracefully and wait to allow `valgrind` dump data
+      - kill -INT $(cat /var/run/tezedge.pid) && sleep 10
+      # convert `massif` output to human-readable form
+      - ms_print old-node.massif.out > old-node.msp.out
+    when:
+      ref:
+      - refs/pull/*/head
+
+  - name: report-for-tezedge-new-node
+    image: busybox
+    volumes:
+      - name: tools
+        path: /tools
+      - name: cache
+        path: /cache
+    commands:
+      - cp new-node.msp.out /cache/
+      # parse `ms_print` outputs, compute peaks, print summary
+      - awk -f /tools/massif.awk -v headers="New node" new-node.msp.out
+    when:
+      ref:
+        exclude:
+          - refs/pull/*/head
+
+  - name: report-and-verify-tezedge-new-vs-old-node
+    image: busybox
+    volumes:
+      - name: tools
+        path: /tools
+      - name: cache
+        path: /cache
+    commands:
+      - cp new-node.msp.out old-node.msp.out /cache/
+      # parse `ms_print` outputs, compute peaks, print summary
+      # if the peak from the `new-node` is greater than from the `old-node`
+      # by 10% or more, this test will fail
+      - awk -f /tools/massif.awk -v headers="New node, Old Node" new-node.msp.out old-node.msp.out
+    when:
+      ref:
+      - refs/pull/*/head
+
 ##############################################################################################################
 # This pipeline builds a docker image and pushes it to docker HUB - (latest) from develop branch
 ##############################################################################################################
@@ -5744,6 +5922,7 @@ depends_on:
   - corr/indexer-tzkt-octez-009-florence
   - corr/indexer-tzkt-tezedge-009-florence
   - perf/wrk-tests-009-florence
+  - perf/memory-allocation-bootstrap-009-florence
 
 ##############################################################################################################
 # This pipeline builds a docker image and pushes it to docker HUB - (versioned/tagged) from master/release
@@ -5833,3 +6012,4 @@ depends_on:
   - corr/indexer-tzkt-octez-009-florence
   - corr/indexer-tzkt-tezedge-009-florence
   - perf/wrk-tests-009-florence
+  - perf/memory-allocation-bootstrap-009-florence


### PR DESCRIPTION
The new pipeline does the following:
- Starts Octez node with a 1000-blocks snapshot
- Runs new Tezedge node with `valgrind`'s `massif` tool to measure memory usage peaks, until bootstrapped to 1000 blocks
- Runs old Tezedge node with `massif` tool until bootstrapped to 1000 blocks (if a PR)
- Analyses both reports and prints out peak snapshots for both runs and verifies that max value is increased not more than 10%