### PR TITLE
Add support for custom networks specified by a config file

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -665,24 +665,26 @@ steps:
     - export CARGO_MANIFEST_DIR=$${TEST_ARTIFACTS_PATH}/test_data
     - $${TEST_ARTIFACTS_PATH}/tests/p2p_test --nocapture --ignored test_proof_of_work_fail
 
-- name: replay-test
-  image: tezedge/tezedge-ci-builder:latest
-  user: root
-  pull: if-not-exists
-  volumes:
-    - name: build
-      path: /artifacts
-    - name: tezedge-data-snapshot
-      path: /tezedge-data-snapshot
-  commands:
-    - cp -R /tezedge-data-snapshot /tmp/tezedge-data
-    - rust_libs=$(echo "`rustup show home`/toolchains/`rustup show active-toolchain | tr " " "\n" | head -1`/lib")
-    - export LD_LIBRARY_PATH="$${BUILD_ARTIFACTS_PATH}/build_files/ffi:$rust_libs"
-    # light-node reads the path of `protocol-runner` from the config file, even if provided as argument.
-    # Copy the `protocol-runner` binary to the path specified in the config file.
-    - mkdir -p target/release
-    - cp $${BUILD_ARTIFACTS_PATH}/build_files/protocol-runner target/release/
-    - $${BUILD_ARTIFACTS_PATH}/build_files/light-node replay --target-path=/tmp/replay --config-file "$${BUILD_ARTIFACTS_PATH}/build_files/tezedge/tezedge_drone.config" --network=florencenet --to-block BLJQc17Wxnhw7Mdd5VzFzmiqYfwYpvYUVnMesFKgGWSartAoQAC --tezos-data-dir=/tmp/tezedge-data --identity-file "$${BUILD_ARTIFACTS_PATH}/build_files/identities/identity_6.json" --bootstrap-db-path=bootstrap_db
+# TODO - TE-609: this test is not working right now because it using an outdated snapshot.
+#        Needs to be updated to produce a snapshot on-the-fly by bootstraping the node first.
+# - name: replay-test
+#   image: tezedge/tezedge-ci-builder:latest
+#   user: root
+#   pull: if-not-exists
+#   volumes:
+#     - name: build
+#       path: /artifacts
+#     - name: tezedge-data-snapshot
+#       path: /tezedge-data-snapshot
+#   commands:
+#     - cp -R /tezedge-data-snapshot /tmp/tezedge-data
+#     - rust_libs=$(echo "`rustup show home`/toolchains/`rustup show active-toolchain | tr " " "\n" | head -1`/lib")
+#     - export LD_LIBRARY_PATH="$${BUILD_ARTIFACTS_PATH}/build_files/ffi:$rust_libs"
+#     # light-node reads the path of `protocol-runner` from the config file, even if provided as argument.
+#     # Copy the `protocol-runner` binary to the path specified in the config file.
+#     - mkdir -p target/release
+#     - cp $${BUILD_ARTIFACTS_PATH}/build_files/protocol-runner target/release/
+#     - $${BUILD_ARTIFACTS_PATH}/build_files/light-node replay --target-path=/tmp/replay --config-file "$${BUILD_ARTIFACTS_PATH}/build_files/tezedge/tezedge_drone.config" --network=florencenet --to-block BLJQc17Wxnhw7Mdd5VzFzmiqYfwYpvYUVnMesFKgGWSartAoQAC --tezos-data-dir=/tmp/tezedge-data --identity-file "$${BUILD_ARTIFACTS_PATH}/build_files/identities/identity_6.json" --bootstrap-db-path=bootstrap_db
 
 # TODO - TE-261: we don't have an equivalent of this right now
 # - name: record/replay-context-action-file-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Nothing.
 
+## [1.6.5] - 2021-07-13
+
+### Added
+
+- Add support for custom networks specified by a config file
+- Log configuration on startup
+
+### Fixed
+
+- Storage db compatibility for 19 vs 20 for snapshots
+
 ## [1.6.4] - 2021-07-12
 
 ### Changed
@@ -442,7 +453,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ability to connect and bootstrap data from Tezos Babylonnet.
 - Protocol FFI integration.
 
-[Unreleased]: https://github.com/tezedge/tezedge/compare/v1.6.4...HEAD
+[Unreleased]: https://github.com/tezedge/tezedge/compare/v1.6.5...HEAD
+[1.6.5]: https://github.com/tezedge/tezedge/releases/v1.6.5
 [1.6.4]: https://github.com/tezedge/tezedge/releases/v1.6.4
 [1.6.2]: https://github.com/tezedge/tezedge/releases/v1.6.2
 [1.6.1]: https://github.com/tezedge/tezedge/releases/v1.6.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3942,7 +3942,6 @@ dependencies = [
  "derive_builder",
  "failure",
  "hex",
- "lazy_static",
  "nom 6.1.2",
  "ocaml-interop",
  "serde 1.0.123",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,7 +804,7 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "base58",
  "failure",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "deploy-monitoring"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz_ack_message"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "honggfuzz",
  "log",
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz_advertise_message"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "honggfuzz",
  "log",
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz_block_header_message"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "honggfuzz",
  "log",
@@ -1338,7 +1338,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz_connection_message"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "honggfuzz",
  "log",
@@ -1347,7 +1347,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz_current_branch_message"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "honggfuzz",
  "log",
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz_current_head_message"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "honggfuzz",
  "log",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz_metadata_message"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "honggfuzz",
  "log",
@@ -1374,7 +1374,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz_operation_message"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "honggfuzz",
  "log",
@@ -1383,7 +1383,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz_operations_for_blocks_message"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "honggfuzz",
  "log",
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz_peer_response_message"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "honggfuzz",
  "log",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "fuzz_protocol_message"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "honggfuzz",
  "log",
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "ipc"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "bincode",
  "failure",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "light-node"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "clap",
  "crypto",
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "logging"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "chrono",
  "libflate",
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "monitoring"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "crypto",
  "erased-serde",
