### PR TITLE
Collect timing messages into a single bigger message before sending

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4105,6 +4105,7 @@ name = "tezos_timing"
 version = "1.7.0"
 dependencies = [
  "crypto",
+ "failure",
  "once_cell",
  "rusqlite",
  "serde 1.0.123",

--- a/tezos/timing/Cargo.toml
+++ b/tezos/timing/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 crypto = { path = "../../crypto" }
+failure = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 once_cell = "1.7.2"
 rusqlite = { version = "0.25.1", features = ["bundled"] }

--- a/tezos/timing/src/lib.rs
+++ b/tezos/timing/src/lib.rs
@@ -2,10 +2,14 @@
 // SPDX-License-Identifier: MIT
 
 use std::{
+    cell::Cell,
     collections::HashMap,
     convert::TryInto,
     path::PathBuf,
-    sync::mpsc::{sync_channel, Receiver, SyncSender},
+    sync::{
+        mpsc::{sync_channel, Receiver, SendError, SyncSender},
+        Mutex,
+    },
     time::{Duration, Instant},
 };
 
@@ -278,8 +282,61 @@ pub struct Action {
     pub tezedge_time: Option<f64>,
 }
 
-pub static TIMING_CHANNEL: Lazy<SyncSender<TimingMessage>> = Lazy::new(|| {
-    let (sender, receiver) = sync_channel(10_000);
+/// Buffered channel for sending timings that delays the sending until
+/// enough messages have been obtained or a commit message is received.
+/// The purpose is to send less messages through the channel to decrease
+/// the overhead.
+pub struct BufferedTimingChannel {
+    buffer: Mutex<Cell<Vec<TimingMessage>>>,
+    sender: SyncSender<Vec<TimingMessage>>,
+}
+
+impl BufferedTimingChannel {
+    const DELAYED_MESSAGES_LIMIT: usize = 100;
+
+    fn new(sender: SyncSender<Vec<TimingMessage>>) -> Self {
+        Self {
+            buffer: Mutex::new(Cell::new(Vec::with_capacity(Self::DELAYED_MESSAGES_LIMIT))),
+            sender,
+        }
+    }
+
+    /// True if the message must be sent immediately, false if it can be buffered.
+    fn is_immediate_message(&self, msg: &TimingMessage) -> bool {
+        match msg {
+            TimingMessage::Commit { .. } => true,
+            TimingMessage::InitTiming { .. } => false,
+            _ => false,
+        }
+    }
+
+    /// Sends messages, delayed and combined into a single bigger message.
+    ///
+    /// Reaching the delayed messages limit or receiving a commit message will trigger the send
+    /// to the underlying channel, otherwise the messages will be kept in the buffer.
+    pub fn send(&self, msg: TimingMessage) -> Result<(), SendError<Vec<TimingMessage>>> {
+        let must_not_delay = self.is_immediate_message(&msg);
+        let limit = Self::DELAYED_MESSAGES_LIMIT - 1;
+        let mut buffer = self.buffer.lock().unwrap();
+
+        buffer.get_mut().push(msg);
+
+        if must_not_delay || buffer.get_mut().len() == limit {
+            let swap_buffer = Cell::new(Vec::with_capacity(Self::DELAYED_MESSAGES_LIMIT));
+
+            buffer.swap(&swap_buffer);
+
+            let pack = swap_buffer.into_inner();
+
+            self.sender.send(pack)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+pub static TIMING_CHANNEL: Lazy<BufferedTimingChannel> = Lazy::new(|| {
+    let (sender, receiver) = sync_channel(1000);
 
     if let Err(e) = std::thread::Builder::new()
         .name("context-timing".to_string())
@@ -290,17 +347,19 @@ pub static TIMING_CHANNEL: Lazy<SyncSender<TimingMessage>> = Lazy::new(|| {
         eprintln!("Fail to create timing channel: {:?}", e);
     }
 
-    sender
+    BufferedTimingChannel::new(sender)
 });
 
-fn start_timing(recv: Receiver<TimingMessage>) {
+fn start_timing(recv: Receiver<Vec<TimingMessage>>) {
     let mut db_path: Option<PathBuf> = None;
 
-    for msg in &recv {
-        if let TimingMessage::InitTiming { db_path: path } = msg {
-            db_path = path.clone();
-            break;
-        };
+    'outer: for msgpack in &recv {
+        for msg in msgpack {
+            if let TimingMessage::InitTiming { db_path: path } = msg {
+                db_path = path.clone();
+                break 'outer;
+            };
+        }
     }
 
     let sql = match Timing::init_sqlite(db_path) {
@@ -314,9 +373,11 @@ fn start_timing(recv: Receiver<TimingMessage>) {
     let mut timing = Timing::new();
     let mut transaction = None;
 
-    for msg in recv {
-        if let Err(err) = timing.process_msg(&sql, &mut transaction, msg) {
-            eprintln!("Timing error={:?}", err);
+    for msgpack in recv {
+        for msg in msgpack {
+            if let Err(err) = timing.process_msg(&sql, &mut transaction, msg) {
+                eprintln!("Timing error={:?}", err);
+            }
         }
     }
 }


### PR DESCRIPTION
Basic initial version, I think there are still possible improvements. For example, preallocate N buffers that get cycled around instead of allocating a new one when sending a combined message. Whenever the receiving side is done processing the buffer, it can return it back to the producer.

## Some measurements:

First 11k blocks from florencenet applied with replay-test with the Irmin context and original libtezos without the latest modifications (which save a bit of time but not enough to matter).

###  timings disabled

```
51.82user 5.90system 1:02.61elapsed 92%CPU (0avgtext+0avgdata 474336maxresident)k
2481784inputs+1642160outputs (497major+158501minor)pagefaults 0swaps
```

### timings enabled

```
102.90user 24.76system 1:25.54elapsed 149%CPU (0avgtext+0avgdata 479560maxresident)k
753112inputs+4166736outputs (295major+160016minor)pagefaults 0swaps
```

### timings enabled with packing (100 messages in one)

```
70.45user 7.45system 0:58.52elapsed 133%CPU (0avgtext+0avgdata 481160maxresident)k
80inputs+4132344outputs (0major+159147minor)pagefaults 0swaps
```

Tried bigger and smaller message buffer values but it didn't make much of a difference.
