### PR TITLE
Log protocol runners stdout/stderr output

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -478,7 +478,7 @@ steps:
   commands:
     - export LD_LIBRARY_PATH=$${BUILD_ARTIFACTS_PATH}/build_files/ffi && echo $${LD_LIBRARY_PATH}
     - export PROTOCOL_RUNNER=$${BUILD_ARTIFACTS_PATH}/build_files/protocol-runner && echo $${PROTOCOL_RUNNER}
-    - $${TEST_ARTIFACTS_PATH}/tests/protocol_runner_test --nocapture --ignored test_mutliple_protocol_runners_with_one_write_multiple_read_init_context
+    - $${TEST_ARTIFACTS_PATH}/tests/protocol_runner_test --nocapture --ignored test_multiple_protocol_runners_with_one_write_multiple_read_init_context
 
 # GIVEN a set pool of protocol runners WHEN we try to acquire one or more protocol-runners from the pool THEN the pool handles each
 # scenario accordingly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4208,9 +4208,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.2.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
+checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
 dependencies = [
  "autocfg",
  "bytes 1.0.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4130,7 +4130,7 @@ dependencies = [
  "tezos_api",
  "tezos_messages",
  "tezos_new_context",
- "wait-timeout",
+ "tokio",
 ]
 
 [[package]]

--- a/apps/deploy_monitoring/Cargo.toml
+++ b/apps/deploy_monitoring/Cargo.toml
@@ -25,7 +25,7 @@ slog = { version = "2.5", features = ["nested-values"] }
 slog-async = "2.5"
 slog-term = "2.6"
 sysinfo = "0.16"
-tokio = { version = "1.2", features = ["full"] }
+tokio = { version = "1.8", features = ["full"] }
 wait-timeout = "0.2"
 warp = "0.3"
 # TODO: TE-499 remove shell dependency, and move stats/memory somewhere

--- a/light_node/Cargo.toml
+++ b/light_node/Cargo.toml
@@ -16,7 +16,7 @@ rlimit = "0.5"
 serde_json = "1.0"
 slog = { version = "2.7", features = ["max_level_trace", "release_max_level_debug"] }
 strum = "0.20"
-tokio = { version = "1.2", features = ["rt-multi-thread", "signal"] }
+tokio = { version = "1.8", features = ["rt-multi-thread", "signal"] }
 # Local dependencies
 crypto = { path = "../crypto" }
 logging = { path = "../logging" }

--- a/monitoring/Cargo.toml
+++ b/monitoring/Cargo.toml
@@ -16,7 +16,7 @@ crypto = { path = "../crypto" }
 networking = { path = "../networking" }
 shell = { path = "../shell" }
 tezos_messages = { path = "../tezos/messages" }
-tokio = { version = "1.2", features = ["full"] }
+tokio = { version = "1.8", features = ["full"] }
 tokio-stream = "0.1.2"
 futures = { version = "0.3", default-features = false }
 warp = "0.3"

--- a/networking/Cargo.toml
+++ b/networking/Cargo.toml
@@ -11,7 +11,7 @@ futures = "0.3"
 hex = "0.4"
 riker = "0.4"
 slog = { version = "2.7", features = ["max_level_trace", "release_max_level_debug"] }
-tokio = { version = "1.2", features = ["time", "net", "io-util", "rt-multi-thread"] }
+tokio = { version = "1.8", features = ["time", "net", "io-util", "rt-multi-thread"] }
 # local dependencies
 crypto = { path = "../crypto" }
 tezos_encoding = { path = "../tezos/encoding" }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -18,7 +18,7 @@ riker = "0.4"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 slog = { version = "2.7", features = ["nested-values", "max_level_trace", "release_max_level_debug"] }
-tokio = { version = "1.2", features = ["time"] }
+tokio = { version = "1.8", features = ["time"] }
 url = "2.2"
 rusqlite = "0.25.1"
 cached = "0.23"
@@ -40,4 +40,4 @@ strum_macros = "0.20"
 lazy_static = "1.4"
 rand = "0.7.3"
 hyper = { version = "0.14", features = ["client"] }
-tokio = { version = "1.2", features = ["macros"] }
+tokio = { version = "1.8", features = ["macros"] }

--- a/sandbox/Cargo.toml
+++ b/sandbox/Cargo.toml
@@ -16,7 +16,7 @@ serde_json = "1.0"
 slog = { version = "2.7", features = ["nested-values", "max_level_trace", "release_max_level_debug"] }
 slog-async = "2.6"
 slog-term = "2.6"
