### PR TITLE
Print hashes in base58 form instead of array of bytes

### DIFF
--- a/crypto/src/hash.rs
+++ b/crypto/src/hash.rs
@@ -55,7 +55,6 @@ pub enum FromBytesError {
 macro_rules! define_hash {
     ($name:ident) => {
         #[derive(
-            Debug,
             Clone,
             PartialEq,
             Eq,
@@ -95,6 +94,16 @@ macro_rules! define_hash {
                     .unwrap_or_else(|_| {
                         unreachable!("Typed hash should always be representable in base58")
                     })
+            }
+        }
+
+        impl ::std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                // TODO - TE-373: with b58 this could be done without the need
+                // to perform a heap allocation.
+                f.debug_tuple(stringify!($name))
+                    .field(&self.to_base58_check())
+                    .finish()
             }
         }
 


### PR DESCRIPTION
Will print:

```
ProtocolHash("PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb")
```

instead of

```
ProtocolHash([62, 94, 58, 96, 106, 250, 183, 74, 89, 202, 9, 227, 51, 99, 62, 39, 112, 182, 73, 44, 94, 89, 68, 85, 183, 30, 154, 47, 14, 169, 42, 251])
```