@@ -2263,7 +2263,7 @@ dependencies = [
 
 [[package]]
 name = "networking"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "async-std",
  "bytes 1.0.1",
@@ -2813,7 +2813,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-runner"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "clap",
  "crypto",
@@ -3136,7 +3136,7 @@ dependencies = [
 
 [[package]]
 name = "rpc"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "assert-json-diff 2.0.1 (git+https://github.com/tezedge/assert-json-diff.git?tag=v2.0.1-public-diff-module)",
  "bincode",
@@ -3250,7 +3250,7 @@ dependencies = [
 
 [[package]]
 name = "sandbox"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "clap",
  "colored",
@@ -3502,7 +3502,7 @@ dependencies = [
 
 [[package]]
 name = "shell"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "chrono",
  "crypto",
@@ -3745,7 +3745,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "bincode",
  "bytes 1.0.1",
@@ -3921,7 +3921,7 @@ dependencies = [
 
 [[package]]
 name = "tezos-sys"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "colored",
  "fs_extra",
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "tezos_api"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "assert-json-diff 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono",
@@ -3957,7 +3957,7 @@ dependencies = [
 
 [[package]]
 name = "tezos_client"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "assert-json-diff 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto",
@@ -3973,7 +3973,7 @@ dependencies = [
 
 [[package]]
 name = "tezos_encoding"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "bit-vec",
  "byteorder",
@@ -3991,7 +3991,7 @@ dependencies = [
 
 [[package]]
 name = "tezos_encoding_derive"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "lazy_static",
  "parse-display",
@@ -4002,7 +4002,7 @@ dependencies = [
 
 [[package]]
 name = "tezos_identity"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "assert-json-diff 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "tezos_interop"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "criterion",
  "crypto",
@@ -4034,7 +4034,7 @@ dependencies = [
 
 [[package]]
 name = "tezos_messages"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "assert-json-diff 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 1.0.1",
@@ -4061,7 +4061,7 @@ dependencies = [
 
 [[package]]
 name = "tezos_new_context"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "bincode",
  "blake2",
@@ -4094,14 +4094,14 @@ dependencies = [
 
 [[package]]
 name = "tezos_spsc"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "loom",
 ]
 
 [[package]]
 name = "tezos_timing"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "crypto",
  "once_cell",
@@ -4111,7 +4111,7 @@ dependencies = [
 
 [[package]]
 name = "tezos_wrapper"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "crypto",
  "failure",

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ _More about building TezEdge docker images see [here](docker/README.md)._
 #### Run image
 
 ```
-docker run -i -p 9732:9732 -p 18732:18732 -p 4927:4927 -t tezedge/tezedge:v1.6.4 --network=mainnet --p2p-port 9732 --rpc-port 18732 --websocket-address 0.0.0.0:4927
+docker run -i -p 9732:9732 -p 18732:18732 -p 4927:4927 -t tezedge/tezedge:v1.6.5 --network=mainnet --p2p-port 9732 --rpc-port 18732 --websocket-address 0.0.0.0:4927
 ```
 _A full description of all arguments can be found in the light_node [README](light_node/README.md) file._
 

--- a/apps/deploy_monitoring/Cargo.toml
+++ b/apps/deploy_monitoring/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deploy-monitoring"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Adrian Nagy <adrian.nagy@viablesystems.io>"]
 edition = "2018"
 default-run = "deploy-monitoring"

--- a/apps/deploy_monitoring/Cargo.toml
+++ b/apps/deploy_monitoring/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = "1.0"
 shiplift = { git = "https://github.com/tezedge/shiplift.git", branch = "master" }
 slog = { version = "2.5", features = ["nested-values"] }
 slog-async = "2.5"
-slog-term = "2.6"
+slog-term = "2.8"
 sysinfo = "0.16"
 tokio = { version = "1.2", features = ["full"] }
 wait-timeout = "0.2"

--- a/apps/deploy_monitoring/docker-compose.deploy.latest-release.yml
+++ b/apps/deploy_monitoring/docker-compose.deploy.latest-release.yml
@@ -31,7 +31,7 @@ services:
       - "11001:11001/udp"  # debugger syslog port for tezos node
 
   tezedge-node:
-    image: tezedge/tezedge:v1.6.4-frame-pointers-enabled
+    image: tezedge/tezedge:v1.6.5-frame-pointers-enabled
     command: ["--network", "${TEZOS_NETWORK}", "--log", "terminal", "file", "--log-file", "/tmp/tezedge/tezedge.log", "--tezos-context-storage", "irmin", "--peer-thresh-low", "60", "--peer-thresh-high", "80"]
     logging:
       # Produce syslogs instead of terminal logs
@@ -50,7 +50,7 @@ services:
       - "3030:3030"       # sandbox launcher port
 
   tezedge-sandbox:
-    image: tezedge/tezedge:sandbox-v1.6.4
+    image: tezedge/tezedge:sandbox-v1.6.5
     logging:
       # Produce syslogs instead of terminal logs
       driver: "syslog"

--- a/apps/deploy_monitoring/docker-compose.deploy.mainnet.latest-release.yml
+++ b/apps/deploy_monitoring/docker-compose.deploy.mainnet.latest-release.yml
@@ -31,7 +31,7 @@ services:
       - "11001:11001/udp"  # debugger syslog port for tezos node
 
   tezedge-node:
-    image: tezedge/tezedge:v1.6.4-frame-pointers-enabled
+    image: tezedge/tezedge:v1.6.5-frame-pointers-enabled
     command: ["--network", "${TEZOS_NETWORK}", "--log", "terminal", "file", "--log-file", "/tmp/tezedge/tezedge.log", "--tezos-context-storage", "both", "--context-stats-db-path", "context-stats-db", "--peer-thresh-low", "60", "--peer-thresh-high", "80"]
     logging:
       # Produce syslogs instead of terminal logs
@@ -50,7 +50,7 @@ services:
       - "3030:3030"       # sandbox launcher port
 
   tezedge-sandbox:
-    image: tezedge/tezedge:sandbox-v1.6.4
+    image: tezedge/tezedge:sandbox-v1.6.5
     logging:
       # Produce syslogs instead of terminal logs
       driver: "syslog"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2018"
 

--- a/delegates/010-granadanet/docker-compose.node.010-granadanet.yml
+++ b/delegates/010-granadanet/docker-compose.node.010-granadanet.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
 
   tezedge-node:
-    image: tezedge/tezedge:v1.6.4
+    image: tezedge/tezedge:v1.6.5
     command: [
         "--network=granadanet",
         "--p2p-port=12534",

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -18,7 +18,7 @@ services:
       - "10001:10001/udp"  # debugger syslog port for tezedge node
 
   tezedge-node:
-    image: tezedge/tezedge:v1.6.4
+    image: tezedge/tezedge:v1.6.5
     command: ["--network", "${TEZOS_NETWORK-mainnet}", "--p2p-port=9732", "--rpc-port=18732", "--websocket-address=0.0.0.0:4927", "--log", "terminal", "file", "--log-file", "/tmp/tezedge/tezedge.log", "--peer-thresh-low", "30", "--peer-thresh-high", "45", "--tezos-context-storage=${TEZOS_CONTEXT_STORAGE:-irmin}", "--context-stats-db-path", "context-stats-db"]
     logging:
       # Produce syslogs instead of terminal logs

--- a/docker-compose.storage.irmin.yml
+++ b/docker-compose.storage.irmin.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
 
   tezedge-with-irmin-storage:
-    image: tezedge/tezedge:v1.6.4
+    image: tezedge/tezedge:v1.6.5
     command: [ "--network=mainnet", "--p2p-port=4444", "--rpc-port=4445", "--websocket-address=0.0.0.0:4446", "--peer-thresh-low", "30", "--peer-thresh-high", "45", "--tezos-context-storage=irmin", "--context-stats-db-path", "context-stats-db" ]
     hostname: tezedge-with-irmin-storage
     ports:

--- a/docker-compose.storage.memory.yml
+++ b/docker-compose.storage.memory.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
 
   tezedge-with-memory-storage:
-    image: tezedge/tezedge:v1.6.4
+    image: tezedge/tezedge:v1.6.5
     command: [ "--network=mainnet", "--p2p-port=5554", "--rpc-port=5555", "--websocket-address=0.0.0.0:5556", "--peer-thresh-low", "30", "--peer-thresh-high", "45", "--tezos-context-storage=tezedge", "--context-stats-db-path", "context-stats-db" ]
     hostname: tezedge-with-memory-storage
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
 
   node:
-    image: tezedge/tezedge:v1.6.4
+    image: tezedge/tezedge:v1.6.5
     command: ["--network=mainnet", "--p2p-port=9732", "--rpc-port=18732", "--websocket-address=0.0.0.0:4927", "--peer-thresh-low", "30", "--peer-thresh-high", "45", "--tezos-context-storage=${TEZOS_CONTEXT_STORAGE:-irmin}"]
     hostname: node
     ports:

--- a/docker/docker-compose.sandbox.yml
+++ b/docker/docker-compose.sandbox.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
 
   tezedge-sandbox-launcher:
-    image: tezedge/tezedge:sandbox-v1.6.4
+    image: tezedge/tezedge:sandbox-v1.6.5
     command: ["--sandbox-rpc-port=3030"]
     volumes:
       - "tezedge-shared-data:/tmp/tezedge"

--- a/fuzz/ack_message/Cargo.toml
+++ b/fuzz/ack_message/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuzz_ack_message"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2018"
 publish = false

--- a/fuzz/advertise_message/Cargo.toml
+++ b/fuzz/advertise_message/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuzz_advertise_message"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2018"
 publish = false

--- a/fuzz/block_header_message/Cargo.toml
+++ b/fuzz/block_header_message/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuzz_block_header_message"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2018"
 publish = false

--- a/fuzz/connection_message/Cargo.toml
+++ b/fuzz/connection_message/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuzz_connection_message"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2018"
 publish = false

--- a/fuzz/current_branch_message/Cargo.toml
+++ b/fuzz/current_branch_message/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuzz_current_branch_message"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2018"
 publish = false

--- a/fuzz/current_head_message/Cargo.toml
+++ b/fuzz/current_head_message/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuzz_current_head_message"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2018"
 publish = false

--- a/fuzz/encoding/Cargo.toml
+++ b/fuzz/encoding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuzz_encoding"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Martin Lacko <martin.lacko@simplestaking.com>"]
 edition = "2018"
 publish = false

--- a/fuzz/metadata_message/Cargo.toml
+++ b/fuzz/metadata_message/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuzz_metadata_message"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2018"
 publish = false

--- a/fuzz/operation_message/Cargo.toml
+++ b/fuzz/operation_message/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuzz_operation_message"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2018"
 publish = false

--- a/fuzz/operations_for_blocks_message/Cargo.toml
+++ b/fuzz/operations_for_blocks_message/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuzz_operations_for_blocks_message"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2018"
 publish = false

--- a/fuzz/peer_response_message/Cargo.toml
+++ b/fuzz/peer_response_message/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuzz_peer_response_message"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2018"
 publish = false

--- a/fuzz/protocol_message/Cargo.toml
+++ b/fuzz/protocol_message/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuzz_protocol_message"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2018"
 publish = false

--- a/ipc/Cargo.toml
+++ b/ipc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ipc"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2018"
 

--- a/light_node/Cargo.toml
+++ b/light_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "light-node"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2018"
 default-run = "light-node"

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -13,7 +13,7 @@ serde = { version = "1.0", features = ["derive"] }
 slog = { version = "2.7", features = ["max_level_trace", "release_max_level_debug"] }
 slog-json = "2.3"
 slog-async = "2.6"
-slog-term = "2.6"
+slog-term = "2.8"
 
 [dev-dependencies]
 tempfile = "3"

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logging"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2018"
 

--- a/monitoring/Cargo.toml
+++ b/monitoring/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monitoring"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Martin Lacko <martin.lacko@simplestaking.com>"]
 edition = "2018"
 

--- a/networking/Cargo.toml
+++ b/networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "networking"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2018"
 

--- a/protocol_runner/Cargo.toml
+++ b/protocol_runner/Cargo.toml
@@ -12,7 +12,7 @@ failure_derive = "0.1"
 jemallocator = "0.3.2"
 slog = { version = "2.7", features = ["max_level_trace", "release_max_level_debug"] }
 slog-async = "2.6"
-slog-term = "2.6"
+slog-term = "2.8"
 # local dependencies
 crypto = { path = "../crypto" }
 tezos_api = { path = "../tezos/api" }

--- a/protocol_runner/Cargo.toml
+++ b/protocol_runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protocol-runner"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2018"
 

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpc"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Martin Lacko <martin.lacko@simplestaking.com>"]
 edition = "2018"
 build = "build.rs"

--- a/sandbox/Cargo.toml
+++ b/sandbox/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 slog = { version = "2.7", features = ["nested-values", "max_level_trace", "release_max_level_debug"] }
 slog-async = "2.6"
-slog-term = "2.6"
+slog-term = "2.8"
 tokio = { version = "1.2", features = ["full"] }
 warp = "0.3"
 wait-timeout = "0.2"

--- a/sandbox/Cargo.toml
+++ b/sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sandbox"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Adrian Nagy <adrian.nagy@simplestaking.com>"]
 edition = "2018"
 default-run = "sandbox"

--- a/shell/Cargo.toml
+++ b/shell/Cargo.toml
@@ -37,7 +37,7 @@ tezos_wrapper = { path = "../tezos/wrapper" }
 r2d2 = "0.8.9"
 serial_test = "0.5"
 slog-async = "2.6"
-slog-term = "2.6"
+slog-term = "2.8"
 fs_extra = "1.2.0"
 zip = "0.5.5"
 tokio = { version = "1.2", features = ["sync"] }

--- a/shell/Cargo.toml
+++ b/shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shell"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2018"
 

--- a/shell/src/peer_manager.rs
+++ b/shell/src/peer_manager.rs
@@ -630,6 +630,10 @@ impl Actor for PeerManager {
     }
 
     fn post_start(&mut self, ctx: &Context<Self::Msg>) {
+        info!(ctx.system.log(), "Peer manager started";
+                                "peers_threshold" => format!("{:?}", &self.threshold),
+                                "num_of_peers_for_bootstrap_threshold" => self.threshold.num_of_peers_for_bootstrap_threshold());
+
         if let Err(e) = self.discover_peers(&ctx.system.log()) {
             warn!(ctx.system.log(), "Failed to discovery peers on startup"; "reason" => format!("{:?}", e));
         }

--- a/shell/tests/chain_test.rs
+++ b/shell/tests/chain_test.rs
@@ -27,7 +27,7 @@ use shell::peer_manager::P2p;
 use shell::PeerConnectionThreshold;
 use storage::tests_common::TmpStorage;
 use storage::{BlockMetaStorage, BlockMetaStorageReader};
-use tezos_api::environment::{TezosEnvironmentConfiguration, TEZOS_ENV};
+use tezos_api::environment::TezosEnvironmentConfiguration;
 use tezos_identity::Identity;
 use tezos_messages::p2p::binary_message::MessageHash;
 use tezos_messages::p2p::encoding::current_head::CurrentHeadMessage;
@@ -67,7 +67,7 @@ fn test_process_current_branch_on_level3_then_current_head_level4() -> Result<()
     let log = common::create_logger(log_level);
 
     let db = common::test_cases_data::current_branch_on_level_3::init_data(&log);
-    let tezos_env: &TezosEnvironmentConfiguration = TEZOS_ENV
+    let tezos_env: &TezosEnvironmentConfiguration = common::test_cases_data::TEZOS_ENV
         .get(&db.tezos_env)
         .expect("no environment configuration");
 
@@ -145,7 +145,7 @@ fn test_process_bootstrapping_current_branch_on_level3_then_current_heads(
     let log = common::create_logger(log_level);
 
     let db = common::test_cases_data::current_branch_on_level_3::init_data(&log);
-    let tezos_env: &TezosEnvironmentConfiguration = TEZOS_ENV
+    let tezos_env: &TezosEnvironmentConfiguration = common::test_cases_data::TEZOS_ENV
         .get(&db.tezos_env)
         .expect("no environment configuration");
 
@@ -269,7 +269,7 @@ fn test_process_reorg_with_different_current_branches() -> Result<(), failure::E
         let (db, patch_context) = common::test_cases_data::sandbox_branch_1_level3::init_data(&log);
         (db.tezos_env, patch_context)
     };
-    let tezos_env: &TezosEnvironmentConfiguration = TEZOS_ENV
+    let tezos_env: &TezosEnvironmentConfiguration = common::test_cases_data::TEZOS_ENV
         .get(&tezos_env)
         .expect("no environment configuration");
 
@@ -377,7 +377,7 @@ fn test_process_current_heads_to_level3() -> Result<(), failure::Error> {
     let log = common::create_logger(log_level);
 
     let db = common::test_cases_data::dont_serve_current_branch_messages::init_data(&log);
-    let tezos_env: &TezosEnvironmentConfiguration = TEZOS_ENV
+    let tezos_env: &TezosEnvironmentConfiguration = common::test_cases_data::TEZOS_ENV
         .get(&db.tezos_env)
         .expect("no environment configuration");
 
@@ -470,7 +470,7 @@ fn test_process_current_head_with_malformed_blocks_and_check_blacklist(
     let log = common::create_logger(log_level);
 
     let db = common::test_cases_data::current_branch_on_level_3::init_data(&log);
-    let tezos_env: &TezosEnvironmentConfiguration = TEZOS_ENV
+    let tezos_env: &TezosEnvironmentConfiguration = common::test_cases_data::TEZOS_ENV
         .get(&db.tezos_env)
         .expect("no environment configuration");
 
@@ -624,7 +624,7 @@ fn process_bootstrap_level1324_and_mempool_for_level1325(
     let log = common::create_logger(log_level);
 
     let db = common::test_cases_data::current_branch_on_level_1324::init_data(&log);
-    let tezos_env: &TezosEnvironmentConfiguration = TEZOS_ENV
+    let tezos_env: &TezosEnvironmentConfiguration = common::test_cases_data::TEZOS_ENV
         .get(&db.tezos_env)
         .expect("no environment configuration");
 
@@ -854,7 +854,7 @@ fn test_process_bootstrap_level1324_and_generate_action_file() -> Result<(), fai
     let log = common::create_logger(log_level);
 
     let db = common::test_cases_data::current_branch_on_level_1324::init_data(&log);
-    let tezos_env: &TezosEnvironmentConfiguration = TEZOS_ENV
+    let tezos_env: &TezosEnvironmentConfiguration = common::test_cases_data::TEZOS_ENV
         .get(&db.tezos_env)
         .expect("no environment configuration");
 

--- a/shell/tests/common/test_cases_data.rs
+++ b/shell/tests/common/test_cases_data.rs
@@ -3,6 +3,7 @@
 
 //! Predefined data sets as callback functions for test node peer
 
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Once;
 use std::{env, fs};
@@ -10,6 +11,7 @@ use std::{env, fs};
 use lazy_static::lazy_static;
 use slog::{info, Logger};
 
+use tezos_api::environment::{default_networks, TezosEnvironment, TezosEnvironmentConfiguration};
 use tezos_api::ffi::PatchContext;
 use tezos_messages::p2p::encoding::block_header::Level;
 use tezos_messages::p2p::encoding::prelude::{
@@ -24,6 +26,7 @@ lazy_static! {
     pub static ref DB_1326_CARTHAGENET: Db = Db::init_db(
         crate::common::samples::read_data_apply_block_request_until_1326(),
     );
+    pub static ref TEZOS_ENV: HashMap<TezosEnvironment, TezosEnvironmentConfiguration> = default_networks();
 }
 
 fn init_data_db_1326_carthagenet(log: &Logger) -> &'static Db {
@@ -41,9 +44,10 @@ pub mod dont_serve_current_branch_messages {
 
     use tezos_messages::p2p::encoding::prelude::PeerMessageResponse;
 
+    use crate::common::test_data::Db;
+
     // use catcommon::test_cases_data::{full_data, init_data_db_1326_carthagenet};
     use super::*;
-    use crate::common::test_data::Db;
 
     pub fn init_data(log: &Logger) -> &'static Db {
         init_data_db_1326_carthagenet(log)
@@ -61,8 +65,9 @@ pub mod current_branch_on_level_3 {
 
     use tezos_messages::p2p::encoding::prelude::PeerMessageResponse;
 
-    use super::*;
     use crate::common::test_data::Db;
+
+    use super::*;
 
     pub fn init_data(log: &Logger) -> &'static Db {
         init_data_db_1326_carthagenet(log)
@@ -80,8 +85,9 @@ pub mod current_branch_on_level_1324 {
 
     use tezos_messages::p2p::encoding::prelude::PeerMessageResponse;
 
-    use super::*;
     use crate::common::test_data::Db;
+
+    use super::*;
 
     pub fn init_data(log: &Logger) -> &'static Db {
         init_data_db_1326_carthagenet(log)
@@ -177,8 +183,9 @@ pub mod sandbox_branch_2_level4 {
     use tezos_api::ffi::PatchContext;
     use tezos_messages::p2p::encoding::prelude::PeerMessageResponse;
 
-    use super::*;
     use crate::common::test_data::Db;
+
+    use super::*;
 
     lazy_static! {
         pub static ref DB: Db = Db::init_db(crate::common::samples::read_data_zip(

--- a/shell/tests/p2p_test.rs
+++ b/shell/tests/p2p_test.rs
@@ -19,7 +19,7 @@ use networking::ShellCompatibilityVersion;
 use shell::peer_manager::P2p;
 use shell::PeerConnectionThreshold;
 use storage::tests_common::TmpStorage;
-use tezos_api::environment::{TezosEnvironmentConfiguration, TEZOS_ENV};
+use tezos_api::environment::TezosEnvironmentConfiguration;
 
 pub mod common;
 
@@ -78,7 +78,7 @@ fn test_proof_of_work(
             common::test_cases_data::sandbox_branch_1_no_level::init_data(&log);
         (db.tezos_env, patch_context)
     };
-    let tezos_env: &TezosEnvironmentConfiguration = TEZOS_ENV
+    let tezos_env: &TezosEnvironmentConfiguration = common::test_cases_data::TEZOS_ENV
         .get(&tezos_env)
         .expect("no environment configuration");
 
@@ -142,7 +142,7 @@ fn test_peer_threshold() -> Result<(), failure::Error> {
         let (db, patch_context) = common::test_cases_data::sandbox_branch_1_level3::init_data(&log);
         (db.tezos_env, patch_context)
     };
-    let tezos_env: &TezosEnvironmentConfiguration = TEZOS_ENV
+    let tezos_env: &TezosEnvironmentConfiguration = common::test_cases_data::TEZOS_ENV
         .get(&tezos_env)
         .expect("no environment configuration");
 

--- a/shell/tests/protocol_runner_test.rs
+++ b/shell/tests/protocol_runner_test.rs
@@ -12,7 +12,7 @@ use failure::format_err;
 use serial_test::serial;
 use slog::{error, info, o, warn, Level, Logger};
 
-use tezos_api::environment::{TezosEnvironmentConfiguration, TEZOS_ENV};
+use tezos_api::environment::TezosEnvironmentConfiguration;
 use tezos_api::ffi::TezosContextTezEdgeStorageConfiguration;
 use tezos_api::ffi::{
     InitProtocolContextResult, TezosContextIrminStorageConfiguration,
@@ -119,7 +119,7 @@ fn create_endpoint<Runner: ProtocolRunner + 'static>(
     context_db_path: PathBuf,
 ) -> Result<(IpcCmdServer, Runner::Subprocess, String), failure::Error> {
     // environement
-    let tezos_env: &TezosEnvironmentConfiguration = TEZOS_ENV
+    let tezos_env: &TezosEnvironmentConfiguration = test_data::TEZOS_ENV
         .get(&test_data::TEZOS_NETWORK)
         .expect("no environment configuration");
 
@@ -183,7 +183,7 @@ fn test_readonly_protocol_runner_connection_pool() -> Result<(), failure::Error>
     let number_of_endpoints = 3;
 
     // environement
-    let tezos_env: &TezosEnvironmentConfiguration = TEZOS_ENV
+    let tezos_env: &TezosEnvironmentConfiguration = test_data::TEZOS_ENV
         .get(&test_data::TEZOS_NETWORK)
         .expect("no environment configuration");
 
@@ -371,13 +371,22 @@ fn test_readonly_protocol_runner_connection_pool() -> Result<(), failure::Error>
 }
 
 mod test_data {
+    use std::collections::HashMap;
     use std::collections::VecDeque;
 
+    use lazy_static::lazy_static;
     use rand::Rng;
 
-    use tezos_api::environment::TezosEnvironment;
+    use tezos_api::environment::{
+        default_networks, TezosEnvironment, TezosEnvironmentConfiguration,
+    };
 
     pub const TEZOS_NETWORK: TezosEnvironment = TezosEnvironment::Carthagenet;
+
+    lazy_static! {
+        pub static ref TEZOS_ENV: HashMap<TezosEnvironment, TezosEnvironmentConfiguration> =
+            default_networks();
+    }
 
     /// Initialize all to readonly true and one set randomly to as 'write/false'
     pub fn init_flags_readonly(count: i32) -> VecDeque<bool> {

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -27,7 +27,7 @@ tezos_messages = { path = "../tezos/messages" }
 
 # Context actions replayer binary and his dependencies
 clap = "2.33"
-slog-term = "2.6"
+slog-term = "2.8"
 slog-async = "2.6"
 
 [[bench]]

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "storage"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2018"
 

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -550,15 +550,15 @@ pub mod initializer {
         log: &Logger,
     ) -> Result<bool, StorageError> {
         let mut system_info = SystemStorage::new(db);
-        let db_version_ok = match system_info.get_db_version()? {
-            Some(db_version) => db_version == expected_database_version,
+        let (db_version_ok, found_database_version) = match system_info.get_db_version()? {
+            Some(db_version) => (db_version == expected_database_version, db_version),
             None => {
                 system_info.set_db_version(expected_database_version)?;
-                true
+                (true, expected_database_version)
             }
         };
         if !db_version_ok {
-            error!(log, "Incompatible database version found. Please re-sync your node to empty storage - see configuration!");
+            error!(log, "Incompatible database version found (expected {}, found {}). Please re-sync your node to empty storage - see configuration!", expected_database_version, found_database_version);
         }
 
         let tezos_env_main_chain_id = &expected_main_chain.chain_id;

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -551,7 +551,14 @@ pub mod initializer {
     ) -> Result<bool, StorageError> {
         let mut system_info = SystemStorage::new(db);
         let (db_version_ok, found_database_version) = match system_info.get_db_version()? {
-            Some(db_version) => (db_version == expected_database_version, db_version),
+            Some(db_version) => {
+                // TODO: TE-608 - refactor this 19/20 fix
+                match expected_database_version {
+                    19 => (db_version == 19 || db_version == 20, db_version),
+                    20 => (db_version == 19 || db_version == 20, db_version),
+                    _ => (db_version == expected_database_version, db_version),
+                }
+            }
             None => {
                 system_info.set_db_version(expected_database_version)?;
                 (true, expected_database_version)

--- a/tezos/api/Cargo.toml
+++ b/tezos/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tezos_api"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2018"
 

--- a/tezos/api/Cargo.toml
+++ b/tezos/api/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 derive_builder = "0.9"
 failure = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
-lazy_static = "1.4"
 ocaml-interop = { version = "0.8.4", features = ["without-ocamlopt", "caml-state"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/tezos/api/src/environment.rs
+++ b/tezos/api/src/environment.rs
@@ -1,8 +1,10 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::path::PathBuf;
+use std::io;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::sync::RwLock;
 use std::{
     collections::HashMap,
     convert::{TryFrom, TryInto},
@@ -27,9 +29,12 @@ use crypto::{base58::FromBase58CheckError, blake2b::Blake2bError};
 use tezos_messages::p2p::encoding::prelude::{BlockHeader, BlockHeaderBuilder};
 
 use crate::ffi::{GenesisChain, PatchContext, ProtocolOverrides};
+use crate::octez_config::OctezConfig;
 
 lazy_static! {
     pub static ref TEZOS_ENV: HashMap<TezosEnvironment, TezosEnvironmentConfiguration> = init();
+    pub static ref CUSTOM_NETWORK_CONFIGURATION: RwLock<Option<TezosEnvironmentConfiguration>> =
+        RwLock::new(None);
 }
 
 pub const PROTOCOL_HASH_ZERO_BASE58_CHECK: &str =
@@ -43,6 +48,7 @@ pub fn get_empty_operation_list_list_hash() -> Result<OperationListListHash, Fro
 /// Enum representing different Tezos environment.
 #[derive(Serialize, Deserialize, Copy, Clone, Debug, PartialEq, Eq, Hash, EnumIter)]
 pub enum TezosEnvironment {
+    Custom,
     Mainnet,
     Sandbox,
     Zeronet,
@@ -67,6 +73,7 @@ impl TezosEnvironment {
 
     pub fn supported_values(&self) -> Vec<&'static str> {
         match self {
+            TezosEnvironment::Custom => vec!["custom"],
             TezosEnvironment::Mainnet => vec!["mainnet"],
             TezosEnvironment::Sandbox => vec!["sandbox"],
             TezosEnvironment::Zeronet => vec!["zeronet"],
@@ -83,6 +90,7 @@ impl TezosEnvironment {
 
     pub fn check_deprecated_network(&self) -> Option<String> {
         match self {
+            TezosEnvironment::Custom => None,
             TezosEnvironment::Mainnet => None,
             TezosEnvironment::Sandbox => None,
             TezosEnvironment::Zeronet => Some(Self::deprecated_testnet_notice(
@@ -205,6 +213,15 @@ impl FromStr for TezosEnvironment {
 /// Initializes hard-code configuration according to different Tezos git branches (genesis_chain.ml, node_config_file.ml)
 fn init() -> HashMap<TezosEnvironment, TezosEnvironmentConfiguration> {
     let mut env: HashMap<TezosEnvironment, TezosEnvironmentConfiguration> = HashMap::new();
+
+    // Set the custom network settings if available
+    for custom in CUSTOM_NETWORK_CONFIGURATION
+        .read()
+        .expect("Couldn't lock the custom network handle for reading")
+        .iter()
+    {
+        env.insert(TezosEnvironment::Custom, custom.clone());
+    }
 
     env.insert(
         TezosEnvironment::Mainnet,
@@ -533,7 +550,7 @@ pub struct GenesisAdditionalData {
 }
 
 /// Structure holding all environment specific crucial information - according to different Tezos Gitlab branches
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct TezosEnvironmentConfiguration {
     /// Genesis information - see genesis_chain.ml
     pub genesis: GenesisChain,
@@ -550,7 +567,41 @@ pub struct TezosEnvironmentConfiguration {
     pub patch_context_genesis_parameters: Option<PatchContext>,
 }
 
+#[derive(Fail, Debug)]
+pub enum TezosNetworkConfigurationError {
+    #[fail(display = "I/O error: {}", reason)]
+    IoError { reason: io::Error },
+
+    #[fail(display = "JSON config parsing error: {}", reason)]
+    ParseError { reason: serde_json::Error },
+}
+
+impl From<io::Error> for TezosNetworkConfigurationError {
+    fn from(reason: io::Error) -> Self {
+        Self::IoError { reason }
+    }
+}
+
+impl From<serde_json::Error> for TezosNetworkConfigurationError {
+    fn from(reason: serde_json::Error) -> Self {
+        Self::ParseError { reason }
+    }
+}
+
 impl TezosEnvironmentConfiguration {
+    /// Loads a custom network configuration from an octez-formatted configuration file
+    pub fn try_from_config_file<P: AsRef<Path>>(
+        path: P,
+    ) -> Result<Self, TezosNetworkConfigurationError> {
+        let contents = fs::read_to_string(path)?;
+        Self::try_from_json(&contents)
+    }
+
+    fn try_from_json(json: &str) -> Result<Self, TezosNetworkConfigurationError> {
+        let octez_config: OctezConfig = serde_json::from_str(json)?;
+        Ok(octez_config.get_custom_network())
+    }
+
     /// Resolves genesis hash from configuration of GenesisChain.block
     pub fn genesis_header_hash(&self) -> Result<BlockHash, TezosEnvironmentError> {
         BlockHash::from_base58_check(&self.genesis.block).map_err(|e| {
@@ -904,31 +955,80 @@ mod tests {
 
     #[test]
     fn test_parse_bootstrap_addr_port_for_all_environment() {
-        TezosEnvironment::iter().for_each(|net| {
-            let tezos_env: &TezosEnvironmentConfiguration = TEZOS_ENV
-                .get(&net)
-                .unwrap_or_else(|| panic!("no tezos environment configured for: {:?}", &net));
+        TezosEnvironment::iter()
+            .filter(|te| *te != TezosEnvironment::Custom)
+            .for_each(|net| {
+                let tezos_env: &TezosEnvironmentConfiguration = TEZOS_ENV
+                    .get(&net)
+                    .unwrap_or_else(|| panic!("no tezos environment configured for: {:?}", &net));
 
-            tezos_env
-                .bootstrap_lookup_addresses
-                .iter()
-                .for_each(|addr| assert!(parse_bootstrap_addr_port(addr, 1111).is_ok()));
-        });
+                tezos_env
+                    .bootstrap_lookup_addresses
+                    .iter()
+                    .for_each(|addr| assert!(parse_bootstrap_addr_port(addr, 1111).is_ok()));
+            });
     }
 
     #[test]
     fn test_network_version_length() {
-        TezosEnvironment::iter().for_each(|net| {
-            let tezos_env: &TezosEnvironmentConfiguration = TEZOS_ENV
-                .get(&net)
-                .unwrap_or_else(|| panic!("no tezos environment configured for: {:?}", &net));
+        TezosEnvironment::iter()
+            .filter(|te| *te != TezosEnvironment::Custom)
+            .for_each(|net| {
+                let tezos_env: &TezosEnvironmentConfiguration = TEZOS_ENV
+                    .get(&net)
+                    .unwrap_or_else(|| panic!("no tezos environment configured for: {:?}", &net));
 
-            assert!(
-                tezos_env.version.len() <= CHAIN_NAME_MAX_LENGTH,
-                "The chain version {} does not fit into the CHAIN_NAME_MAX_LENGTH value {}",
-                tezos_env.version.len(),
-                CHAIN_NAME_MAX_LENGTH
-            );
-        });
+                assert!(
+                    tezos_env.version.len() <= CHAIN_NAME_MAX_LENGTH,
+                    "The chain version {} does not fit into the CHAIN_NAME_MAX_LENGTH value {}",
+                    tezos_env.version.len(),
+                    CHAIN_NAME_MAX_LENGTH
+                );
+            });
+    }
+
+    #[test]
+    fn test_tezos_environment_configuration_from_custom_network_json() {
+        let json = r#"{
+            "network": {
+                "chain_name": "SANDBOXED_TEZOS",
+                "genesis": {
+                  "block": "BLockGenesisGenesisGenesisGenesisGenesisf79b5d1CoW2",
+                  "protocol": "PtYuensgYBb3G3x1hLLbCmcav8ue8Kyd2khADcL5LsT5R1hcXex",
+                  "timestamp": "2018-06-30T16:07:32Z"
+                },
+                "sandboxed_chain_name": "SANDBOXED_TEZOS",
+                "default_bootstrap_peers": [],
+                "genesis_parameters": {
+                  "values": {
+                    "genesis_pubkey": "edpkuJQjuxBndWiwNRFGndPaJATFVXsiDDyAfE4oHvUtu138w5LYRs"
+                  }
+                }
+            }
+        }"#;
+
+        let tezos_env = TezosEnvironmentConfiguration::try_from_json(json).unwrap();
+        let expected = TezosEnvironmentConfiguration {
+            genesis: GenesisChain {
+                time: "2018-06-30T16:07:32Z".into(),
+                block: "BLockGenesisGenesisGenesisGenesisGenesisf79b5d1CoW2".into(),
+                protocol: "PtYuensgYBb3G3x1hLLbCmcav8ue8Kyd2khADcL5LsT5R1hcXex".into(),
+            },
+            bootstrap_lookup_addresses: vec![],
+            version: "SANDBOXED_TEZOS".into(),
+            protocol_overrides: ProtocolOverrides {
+                user_activated_upgrades: vec![],
+                user_activated_protocol_overrides: vec![],
+            },
+            enable_testchain: false,
+            patch_context_genesis_parameters: Some(PatchContext {
+                key: "sandbox_parameter".into(),
+                json:
+                    r#"{"genesis_pubkey":"edpkuJQjuxBndWiwNRFGndPaJATFVXsiDDyAfE4oHvUtu138w5LYRs"}"#
+                        .into(),
+            }),
+        };
+
+        assert_eq!(tezos_env, expected);
     }
 }

--- a/tezos/api/src/ffi.rs
+++ b/tezos/api/src/ffi.rs
@@ -26,7 +26,7 @@ use crate::ocaml_conv::ffi_error_ids;
 pub type RustBytes = Vec<u8>;
 
 /// Genesis block information structure
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct GenesisChain {
     pub time: String,
     pub block: String,
@@ -34,7 +34,7 @@ pub struct GenesisChain {
 }
 
 /// Voted protocol overrides
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct ProtocolOverrides {
     pub user_activated_upgrades: Vec<(i32, String)>,
     pub user_activated_protocol_overrides: Vec<(String, String)>,
@@ -76,7 +76,7 @@ impl ProtocolOverrides {
 }
 
 /// Patch_context key json
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, PartialEq)]
 pub struct PatchContext {
     pub key: String,
     pub json: String,

--- a/tezos/api/src/lib.rs
+++ b/tezos/api/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod environment;
 pub mod ffi;
 pub mod ocaml_conv;
+mod octez_config;
 
 pub fn force_libtezos_linking() {
     tezos_sys::force_libtezos_linking();

--- a/tezos/api/src/octez_config.rs
+++ b/tezos/api/src/octez_config.rs
@@ -1,0 +1,113 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+use crate::environment::TezosEnvironmentConfiguration;
+use crate::ffi::{GenesisChain, PatchContext, ProtocolOverrides};
+
+#[derive(Deserialize, Debug)]
+pub struct OctezConfig {
+    network: OctezCustomNetwork,
+}
+
+impl OctezConfig {
+    pub fn get_custom_network(&self) -> TezosEnvironmentConfiguration {
+        self.network.clone().into()
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+struct OctezCustomNetwork {
+    pub chain_name: String,
+    pub genesis: OctezGenesisChain,
+    pub sandboxed_chain_name: String,
+    #[serde(default)]
+    pub default_bootstrap_peers: Vec<String>,
+    pub genesis_parameters: Option<OctezGenesisParameters>,
+    #[serde(default)]
+    pub user_activate_upgrades: Vec<UserActivatedProtocolUpgrades>,
+    #[serde(default)]
+    pub user_activate_protocol_overrides: Vec<UserActivatedProtocolOverride>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+struct UserActivatedProtocolOverride {
+    replaced_protocol: String,
+    replacement_protocol: String,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+struct UserActivatedProtocolUpgrades {
+    level: i32,
+    replacement_protocol: String,
+}
+
+impl From<OctezCustomNetwork> for TezosEnvironmentConfiguration {
+    fn from(octez: OctezCustomNetwork) -> Self {
+        Self {
+            genesis: octez.genesis.into(),
+            bootstrap_lookup_addresses: octez.default_bootstrap_peers,
+            version: octez.chain_name,
+            protocol_overrides: ProtocolOverrides {
+                user_activated_upgrades: octez
+                    .user_activate_upgrades
+                    .iter()
+                    .map(|u| (u.level, u.replacement_protocol.clone()))
+                    .collect(),
+                user_activated_protocol_overrides: octez
+                    .user_activate_protocol_overrides
+                    .iter()
+                    .map(|po| {
+                        (
+                            po.replaced_protocol.clone(),
+                            po.replacement_protocol.clone(),
+                        )
+                    })
+                    .collect(),
+            },
+            enable_testchain: false,
+            patch_context_genesis_parameters: octez.genesis_parameters.map(|gp| gp.into()),
+        }
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+struct OctezGenesisChain {
+    pub timestamp: String,
+    pub block: String,
+    pub protocol: String,
+}
+
+impl From<OctezGenesisChain> for GenesisChain {
+    fn from(octez: OctezGenesisChain) -> Self {
+        Self {
+            time: octez.timestamp,
+            block: octez.block,
+            protocol: octez.protocol,
+        }
+    }
+}
+
+fn octez_default_context_key() -> String {
+    "sandbox_parameter".to_owned()
+}
+
+#[derive(Deserialize, Debug, Clone)]
+struct OctezGenesisParameters {
+    #[serde(default = "octez_default_context_key")]
+    context_key: String,
+    #[serde(default)]
+    values: HashMap<String, String>,
+}
+
+impl From<OctezGenesisParameters> for PatchContext {
+    fn from(octez: OctezGenesisParameters) -> Self {
+        Self {
+            key: octez.context_key,
+            json: serde_json::to_string(&octez.values).unwrap(), // TODO - TE-578: remove unwrap
+        }
+    }
+}

--- a/tezos/client/Cargo.toml
+++ b/tezos/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tezos_client"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Branislav Kontur <branislav.kontur@simplestaking.com>"]
 edition = "2018"
 

--- a/tezos/client/benches/bench_apply_first_three_blocks.rs
+++ b/tezos/client/benches/bench_apply_first_three_blocks.rs
@@ -8,7 +8,7 @@ use test::Bencher;
 
 use crypto::hash::ChainId;
 use tezos_api::environment::{
-    get_empty_operation_list_list_hash, TezosEnvironmentConfiguration, TEZOS_ENV,
+    default_networks, get_empty_operation_list_list_hash, TezosEnvironmentConfiguration,
 };
 use tezos_api::ffi::{
     ApplyBlockRequest, InitProtocolContextResult, TezosContextConfiguration,
@@ -138,7 +138,8 @@ fn apply_first_three_blocks(
 }
 
 fn init_test_protocol_context(dir_name: &str) -> (ChainId, BlockHeader, InitProtocolContextResult) {
-    let tezos_env: &TezosEnvironmentConfiguration = TEZOS_ENV
+    let default_networks = default_networks();
+    let tezos_env: &TezosEnvironmentConfiguration = default_networks
         .get(&test_data::TEZOS_NETWORK)
         .expect("no tezos environment configured");
 

--- a/tezos/client/tests/bootstrap_storage_test.rs
+++ b/tezos/client/tests/bootstrap_storage_test.rs
@@ -7,8 +7,8 @@ use serial_test::serial;
 
 use crypto::hash::ChainId;
 use tezos_api::environment::{
-    get_empty_operation_list_list_hash, GenesisAdditionalData, TezosEnvironmentConfiguration,
-    TEZOS_ENV,
+    default_networks, get_empty_operation_list_list_hash, GenesisAdditionalData,
+    TezosEnvironmentConfiguration,
 };
 use tezos_api::ffi::{
     ApplyBlockError, ApplyBlockRequest, BeginApplicationRequest, InitProtocolContextResult,
@@ -40,7 +40,8 @@ fn init_test_protocol_context(
     GenesisAdditionalData,
     InitProtocolContextResult,
 ) {
-    let tezos_env: &TezosEnvironmentConfiguration = TEZOS_ENV
+    let default_networks = default_networks();
+    let tezos_env: &TezosEnvironmentConfiguration = default_networks
         .get(&test_data::TEZOS_NETWORK)
         .expect("no tezos environment configured");
 

--- a/tezos/client/tests/ffi_rpc_router_test.rs
+++ b/tezos/client/tests/ffi_rpc_router_test.rs
@@ -13,7 +13,9 @@ use tezos_api::ffi::{
     TezosContextTezEdgeStorageConfiguration, TezosRuntimeConfiguration,
 };
 use tezos_api::{
-    environment::{get_empty_operation_list_list_hash, TezosEnvironmentConfiguration, TEZOS_ENV},
+    environment::{
+        default_networks, get_empty_operation_list_list_hash, TezosEnvironmentConfiguration,
+    },
     ffi::{
         ProtocolRpcResponse, RpcMethod, TezosContextConfiguration,
         TezosContextIrminStorageConfiguration, TezosContextStorageConfiguration,
@@ -47,7 +49,8 @@ fn init_test_protocol_context(
     ProtocolHash,
     InitProtocolContextResult,
 ) {
-    let tezos_env: &TezosEnvironmentConfiguration = TEZOS_ENV
+    let default_networks = default_networks();
+    let tezos_env: &TezosEnvironmentConfiguration = default_networks
         .get(&test_data::TEZOS_NETWORK)
         .expect("no tezos environment configured");
 

--- a/tezos/client/tests/ffi_tests.rs
+++ b/tezos/client/tests/ffi_tests.rs
@@ -111,7 +111,8 @@ fn prepare_protocol_context(
     tezos_env: &TezosEnvironment,
     commit_genesis: bool,
 ) -> InitProtocolContextResult {
-    let cfg = environment::TEZOS_ENV
+    let default_networks = environment::default_networks();
+    let cfg = default_networks
         .get(tezos_env)
         .expect("no tezos environment configured");
 

--- a/tezos/client/tests/init_storage_tests.rs
+++ b/tezos/client/tests/init_storage_tests.rs
@@ -6,7 +6,7 @@ use std::{collections::HashSet, convert::TryFrom};
 use strum::IntoEnumIterator;
 
 use crypto::hash::{ContextHash, ProtocolHash};
-use tezos_api::environment::{TezosEnvironment, TezosEnvironmentConfiguration, TEZOS_ENV};
+use tezos_api::environment::{default_networks, TezosEnvironment, TezosEnvironmentConfiguration};
 use tezos_api::ffi::{
     PatchContext, TezosContextConfiguration, TezosContextIrminStorageConfiguration,
     TezosContextStorageConfiguration, TezosContextTezEdgeStorageConfiguration,
@@ -17,7 +17,7 @@ use tezos_client::client;
 mod common;
 
 #[test]
-fn test_init_empty_context_for_all_enviroment_nets() {
+fn test_init_empty_context_for_all_enviroment_expect_custom_nets() {
     // init runtime and turn on/off ocaml logging
     client::change_runtime_configuration(TezosRuntimeConfiguration {
         debug_mode: false,
@@ -33,13 +33,14 @@ fn test_init_empty_context_for_all_enviroment_nets() {
     let mut protocol_hashes: HashSet<ProtocolHash> = HashSet::new();
 
     // run init storage for all nets
+    let default_networks = default_networks();
     let mut environment_counter = 0;
     TezosEnvironment::iter()
         .filter(|te| *te != TezosEnvironment::Custom)
         .for_each(|net| {
             environment_counter += 1;
 
-            let tezos_env: &TezosEnvironmentConfiguration = TEZOS_ENV
+            let tezos_env: &TezosEnvironmentConfiguration = default_networks
                 .get(&net)
                 .unwrap_or_else(|| panic!("no tezos environment configured for: {:?}", &net));
 
@@ -88,6 +89,83 @@ fn test_init_empty_context_for_all_enviroment_nets() {
 }
 
 #[test]
+fn test_init_empty_context_for_custom_network() {
+    // init runtime and turn on/off ocaml logging
+    client::change_runtime_configuration(TezosRuntimeConfiguration {
+        debug_mode: false,
+        compute_context_action_tree_hashes: false,
+        log_enabled: common::is_ocaml_log_enabled(),
+    })
+    .unwrap();
+
+    // prepare data
+    let storage_data_dir = "init_storage_tests_04";
+
+    let mut genesis_commit_hashes: Vec<ContextHash> = Vec::new();
+    let mut protocol_hashes: HashSet<ProtocolHash> = HashSet::new();
+
+    // run init storage for all nets
+    let custom_network_json = r#"{
+            "network": {
+                "chain_name": "SANDBOXED_TEZOS",
+                "genesis": {
+                  "block": "BLockGenesisGenesisGenesisGenesisGenesisf79b5d1CoW2",
+                  "protocol": "PtYuensgYBb3G3x1hLLbCmcav8ue8Kyd2khADcL5LsT5R1hcXex",
+                  "timestamp": "2018-06-30T16:07:32Z"
+                },
+                "sandboxed_chain_name": "SANDBOXED_TEZOS",
+                "default_bootstrap_peers": [],
+                "genesis_parameters": {
+                  "values": {
+                    "genesis_pubkey": "edpkuJQjuxBndWiwNRFGndPaJATFVXsiDDyAfE4oHvUtu138w5LYRs"
+                  }
+                }
+            }
+        }"#;
+
+    let net = TezosEnvironment::Custom;
+    let tezos_env = TezosEnvironmentConfiguration::try_from_json(custom_network_json).unwrap();
+
+    let storage = TezosContextStorageConfiguration::Both(
+        TezosContextIrminStorageConfiguration {
+            data_dir: common::prepare_empty_dir(storage_data_dir),
+        },
+        TezosContextTezEdgeStorageConfiguration {
+            backend: tezos_api::ffi::ContextKvStoreConfiguration::InMem,
+            ipc_socket_path: None,
+        },
+    );
+    let context_config = TezosContextConfiguration {
+        storage,
+        genesis: tezos_env.genesis.clone(),
+        protocol_overrides: tezos_env.protocol_overrides.clone(),
+        commit_genesis: true,
+        enable_testchain: false,
+        readonly: false,
+        sandbox_json_patch_context: None,
+        context_stats_db_path: None,
+    };
+
+    match client::init_protocol_context(context_config) {
+        Err(e) => panic!(
+            "Failed to initialize storage for: {:?}, Reason: {:?}",
+            net, e
+        ),
+        Ok(init_info) => {
+            if let Some(commit_hash) = &init_info.genesis_commit_hash {
+                genesis_commit_hashes.push(commit_hash.clone());
+            }
+            init_info
+                .supported_protocol_hashes
+                .iter()
+                .for_each(|protocol_hash| {
+                    protocol_hashes.insert(protocol_hash.clone());
+                });
+        }
+    }
+}
+
+#[test]
 fn test_init_empty_context_for_sandbox_with_patch_json() -> Result<(), failure::Error> {
     // init runtime and turn on/off ocaml logging
     client::change_runtime_configuration(TezosRuntimeConfiguration {
@@ -102,7 +180,8 @@ fn test_init_empty_context_for_sandbox_with_patch_json() -> Result<(), failure::
 
     // run init storage for all nets
     let net = TezosEnvironment::Sandbox;
-    let tezos_env: &TezosEnvironmentConfiguration = TEZOS_ENV
+    let default_networks = default_networks();
+    let tezos_env: &TezosEnvironmentConfiguration = default_networks
         .get(&net)
         .unwrap_or_else(|| panic!("no tezos environment configured for: {:?}", &net));
 
@@ -168,7 +247,8 @@ fn test_init_empty_context_for_sandbox_without_patch_json() -> Result<(), failur
 
     // run init storage for all nets
     let net = TezosEnvironment::Sandbox;
-    let tezos_env: &TezosEnvironmentConfiguration = TEZOS_ENV
+    let default_networks = default_networks();
+    let tezos_env: &TezosEnvironmentConfiguration = default_networks
         .get(&net)
         .unwrap_or_else(|| panic!("no tezos environment configured for: {:?}", &net));
 

--- a/tezos/client/tests/prevalidator_mempool_test.rs
+++ b/tezos/client/tests/prevalidator_mempool_test.rs
@@ -5,7 +5,7 @@ use serial_test::serial;
 
 use crypto::hash::{ChainId, ProtocolHash};
 use tezos_api::environment::{
-    get_empty_operation_list_list_hash, TezosEnvironmentConfiguration, TEZOS_ENV,
+    default_networks, get_empty_operation_list_list_hash, TezosEnvironmentConfiguration,
 };
 use tezos_api::ffi::{
     ApplyBlockRequest, BeginConstructionRequest, InitProtocolContextResult,
@@ -37,7 +37,8 @@ fn init_test_protocol_context(
     ProtocolHash,
     InitProtocolContextResult,
 ) {
-    let tezos_env: &TezosEnvironmentConfiguration = TEZOS_ENV
+    let default_networks = default_networks();
+    let tezos_env: &TezosEnvironmentConfiguration = default_networks
         .get(&test_data::TEZOS_NETWORK)
         .expect("no tezos environment configured");
 

--- a/tezos/encoding-derive/Cargo.toml
+++ b/tezos/encoding-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tezos_encoding_derive"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Alexander Koptelov <alexandre.koptelov@simplestaking.com>"]
 edition = "2018"
 

--- a/tezos/encoding/Cargo.toml
+++ b/tezos/encoding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tezos_encoding"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2018"
 

--- a/tezos/identity/Cargo.toml
+++ b/tezos/identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tezos_identity"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Branislav Kontur <branislav.kontur@simplestaking.com>"]
 edition = "2018"
 

--- a/tezos/interop/Cargo.toml
+++ b/tezos/interop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tezos_interop"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2018"
 

--- a/tezos/messages/Cargo.toml
+++ b/tezos/messages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tezos_messages"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2018"
 

--- a/tezos/new_context/Cargo.toml
+++ b/tezos/new_context/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tezos_new_context"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Branislav Kontur <branislav.kontur@simplestaking.com>"]
 edition = "2018"
 

--- a/tezos/spsc/Cargo.toml
+++ b/tezos/spsc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tezos_spsc"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Sebastien Chapuis <sebastien@chapu.is>"]
 edition = "2018"
 

--- a/tezos/sys/Cargo.toml
+++ b/tezos/sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tezos-sys"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Bruno Deferrari <bruno.deferrari@simplestaking.com>"]
 edition = "2018"
 links = "tezos"

--- a/tezos/sys/lib_tezos/libtezos-ffi-distribution-summary.json
+++ b/tezos/sys/lib_tezos/libtezos-ffi-distribution-summary.json
@@ -1,482 +1,542 @@
 [
   {
-    "id": 271399,
+    "id": 273771,
     "name": "libtezos-ffi-centos8.so.gz",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/f6729fd961b7bd26e883c914825f8809/libtezos-ffi-centos8.so.gz",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/f6729fd961b7bd26e883c914825f8809/libtezos-ffi-centos8.so.gz",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/4ab0b7331d6125f3015136a8879e4e8a/libtezos-ffi-centos8.so.gz",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/4ab0b7331d6125f3015136a8879e4e8a/libtezos-ffi-centos8.so.gz",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271400,
+    "id": 273772,
     "name": "libtezos-ffi-centos8.so.gz.sha256",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/f005b47bd50a1aeeef9b24bbd52dadb1/libtezos-ffi-centos8.so.gz.sha256",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/f005b47bd50a1aeeef9b24bbd52dadb1/libtezos-ffi-centos8.so.gz.sha256",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/f9556138ab5fba102c39b81955d61ec4/libtezos-ffi-centos8.so.gz.sha256",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/f9556138ab5fba102c39b81955d61ec4/libtezos-ffi-centos8.so.gz.sha256",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271387,
+    "id": 273759,
     "name": "libtezos-ffi-debian10.so.gz",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/4c28269846362dff5eefad3e6b384afc/libtezos-ffi-debian10.so.gz",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/4c28269846362dff5eefad3e6b384afc/libtezos-ffi-debian10.so.gz",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/555dc4c780bee6229ec3f7ff0e4288f6/libtezos-ffi-debian10.so.gz",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/555dc4c780bee6229ec3f7ff0e4288f6/libtezos-ffi-debian10.so.gz",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271388,
+    "id": 273760,
     "name": "libtezos-ffi-debian10.so.gz.sha256",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/26abf2b710a7e627f4196f89a596ee69/libtezos-ffi-debian10.so.gz.sha256",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/26abf2b710a7e627f4196f89a596ee69/libtezos-ffi-debian10.so.gz.sha256",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/898a5c58e4d438bee37ca98e8a794c9d/libtezos-ffi-debian10.so.gz.sha256",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/898a5c58e4d438bee37ca98e8a794c9d/libtezos-ffi-debian10.so.gz.sha256",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271381,
+    "id": 273753,
     "name": "libtezos-ffi-debian9.so.gz",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/3139eb239aeaad334625f4b6c0a2fd2d/libtezos-ffi-debian9.so.gz",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/3139eb239aeaad334625f4b6c0a2fd2d/libtezos-ffi-debian9.so.gz",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/0868a12592f5321585a8ab14f4547270/libtezos-ffi-debian9.so.gz",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/0868a12592f5321585a8ab14f4547270/libtezos-ffi-debian9.so.gz",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271382,
+    "id": 273754,
     "name": "libtezos-ffi-debian9.so.gz.sha256",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/69facdbfa28ead2c496f95db768aefe1/libtezos-ffi-debian9.so.gz.sha256",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/69facdbfa28ead2c496f95db768aefe1/libtezos-ffi-debian9.so.gz.sha256",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/76c2bc2803d5bc92f08645260845deeb/libtezos-ffi-debian9.so.gz.sha256",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/76c2bc2803d5bc92f08645260845deeb/libtezos-ffi-debian9.so.gz.sha256",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271361,
+    "id": 273733,
     "name": "libtezos-ffi-headers.tar.gz",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/9b9e5218f7f3390df500585b99c78e51/libtezos-ffi-headers.tar.gz",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/9b9e5218f7f3390df500585b99c78e51/libtezos-ffi-headers.tar.gz",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/080ca69057c57fa7f81d4df41563e219/libtezos-ffi-headers.tar.gz",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/080ca69057c57fa7f81d4df41563e219/libtezos-ffi-headers.tar.gz",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271362,
+    "id": 273734,
     "name": "libtezos-ffi-headers.tar.gz.sha256",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/ed138e0f3a467b7ab3e5f378ce32891c/libtezos-ffi-headers.tar.gz.sha256",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/ed138e0f3a467b7ab3e5f378ce32891c/libtezos-ffi-headers.tar.gz.sha256",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/d9fc2b93d3635a3e5649c79b6f48e6bc/libtezos-ffi-headers.tar.gz.sha256",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/d9fc2b93d3635a3e5649c79b6f48e6bc/libtezos-ffi-headers.tar.gz.sha256",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271407,
+    "id": 273777,
     "name": "libtezos-ffi-macos.dylib.gz",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/5e20690ad1d96dd08335cd3e4b4f1d87/libtezos-ffi-macos.dylib.gz",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/5e20690ad1d96dd08335cd3e4b4f1d87/libtezos-ffi-macos.dylib.gz",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/510c9dfbc2538052f63013794ecd163e/libtezos-ffi-macos.dylib.gz",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/510c9dfbc2538052f63013794ecd163e/libtezos-ffi-macos.dylib.gz",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271408,
+    "id": 273778,
     "name": "libtezos-ffi-macos.dylib.gz.sha256",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/df3b41ab879e6301197fe2919ee511ea/libtezos-ffi-macos.dylib.gz.sha256",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/df3b41ab879e6301197fe2919ee511ea/libtezos-ffi-macos.dylib.gz.sha256",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/a51ff915470cfab580dc00633f9bbb16/libtezos-ffi-macos.dylib.gz.sha256",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/a51ff915470cfab580dc00633f9bbb16/libtezos-ffi-macos.dylib.gz.sha256",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271393,
+    "id": 273765,
     "name": "libtezos-ffi-opensuse15.1.so.gz",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/be0ed93066a6a8c7c7d820416dd9845a/libtezos-ffi-opensuse15.1.so.gz",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/be0ed93066a6a8c7c7d820416dd9845a/libtezos-ffi-opensuse15.1.so.gz",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/5fdedc74e7bdfdd3d30f862c8c0aa8c4/libtezos-ffi-opensuse15.1.so.gz",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/5fdedc74e7bdfdd3d30f862c8c0aa8c4/libtezos-ffi-opensuse15.1.so.gz",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271394,
+    "id": 273766,
     "name": "libtezos-ffi-opensuse15.1.so.gz.sha256",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/acfde7834b3b898dfdefc9a64ecacdca/libtezos-ffi-opensuse15.1.so.gz.sha256",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/acfde7834b3b898dfdefc9a64ecacdca/libtezos-ffi-opensuse15.1.so.gz.sha256",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/cc711ad104d647099fd8cdb428e95961/libtezos-ffi-opensuse15.1.so.gz.sha256",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/cc711ad104d647099fd8cdb428e95961/libtezos-ffi-opensuse15.1.so.gz.sha256",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271355,
+    "id": 273727,
     "name": "libtezos-ffi-ubuntu16.so.gz",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/ada1a1e17d4ba28985b7ddeca4d0cd91/libtezos-ffi-ubuntu16.so.gz",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/ada1a1e17d4ba28985b7ddeca4d0cd91/libtezos-ffi-ubuntu16.so.gz",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/0519faa667ac69791e022df0bf7e7028/libtezos-ffi-ubuntu16.so.gz",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/0519faa667ac69791e022df0bf7e7028/libtezos-ffi-ubuntu16.so.gz",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271356,
+    "id": 273728,
     "name": "libtezos-ffi-ubuntu16.so.gz.sha256",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/4483cf620596565c8b3557f6d5824a7d/libtezos-ffi-ubuntu16.so.gz.sha256",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/4483cf620596565c8b3557f6d5824a7d/libtezos-ffi-ubuntu16.so.gz.sha256",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/aa7ce38fad5a7fa08ad52519d0bc9aaa/libtezos-ffi-ubuntu16.so.gz.sha256",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/aa7ce38fad5a7fa08ad52519d0bc9aaa/libtezos-ffi-ubuntu16.so.gz.sha256",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271363,
+    "id": 273735,
     "name": "libtezos-ffi-ubuntu18.so.gz",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/79873520ad49509871adcde0226c2739/libtezos-ffi-ubuntu18.so.gz",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/79873520ad49509871adcde0226c2739/libtezos-ffi-ubuntu18.so.gz",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/0fdbbe3fcf7cde99389292f817a9bb92/libtezos-ffi-ubuntu18.so.gz",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/0fdbbe3fcf7cde99389292f817a9bb92/libtezos-ffi-ubuntu18.so.gz",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271364,
+    "id": 273736,
     "name": "libtezos-ffi-ubuntu18.so.gz.sha256",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/41bf3934234a64464ceed405c08fb7a0/libtezos-ffi-ubuntu18.so.gz.sha256",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/41bf3934234a64464ceed405c08fb7a0/libtezos-ffi-ubuntu18.so.gz.sha256",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/21c951634513197d56ed6ae24efa1b71/libtezos-ffi-ubuntu18.so.gz.sha256",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/21c951634513197d56ed6ae24efa1b71/libtezos-ffi-ubuntu18.so.gz.sha256",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271369,
+    "id": 273741,
     "name": "libtezos-ffi-ubuntu19.so.gz",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/274ba06cb9622424b0364c116c4061a2/libtezos-ffi-ubuntu19.so.gz",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/274ba06cb9622424b0364c116c4061a2/libtezos-ffi-ubuntu19.so.gz",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/c73ce96fa6d935499e80cf0c19711c3b/libtezos-ffi-ubuntu19.so.gz",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/c73ce96fa6d935499e80cf0c19711c3b/libtezos-ffi-ubuntu19.so.gz",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271370,
+    "id": 273742,
     "name": "libtezos-ffi-ubuntu19.so.gz.sha256",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/86f2c0b936921459901ca153e21e9c35/libtezos-ffi-ubuntu19.so.gz.sha256",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/86f2c0b936921459901ca153e21e9c35/libtezos-ffi-ubuntu19.so.gz.sha256",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/c4cd489b6fa965b03694bef8bf731f3b/libtezos-ffi-ubuntu19.so.gz.sha256",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/c4cd489b6fa965b03694bef8bf731f3b/libtezos-ffi-ubuntu19.so.gz.sha256",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271375,
+    "id": 273747,
     "name": "libtezos-ffi-ubuntu20.so.gz",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/97682a7a267b5c884c9b825942d67701/libtezos-ffi-ubuntu20.so.gz",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/97682a7a267b5c884c9b825942d67701/libtezos-ffi-ubuntu20.so.gz",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/2b44d7abe1ac107602332f6792abc070/libtezos-ffi-ubuntu20.so.gz",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/2b44d7abe1ac107602332f6792abc070/libtezos-ffi-ubuntu20.so.gz",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271376,
+    "id": 273748,
     "name": "libtezos-ffi-ubuntu20.so.gz.sha256",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/ce02b855c6bf351f375cc97b2373b0ac/libtezos-ffi-ubuntu20.so.gz.sha256",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/ce02b855c6bf351f375cc97b2373b0ac/libtezos-ffi-ubuntu20.so.gz.sha256",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/df331a6a418708af142a1f9d11ea63e2/libtezos-ffi-ubuntu20.so.gz.sha256",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/df331a6a418708af142a1f9d11ea63e2/libtezos-ffi-ubuntu20.so.gz.sha256",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271353,
+    "id": 273725,
     "name": "sapling-output.params",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/ac3242db84b13999100e6827a1da1679/sapling-output.params",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/ac3242db84b13999100e6827a1da1679/sapling-output.params",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/5958325e33b6b0f1f87aa5746a659249/sapling-output.params",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/5958325e33b6b0f1f87aa5746a659249/sapling-output.params",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271354,
+    "id": 273726,
     "name": "sapling-output.params.sha256",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/334babaf8f2b055a1df59a98c5fd6690/sapling-output.params.sha256",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/334babaf8f2b055a1df59a98c5fd6690/sapling-output.params.sha256",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/8b6033cf9faeef8ab2fa369f4cc3c92f/sapling-output.params.sha256",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/8b6033cf9faeef8ab2fa369f4cc3c92f/sapling-output.params.sha256",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271351,
+    "id": 273723,
     "name": "sapling-spend.params",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/ab08743be9dc4246892bcf6a64555d5a/sapling-spend.params",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/ab08743be9dc4246892bcf6a64555d5a/sapling-spend.params",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/e1f037b4b30d1a8362ecf967aa31b39d/sapling-spend.params",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/e1f037b4b30d1a8362ecf967aa31b39d/sapling-spend.params",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271352,
+    "id": 273724,
     "name": "sapling-spend.params.sha256",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/36446da75500f8851406eb272e63ade7/sapling-spend.params.sha256",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/36446da75500f8851406eb272e63ade7/sapling-spend.params.sha256",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/5c83af2f897acdf59b272a9a3a0bf022/sapling-spend.params.sha256",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/5c83af2f897acdf59b272a9a3a0bf022/sapling-spend.params.sha256",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271405,
+    "id": 273775,
     "name": "tezos-admin-client-centos8.gz",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/6adc324bb41d07b4fc6ddacffd37351b/tezos-admin-client-centos8.gz",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/6adc324bb41d07b4fc6ddacffd37351b/tezos-admin-client-centos8.gz",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/b4c08a4581e596157c15ff4627418fb5/tezos-admin-client-centos8.gz",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/b4c08a4581e596157c15ff4627418fb5/tezos-admin-client-centos8.gz",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271406,
+    "id": 273776,
     "name": "tezos-admin-client-centos8.gz.sha256",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/e77d173263a87509143bbe9d631d8f2e/tezos-admin-client-centos8.gz.sha256",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/e77d173263a87509143bbe9d631d8f2e/tezos-admin-client-centos8.gz.sha256",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/bc91687d2a6f15a30fc2a972c6527af6/tezos-admin-client-centos8.gz.sha256",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/bc91687d2a6f15a30fc2a972c6527af6/tezos-admin-client-centos8.gz.sha256",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271391,
+    "id": 273763,
     "name": "tezos-admin-client-debian10.gz",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/f42213db12a951cf5de58577bfb187e9/tezos-admin-client-debian10.gz",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/f42213db12a951cf5de58577bfb187e9/tezos-admin-client-debian10.gz",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/e88ab2d2f3f46e412f0ba8559e85d8a7/tezos-admin-client-debian10.gz",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/e88ab2d2f3f46e412f0ba8559e85d8a7/tezos-admin-client-debian10.gz",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271392,
+    "id": 273764,
     "name": "tezos-admin-client-debian10.gz.sha256",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/f29fb0453ed097e02bf2710faa99c2a3/tezos-admin-client-debian10.gz.sha256",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/f29fb0453ed097e02bf2710faa99c2a3/tezos-admin-client-debian10.gz.sha256",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/bddcd03dd8c21fc1406d3352b56ffbcd/tezos-admin-client-debian10.gz.sha256",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/bddcd03dd8c21fc1406d3352b56ffbcd/tezos-admin-client-debian10.gz.sha256",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271385,
+    "id": 273757,
     "name": "tezos-admin-client-debian9.gz",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/4cd767b4d6f1f068fe4b0a97ffc2b2c4/tezos-admin-client-debian9.gz",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/4cd767b4d6f1f068fe4b0a97ffc2b2c4/tezos-admin-client-debian9.gz",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/3147f3e48a76e77989fa844d2dc37801/tezos-admin-client-debian9.gz",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/3147f3e48a76e77989fa844d2dc37801/tezos-admin-client-debian9.gz",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271386,
+    "id": 273758,
     "name": "tezos-admin-client-debian9.gz.sha256",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/97889142d71d9fa502bc90ebd99e8aae/tezos-admin-client-debian9.gz.sha256",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/97889142d71d9fa502bc90ebd99e8aae/tezos-admin-client-debian9.gz.sha256",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/0b13aef33c9cb759342a7680f2362d71/tezos-admin-client-debian9.gz.sha256",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/0b13aef33c9cb759342a7680f2362d71/tezos-admin-client-debian9.gz.sha256",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271411,
+    "id": 273781,
     "name": "tezos-admin-client-macos.gz",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/d0ae2114894b207be5c393f9de9afe3e/tezos-admin-client-macos.gz",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/d0ae2114894b207be5c393f9de9afe3e/tezos-admin-client-macos.gz",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/8069560b9a77ecd12157699c4ff2bd21/tezos-admin-client-macos.gz",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/8069560b9a77ecd12157699c4ff2bd21/tezos-admin-client-macos.gz",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271412,
+    "id": 273782,
     "name": "tezos-admin-client-macos.gz.sha256",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/d0fbe0788121f9fcfe1daa90a14cb89a/tezos-admin-client-macos.gz.sha256",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/d0fbe0788121f9fcfe1daa90a14cb89a/tezos-admin-client-macos.gz.sha256",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/dfc64dd2b15ec0285ff795096fd1f912/tezos-admin-client-macos.gz.sha256",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/dfc64dd2b15ec0285ff795096fd1f912/tezos-admin-client-macos.gz.sha256",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271397,
+    "id": 273769,
     "name": "tezos-admin-client-opensuse15.1.gz",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/a41d4345fb141f0409fbf52dca25bcf2/tezos-admin-client-opensuse15.1.gz",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/a41d4345fb141f0409fbf52dca25bcf2/tezos-admin-client-opensuse15.1.gz",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/2b60268af1cafa2fb0fc6c4de1f18b7e/tezos-admin-client-opensuse15.1.gz",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/2b60268af1cafa2fb0fc6c4de1f18b7e/tezos-admin-client-opensuse15.1.gz",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271398,
+    "id": 273770,
     "name": "tezos-admin-client-opensuse15.1.gz.sha256",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/86c2189d03833706e33a7b4814e6a711/tezos-admin-client-opensuse15.1.gz.sha256",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/86c2189d03833706e33a7b4814e6a711/tezos-admin-client-opensuse15.1.gz.sha256",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/8a230758449c9e5e2ba74ddb5bfdaff8/tezos-admin-client-opensuse15.1.gz.sha256",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/8a230758449c9e5e2ba74ddb5bfdaff8/tezos-admin-client-opensuse15.1.gz.sha256",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271359,
+    "id": 273731,
     "name": "tezos-admin-client-ubuntu16.gz",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/2295570030bc00589977deafc7dfda71/tezos-admin-client-ubuntu16.gz",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/2295570030bc00589977deafc7dfda71/tezos-admin-client-ubuntu16.gz",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/887d15c9a8e9477c667c407c185c8718/tezos-admin-client-ubuntu16.gz",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/887d15c9a8e9477c667c407c185c8718/tezos-admin-client-ubuntu16.gz",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271360,
+    "id": 273732,
     "name": "tezos-admin-client-ubuntu16.gz.sha256",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/a2edcd8da9968b915cffda5f9c6327ce/tezos-admin-client-ubuntu16.gz.sha256",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/a2edcd8da9968b915cffda5f9c6327ce/tezos-admin-client-ubuntu16.gz.sha256",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/4d93e4eef29ad851fc1c99a04510770b/tezos-admin-client-ubuntu16.gz.sha256",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/4d93e4eef29ad851fc1c99a04510770b/tezos-admin-client-ubuntu16.gz.sha256",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271367,
+    "id": 273739,
     "name": "tezos-admin-client-ubuntu18.gz",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/d4a40c6afd9f4162fca863933da16ea6/tezos-admin-client-ubuntu18.gz",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/d4a40c6afd9f4162fca863933da16ea6/tezos-admin-client-ubuntu18.gz",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/0402e33864ae758e7ec6d3342ee31ff6/tezos-admin-client-ubuntu18.gz",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/0402e33864ae758e7ec6d3342ee31ff6/tezos-admin-client-ubuntu18.gz",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271368,
+    "id": 273740,
     "name": "tezos-admin-client-ubuntu18.gz.sha256",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/59f3c88dc6e02e0c2ff3fe90be2b4574/tezos-admin-client-ubuntu18.gz.sha256",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/59f3c88dc6e02e0c2ff3fe90be2b4574/tezos-admin-client-ubuntu18.gz.sha256",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/2b68898c998bfedad0580eb903a3ee57/tezos-admin-client-ubuntu18.gz.sha256",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/2b68898c998bfedad0580eb903a3ee57/tezos-admin-client-ubuntu18.gz.sha256",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271373,
+    "id": 273745,
     "name": "tezos-admin-client-ubuntu19.gz",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/036288a439766533441957459c54e52c/tezos-admin-client-ubuntu19.gz",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/036288a439766533441957459c54e52c/tezos-admin-client-ubuntu19.gz",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/60e51613754bd0acdbbe7d266a5f88bf/tezos-admin-client-ubuntu19.gz",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/60e51613754bd0acdbbe7d266a5f88bf/tezos-admin-client-ubuntu19.gz",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271374,
+    "id": 273746,
     "name": "tezos-admin-client-ubuntu19.gz.sha256",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/429a01dd621345df0513ea06ef7a0d92/tezos-admin-client-ubuntu19.gz.sha256",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/429a01dd621345df0513ea06ef7a0d92/tezos-admin-client-ubuntu19.gz.sha256",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/1652bae5465eb571d070430c64082073/tezos-admin-client-ubuntu19.gz.sha256",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/1652bae5465eb571d070430c64082073/tezos-admin-client-ubuntu19.gz.sha256",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271379,
+    "id": 273751,
     "name": "tezos-admin-client-ubuntu20.gz",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/55f18258af2fa4cd6bd348e7a98ddcc7/tezos-admin-client-ubuntu20.gz",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/55f18258af2fa4cd6bd348e7a98ddcc7/tezos-admin-client-ubuntu20.gz",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/a4738581eb515c2af4934348103618ef/tezos-admin-client-ubuntu20.gz",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/a4738581eb515c2af4934348103618ef/tezos-admin-client-ubuntu20.gz",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271380,
+    "id": 273752,
     "name": "tezos-admin-client-ubuntu20.gz.sha256",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/04497bb891cd217e4669024f94df4355/tezos-admin-client-ubuntu20.gz.sha256",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/04497bb891cd217e4669024f94df4355/tezos-admin-client-ubuntu20.gz.sha256",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/659b41fae0ae08034596952ebc1557a8/tezos-admin-client-ubuntu20.gz.sha256",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/659b41fae0ae08034596952ebc1557a8/tezos-admin-client-ubuntu20.gz.sha256",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271403,
+    "id": 273773,
     "name": "tezos-client-centos8.gz",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/61e5ff1650419161be9c99dc09adbb64/tezos-client-centos8.gz",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/61e5ff1650419161be9c99dc09adbb64/tezos-client-centos8.gz",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/5d50dea92f2a83bbcf342fe7a846732d/tezos-client-centos8.gz",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/5d50dea92f2a83bbcf342fe7a846732d/tezos-client-centos8.gz",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271404,
+    "id": 273774,
     "name": "tezos-client-centos8.gz.sha256",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/0256eb36156570e0450d8e791edee56e/tezos-client-centos8.gz.sha256",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/0256eb36156570e0450d8e791edee56e/tezos-client-centos8.gz.sha256",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/d151a233f58f533b4e462adade236143/tezos-client-centos8.gz.sha256",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/d151a233f58f533b4e462adade236143/tezos-client-centos8.gz.sha256",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271389,
+    "id": 273761,
     "name": "tezos-client-debian10.gz",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/04989e25c8e3e073cdfebf9661e61586/tezos-client-debian10.gz",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/04989e25c8e3e073cdfebf9661e61586/tezos-client-debian10.gz",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/d360c66a4e40a8cd834d320f776daeda/tezos-client-debian10.gz",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/d360c66a4e40a8cd834d320f776daeda/tezos-client-debian10.gz",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271390,
+    "id": 273762,
     "name": "tezos-client-debian10.gz.sha256",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/543c6ccdd2308ec6b38226d7478569a6/tezos-client-debian10.gz.sha256",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/543c6ccdd2308ec6b38226d7478569a6/tezos-client-debian10.gz.sha256",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/34018646cf68e87500b85b0d55445953/tezos-client-debian10.gz.sha256",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/34018646cf68e87500b85b0d55445953/tezos-client-debian10.gz.sha256",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271383,
+    "id": 273755,
     "name": "tezos-client-debian9.gz",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/9661ebd47bd4ffd13c88dbbb2d6fa421/tezos-client-debian9.gz",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/9661ebd47bd4ffd13c88dbbb2d6fa421/tezos-client-debian9.gz",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/14a3957e3d81ed4eab31efbe4b31814c/tezos-client-debian9.gz",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/14a3957e3d81ed4eab31efbe4b31814c/tezos-client-debian9.gz",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271384,
+    "id": 273756,
     "name": "tezos-client-debian9.gz.sha256",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/7078bbb73c08434ed78a9a9a8f8e3ffb/tezos-client-debian9.gz.sha256",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/7078bbb73c08434ed78a9a9a8f8e3ffb/tezos-client-debian9.gz.sha256",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/b6086daf20ff5b69f879b5b3c65548fd/tezos-client-debian9.gz.sha256",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/b6086daf20ff5b69f879b5b3c65548fd/tezos-client-debian9.gz.sha256",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271409,
+    "id": 273779,
     "name": "tezos-client-macos.gz",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/29244cb93ef48f63b3e4155ea5757121/tezos-client-macos.gz",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/29244cb93ef48f63b3e4155ea5757121/tezos-client-macos.gz",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/48b200fc716690ccbe0f478c3fcf707a/tezos-client-macos.gz",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/48b200fc716690ccbe0f478c3fcf707a/tezos-client-macos.gz",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271410,
+    "id": 273780,
     "name": "tezos-client-macos.gz.sha256",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/d022853ec874f86868efa7a3175340fe/tezos-client-macos.gz.sha256",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/d022853ec874f86868efa7a3175340fe/tezos-client-macos.gz.sha256",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/c63d126e528ed925560d98d3e36bbbdb/tezos-client-macos.gz.sha256",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/c63d126e528ed925560d98d3e36bbbdb/tezos-client-macos.gz.sha256",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271395,
+    "id": 273767,
     "name": "tezos-client-opensuse15.1.gz",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/2572efe9db9fb3c7b84f9f1436d1c3d2/tezos-client-opensuse15.1.gz",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/2572efe9db9fb3c7b84f9f1436d1c3d2/tezos-client-opensuse15.1.gz",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/4a30e0ecdfb43f74d83cc7a1ad832523/tezos-client-opensuse15.1.gz",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/4a30e0ecdfb43f74d83cc7a1ad832523/tezos-client-opensuse15.1.gz",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271396,
+    "id": 273768,
     "name": "tezos-client-opensuse15.1.gz.sha256",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/c484ed5c9842961f390937a9464f53b2/tezos-client-opensuse15.1.gz.sha256",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/c484ed5c9842961f390937a9464f53b2/tezos-client-opensuse15.1.gz.sha256",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/cebd03cb8ff7ec3d931c4f435742abf1/tezos-client-opensuse15.1.gz.sha256",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/cebd03cb8ff7ec3d931c4f435742abf1/tezos-client-opensuse15.1.gz.sha256",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271357,
+    "id": 273729,
     "name": "tezos-client-ubuntu16.gz",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/4c42488dbec3f1c4ea05605cc249ed79/tezos-client-ubuntu16.gz",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/4c42488dbec3f1c4ea05605cc249ed79/tezos-client-ubuntu16.gz",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/9ef52131db2dbf7d81bcfe646aa29730/tezos-client-ubuntu16.gz",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/9ef52131db2dbf7d81bcfe646aa29730/tezos-client-ubuntu16.gz",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271358,
+    "id": 273730,
     "name": "tezos-client-ubuntu16.gz.sha256",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/40acdd3b11e42f085339f1a53750e10d/tezos-client-ubuntu16.gz.sha256",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/40acdd3b11e42f085339f1a53750e10d/tezos-client-ubuntu16.gz.sha256",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/759b2897813d0499774aef30d841fc57/tezos-client-ubuntu16.gz.sha256",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/759b2897813d0499774aef30d841fc57/tezos-client-ubuntu16.gz.sha256",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271365,
+    "id": 273737,
     "name": "tezos-client-ubuntu18.gz",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/141761ab2dc8b9cb123175f7279981b6/tezos-client-ubuntu18.gz",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/141761ab2dc8b9cb123175f7279981b6/tezos-client-ubuntu18.gz",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/361e10a9f6e24b38c84704b74cbae081/tezos-client-ubuntu18.gz",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/361e10a9f6e24b38c84704b74cbae081/tezos-client-ubuntu18.gz",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271366,
+    "id": 273738,
     "name": "tezos-client-ubuntu18.gz.sha256",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/b11a2b399dc592ea2c867a1ea4501590/tezos-client-ubuntu18.gz.sha256",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/b11a2b399dc592ea2c867a1ea4501590/tezos-client-ubuntu18.gz.sha256",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/85736a9ab8103eed00a14758b4a73d3c/tezos-client-ubuntu18.gz.sha256",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/85736a9ab8103eed00a14758b4a73d3c/tezos-client-ubuntu18.gz.sha256",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271371,
+    "id": 273743,
     "name": "tezos-client-ubuntu19.gz",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/87ffe1b88ac4f8927bc95152b4e304bf/tezos-client-ubuntu19.gz",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/87ffe1b88ac4f8927bc95152b4e304bf/tezos-client-ubuntu19.gz",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/df3b54f5657a1bb03ec399fb65722411/tezos-client-ubuntu19.gz",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/df3b54f5657a1bb03ec399fb65722411/tezos-client-ubuntu19.gz",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271372,
+    "id": 273744,
     "name": "tezos-client-ubuntu19.gz.sha256",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/3abc54677db23124f915c86cd7f96820/tezos-client-ubuntu19.gz.sha256",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/3abc54677db23124f915c86cd7f96820/tezos-client-ubuntu19.gz.sha256",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/6539cf76ecd23190862b902fd90e5e61/tezos-client-ubuntu19.gz.sha256",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/6539cf76ecd23190862b902fd90e5e61/tezos-client-ubuntu19.gz.sha256",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271377,
+    "id": 273749,
     "name": "tezos-client-ubuntu20.gz",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/89027fb3ba5c5258f4b24d05b1790c66/tezos-client-ubuntu20.gz",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/89027fb3ba5c5258f4b24d05b1790c66/tezos-client-ubuntu20.gz",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/1592bcaf20bc3e9d610cdd860988fd13/tezos-client-ubuntu20.gz",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/1592bcaf20bc3e9d610cdd860988fd13/tezos-client-ubuntu20.gz",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   },
   {
-    "id": 271378,
+    "id": 273750,
     "name": "tezos-client-ubuntu20.gz.sha256",
-    "url": "https://gitlab.com/tezedge/tezos/uploads/7022a1f95ae63266db7708f4659648cf/tezos-client-ubuntu20.gz.sha256",
-    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/7022a1f95ae63266db7708f4659648cf/tezos-client-ubuntu20.gz.sha256",
+    "url": "https://gitlab.com/tezedge/tezos/uploads/e24b7cbfe0d401f418b9282893ee9e9d/tezos-client-ubuntu20.gz.sha256",
+    "direct_asset_url": "https://gitlab.com/tezedge/tezos/uploads/e24b7cbfe0d401f418b9282893ee9e9d/tezos-client-ubuntu20.gz.sha256",
     "external": false,
-    "link_type": "other"
+    "link_type": "other",
+    "git_tag": "v1.6.10-v9.3"
   }
 ]

--- a/tezos/timing/Cargo.toml
+++ b/tezos/timing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tezos_timing"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Sebastien Chapuis <sebastien@chapu.is>"]
 edition = "2018"
 

--- a/tezos/wrapper/Cargo.toml
+++ b/tezos/wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tezos_wrapper"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Solves #655

Adds new `custom` network, and `--custom-network-file=custom-network.json` command line flag that is required when `--network=custom` is used.

The json file follows the same format as Octez's config file, but only the "network" key is used.

The contents of that file are used to initialize an environment for `TezosEnvironment::Custom`, which is then filled in when initializing `TEZOS_ENV` (quite hacky, any better idea of how to handle this?).