-tokio = { version = "1.2", features = ["full"] }
+tokio = { version = "1.8", features = ["full"] }
 warp = "0.3"
 wait-timeout = "0.2"
 # local dependencies

--- a/shell/Cargo.toml
+++ b/shell/Cargo.toml
@@ -22,7 +22,7 @@ riker = "0.4"
 slog = { version = "2.7", features = ["max_level_trace", "release_max_level_debug"] }
 serde = "1.0"
 serde_json = "1.0"
-tokio = { version = "1.2", features = ["time"] }
+tokio = { version = "1.8", features = ["time"] }
 # local dependencies
 crypto = { path = "../crypto" }
 networking = { path = "../networking" }
@@ -40,7 +40,7 @@ slog-async = "2.6"
 slog-term = "2.6"
 fs_extra = "1.2.0"
 zip = "0.5.5"
-tokio = { version = "1.2", features = ["sync"] }
+tokio = { version = "1.8", features = ["sync"] }
 nom = "6.1"
 tezos_encoding = { path = "../tezos/encoding" }
 # TODO: TE-224 - this is not used directly, but test which using PROTOCOL_RUNNER fails without that (tezos_interop can be also replaced with tezos_client, and still works)

--- a/shell/tests/common/infra.rs
+++ b/shell/tests/common/infra.rs
@@ -117,6 +117,8 @@ impl NodeInfrastructure {
         )
         .expect("Failed to resolve init storage chain data");
 
+        let tokio_runtime = create_tokio_runtime();
+
         // create pool for ffi protocol runner connections (used just for readonly context)
         let tezos_readonly_api_pool = Arc::new(TezosApiConnectionPool::new_with_readonly_context(
             String::from(&format!("{}_readonly_runner_pool", name)),
@@ -139,6 +141,7 @@ impl NodeInfrastructure {
                 &common::protocol_runner_executable_path(),
                 log_level,
             ),
+            tokio_runtime.handle().clone(),
             log.clone(),
         )?);
 
@@ -164,6 +167,7 @@ impl NodeInfrastructure {
                 &common::protocol_runner_executable_path(),
                 log_level,
             ),
+            tokio_runtime.handle().clone(),
             log.clone(),
         )?);
 
@@ -173,7 +177,6 @@ impl NodeInfrastructure {
         let bootstrap_state = init_synchronization_bootstrap_state_storage(
             p2p_threshold.num_of_peers_for_bootstrap_threshold(),
         );
-        let tokio_runtime = create_tokio_runtime();
 
         // run actor's
         let actor_system = SystemBuilder::new()
@@ -432,7 +435,7 @@ impl Drop for NodeInfrastructure {
     }
 }
 
-fn create_tokio_runtime() -> tokio::runtime::Runtime {
+pub fn create_tokio_runtime() -> tokio::runtime::Runtime {
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()

--- a/tezos/wrapper/Cargo.toml
+++ b/tezos/wrapper/Cargo.toml
@@ -15,7 +15,7 @@ r2d2 = "0.8.9"
 serde = { version = "1.0", features = ["derive"] }
 slog = { version = "2.7", features = ["max_level_trace", "release_max_level_debug"] }
 strum_macros = "0.20"
-wait-timeout = "0.2"
+tokio = { version = "1.8", features = ["full"] }
 # local dependencies
 ipc = { path = "../../ipc" }
 crypto = { path = "../../crypto" }

--- a/tezos/wrapper/src/lib.rs
+++ b/tezos/wrapper/src/lib.rs
@@ -79,12 +79,14 @@ impl TezosApiConnectionPool {
         pool_name: String,
         pool_cfg: TezosApiConnectionPoolConfiguration,
         endpoint_cfg: ProtocolEndpointConfiguration,
+        tokio_runtime: tokio::runtime::Handle,
         log: Logger,
     ) -> Result<TezosApiConnectionPool, TezosApiConnectionPoolError> {
         Self::new(
             pool_name,
             pool_cfg,
             endpoint_cfg,
+            tokio_runtime,
             log,
             Box::new(InitReadonlyContextProtocolRunnerConnectionCustomizer),
         )
@@ -96,12 +98,14 @@ impl TezosApiConnectionPool {
         pool_name: String,
         pool_cfg: TezosApiConnectionPoolConfiguration,
         endpoint_cfg: ProtocolEndpointConfiguration,
+        tokio_runtime: tokio::runtime::Handle,
         log: Logger,
     ) -> Result<TezosApiConnectionPool, TezosApiConnectionPoolError> {
         Self::new(
             pool_name,
             pool_cfg,
             endpoint_cfg,
+            tokio_runtime,
             log,
             Box::new(NoopProtocolRunnerConnectionCustomizer),
         )
@@ -111,6 +115,7 @@ impl TezosApiConnectionPool {
         pool_name: String,
         pool_cfg: TezosApiConnectionPoolConfiguration,
         endpoint_cfg: ProtocolEndpointConfiguration,
+        tokio_runtime: tokio::runtime::Handle,
         log: Logger,
         initializer: Box<dyn CustomizeConnection<ProtocolRunnerConnection<RunnerType>, PoolError>>,
     ) -> Result<TezosApiConnectionPool, TezosApiConnectionPoolError> {
@@ -119,6 +124,7 @@ impl TezosApiConnectionPool {
             pool_name.clone(),
             pool_cfg.connection_timeout,
             endpoint_cfg,
+            tokio_runtime,
             log.clone(),
         );
 

--- a/tezos/wrapper/src/runner.rs
+++ b/tezos/wrapper/src/runner.rs
@@ -3,15 +3,18 @@
 
 use std::io;
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command};
+use std::process::Stdio;
 use std::time::Duration;
+
+use tokio::io::AsyncBufReadExt;
+use tokio::io::BufReader;
+use tokio::process::{Child, Command};
 
 use failure::Fail;
 use nix::sys::signal;
 use nix::sys::signal::Signal;
 use nix::unistd::Pid;
-use slog::Level;
-use wait_timeout::ChildExt;
+use slog::{info, warn, Level, Logger};
 
 use crate::ProtocolEndpointConfiguration;
 
@@ -47,28 +50,75 @@ pub struct ExecutableProtocolRunner {
     sock_cmd_path: PathBuf,
     executable_path: PathBuf,
     endpoint_name: String,
+    tokio_runtime: tokio::runtime::Handle,
     log_level: Level,
 }
 
 impl ExecutableProtocolRunner {
     /// Send SIGINT signal to the sub-process, which is cheking for this ctrl-c signal and shuts down gracefully if recieved
-    fn terminate_or_kill(process: &mut Child, reason: String) -> Result<(), ProtocolRunnerError> {
+    async fn terminate_or_kill(
+        process: &mut Child,
+        reason: String,
+    ) -> Result<(), ProtocolRunnerError> {
         // try to send SIGINT (ctrl-c)
-        match signal::kill(Pid::from_raw(process.id() as i32), Signal::SIGINT) {
-            Ok(_) => Ok(()),
-            Err(sigint_error) => {
-                // (fallback) if SIGINT failed, we just kill process
-                match process.kill() {
-                    Ok(_) => Ok(()),
-                    Err(kill_error) => Err(ProtocolRunnerError::TerminateError {
-                        reason: format!(
-                            "Reason for termination: {}, sigint_error: {}, kill_error: {}",
-                            reason, sigint_error, kill_error
-                        ),
-                    }),
+        if let Some(pid) = process.id() {
+            let pid = Pid::from_raw(pid as i32);
+            match signal::kill(pid, Signal::SIGINT) {
+                Ok(_) => Ok(()),
+                Err(sigint_error) => {
+                    // (fallback) if SIGINT failed, we just kill process
+                    match process.kill().await {
+                        Ok(_) => Ok(()),
+                        Err(kill_error) => Err(ProtocolRunnerError::TerminateError {
+                            reason: format!(
+                                "Reason for termination: {}, sigint_error: {}, kill_error: {}",
+                                reason, sigint_error, kill_error
+                            ),
+                        }),
+                    }
                 }
             }
+        } else {
+            Ok(())
         }
+    }
+
+    /// Spawns a tokio task that will forward STDOUT and STDERR from the child
+    /// process to slog's output
+    fn log_subprocess_output(&self, process: &mut Child, log: Logger) {
+        // Only launch logging task if the output port if present, otherwise log a warning.
+        macro_rules! handle_output {
+            ($tag:expr, $name:expr, $io:expr, $log:expr) => {{
+                if let Some(out) = $io.take() {
+                    let log = $log;
+                    self.tokio_runtime.spawn(async move {
+                        let reader = BufReader::new(out);
+                        let mut lines = reader.lines();
+                        loop {
+                            match lines.next_line().await {
+                                Ok(Some(line)) => info!(log, "[{}] {}", $tag, line),
+                                Ok(None) => {
+                                    info!(log, "[{}] {} closed.", $tag, $name);
+                                    break;
+                                }
+                                Err(err) => {
+                                    warn!(log, "[{}] {} closed with error: {:?}", $tag, $name, err);
+                                    break;
+                                }
+                            }
+                        }
+                    });
+                } else {
+                    warn!(
+                        log,
+                        "Expected child process to have {}, but it was None", $name
+                    );
+                };
+            }};
+        }
+
+        handle_output!("OCaml-out", "STDOUT", process.stdout, log.clone());
+        handle_output!("OCaml-err", "STDERR", process.stderr, log.clone());
     }
 }
 
@@ -80,6 +130,7 @@ impl ProtocolRunner for ExecutableProtocolRunner {
         configuration: ProtocolEndpointConfiguration,
         sock_cmd_path: &Path,
         endpoint_name: String,
+        tokio_runtime: tokio::runtime::Handle,
     ) -> Self {
         let ProtocolEndpointConfiguration {
             executable_path,
@@ -90,12 +141,16 @@ impl ProtocolRunner for ExecutableProtocolRunner {
             sock_cmd_path: sock_cmd_path.to_path_buf(),
             executable_path,
             endpoint_name,
+            tokio_runtime,
             log_level,
         }
     }
 
-    fn spawn(&self) -> Result<Self::Subprocess, ProtocolRunnerError> {
-        let process = Command::new(&self.executable_path)
+    fn spawn(&self, log: Logger) -> Result<Self::Subprocess, ProtocolRunnerError> {
+        let _guard = self.tokio_runtime.enter();
+        let mut process = Command::new(&self.executable_path)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
             .arg("--sock-cmd")
             .arg(&self.sock_cmd_path)
             .arg("--endpoint")
@@ -104,21 +159,34 @@ impl ProtocolRunner for ExecutableProtocolRunner {
             .arg(&self.log_level.as_str().to_lowercase())
             .spawn()
             .map_err(|err| ProtocolRunnerError::SpawnError { reason: err })?;
+
+        self.log_subprocess_output(&mut process, log.clone());
+
         Ok(process)
     }
 
     fn wait_and_terminate_ref(
+        tokio_runtime: tokio::runtime::Handle,
         process: &mut Self::Subprocess,
         wait_timeout: Duration,
+        log: &Logger,
     ) -> Result<(), ProtocolRunnerError> {
-        match process.wait_timeout(wait_timeout) {
-            Ok(Some(_exit_status)) => {
-                // process exited, so we are ok
-                Ok(())
+        tokio_runtime.block_on(async move {
+            match tokio::time::timeout(wait_timeout, process.wait()).await {
+                Ok(Ok(exit_status)) => {
+                    if exit_status.success() {
+                        info!(log, "Exited successfuly");
+                    } else {
+                        warn!(log, "Exited with status code: {}", exit_status);
+                    }
+                    Ok(())
+                }
+                Ok(Err(err)) => Self::terminate_or_kill(process, format!("{:?}", err)).await,
+                Err(_) => {
+                    Self::terminate_or_kill(process, "wait timeout exceeded".to_string()).await
+                }
             }
-            Ok(None) => Self::terminate_or_kill(process, "wait timeout exceeded".to_string()),
-            Err(e) => Self::terminate_or_kill(process, format!("{}", e)),
-        }
+        })
     }
 
     fn is_running(process: &mut Self::Subprocess) -> bool {
@@ -134,14 +202,17 @@ pub trait ProtocolRunner: Clone + Send + Sync {
         configuration: ProtocolEndpointConfiguration,
         sock_cmd_path: &Path,
         endpoint_name: String,
+        tokio_runtime: tokio::runtime::Handle,
     ) -> Self;
 
-    fn spawn(&self) -> Result<Self::Subprocess, ProtocolRunnerError>;
+    fn spawn(&self, log: Logger) -> Result<Self::Subprocess, ProtocolRunnerError>;
 
     /// Give [`wait_timeout`] time to stop process, and after that if tries to terminate/kill it
     fn wait_and_terminate_ref(
+        tokio_runtime: tokio::runtime::Handle,
         process: &mut Self::Subprocess,
         wait_timeout: Duration,
+        log: &Logger,
     ) -> Result<(), ProtocolRunnerError>;
 
     /// Checks if process is running


### PR DESCRIPTION
Very hacky implementation, not meant to be merged in its current state, but will be used for debugging.

What would be a better way to handle this? I saw that there is a [tokio::process](https://docs.rs/tokio/1.8.1/tokio/process/index.html) module that could be used to work with this in a more async way.