### PR TITLE
Implement Inode representation in the context storage

### DIFF
--- a/tezos/new_context/src/kv_store/mod.rs
+++ b/tezos/new_context/src/kv_store/mod.rs
@@ -22,6 +22,7 @@ pub const INMEM: &str = "inmem";
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct HashId(NonZeroU32); // NonZeroU32 so that `Option<HashId>` is 4 bytes
 
+#[derive(Debug)]
 pub struct HashIdError;
 
 impl TryInto<usize> for HashId {

--- a/tezos/new_context/src/working_tree/mod.rs
+++ b/tezos/new_context/src/working_tree/mod.rs
@@ -83,6 +83,11 @@ impl Node {
         HashId::new(id)
     }
 
+    /// Return the entry of this `Node`.
+    ///
+    /// It returns `None` when the entry has not been fetched from the repository.
+    /// In that case, `TezedgeIndex::get_entry` must be used with the `HashId` of this
+    /// `Node` to get the entry.
     pub fn get_entry(&self) -> Option<Entry> {
         let inner = self.inner.get();
 

--- a/tezos/new_context/src/working_tree/serializer.rs
+++ b/tezos/new_context/src/working_tree/serializer.rs
@@ -3,7 +3,7 @@
 
 use std::{
     array::TryFromSliceError, convert::TryInto, io::Write, num::TryFromIntError, str::Utf8Error,
-    string::FromUtf8Error,
+    string::FromUtf8Error, sync::Arc,
 };
 
 use modular_bitfield::prelude::*;
@@ -12,19 +12,29 @@ use tezos_timing::SerializeStats;
 
 use crate::{
     kv_store::HashId,
-    working_tree::{Commit, NodeKind},
+    working_tree::{
+        storage::{Inode, PointerToInode, TreeStorageId},
+        Commit, NodeKind,
+    },
+    ContextKeyValueStore,
 };
 
 use super::{
-    storage::{Blob, NodeIdError, Storage, StorageIdError},
+    storage::{Blob, InodeId, NodeId, NodeIdError, Storage, StorageError},
+    string_interner::StringId,
     Entry, Node,
 };
 
 const ID_TREE: u8 = 0;
 const ID_BLOB: u8 = 1;
 const ID_COMMIT: u8 = 2;
+const ID_INODE_POINTERS: u8 = 3;
+const ID_INODE_DIRECTORY: u8 = 4;
 
 const COMPACT_HASH_ID_BIT: u32 = 1 << 23;
+
+const FULL_31_BITS: u32 = 0x7FFFFFFF;
+const FULL_23_BITS: u32 = 0x7FFFFF;
 
 #[derive(Debug)]
 pub enum SerializationError {
@@ -33,8 +43,9 @@ pub enum SerializationError {
     NodeNotFound,
     BlobNotFound,
     TryFromIntError,
-    StorageIdError { error: StorageIdError },
+    StorageIdError { error: StorageError },
     HashIdTooBig,
+    MissingHashId,
 }
 
 impl From<std::io::Error> for SerializationError {
@@ -49,8 +60,8 @@ impl From<TryFromIntError> for SerializationError {
     }
 }
 
-impl From<StorageIdError> for SerializationError {
-    fn from(error: StorageIdError) -> Self {
+impl From<StorageError> for SerializationError {
+    fn from(error: StorageError) -> Self {
         Self::StorageIdError { error }
     }
 }
@@ -75,100 +86,110 @@ pub struct KeyNodeDescriptor {
 // Must fit in 1 byte
 assert_eq_size!(KeyNodeDescriptor, u8);
 
-pub fn serialize_entry(
-    entry: &Entry,
+fn serialize_directory(
+    tree: &[(StringId, NodeId)],
     output: &mut Vec<u8>,
     storage: &Storage,
     stats: &mut SerializeStats,
 ) -> Result<(), SerializationError> {
+    let mut keys_length: usize = 0;
+    let mut hash_ids_length: usize = 0;
+    let mut highest_hash_id: u32 = 0;
+    let mut nblobs_inlined: usize = 0;
+    let mut blobs_length: usize = 0;
+
+    for (key_id, node_id) in tree {
+        let key = storage.get_str(*key_id)?;
+
+        let node = storage.get_node(*node_id)?;
+
+        let hash_id: u32 = node.hash_id().map(|h| h.as_u32()).unwrap_or(0);
+        let kind = node.node_kind();
+
+        let blob_inline = get_inline_blob(storage, &node);
+        let blob_inline_length = blob_inline.as_ref().map(|b| b.len()).unwrap_or(0);
+
+        match key.len() {
+            len if len != 0 && len < 16 => {
+                let byte: [u8; 1] = KeyNodeDescriptor::new()
+                    .with_kind(kind)
+                    .with_key_inline_length(len as u8)
+                    .with_blob_inline_length(blob_inline_length as u8)
+                    .into_bytes();
+                output.write_all(&byte[..])?;
+                output.write_all(key.as_bytes())?;
+                keys_length += len;
+            }
+            len => {
+                let byte: [u8; 1] = KeyNodeDescriptor::new()
+                    .with_kind(kind)
+                    .with_key_inline_length(0)
+                    .with_blob_inline_length(blob_inline_length as u8)
+                    .into_bytes();
+                output.write_all(&byte[..])?;
+
+                let key_length: u16 = len.try_into()?;
+                output.write_all(&key_length.to_ne_bytes())?;
+                output.write_all(key.as_bytes())?;
+                keys_length += 2 + key.len();
+            }
+        }
+
+        if let Some(blob_inline) = blob_inline {
+            nblobs_inlined += 1;
+            blobs_length += blob_inline.len();
+
+            output.write_all(&blob_inline)?;
+        } else {
+            let nbytes = serialize_hash_id(hash_id, output)?;
+
+            hash_ids_length += nbytes;
+            highest_hash_id = highest_hash_id.max(hash_id);
+        }
+    }
+
+    stats.add_tree(
+        hash_ids_length,
+        keys_length,
+        highest_hash_id,
+        nblobs_inlined,
+        blobs_length,
+    );
+
+    Ok(())
+}
+
+pub fn serialize_entry(
+    entry: &Entry,
+    entry_hash_id: HashId,
+    output: &mut Vec<u8>,
+    storage: &Storage,
+    stats: &mut SerializeStats,
+    batch: &mut Vec<(HashId, Arc<[u8]>)>,
+    referenced_older_entries: &mut Vec<HashId>,
+) -> Result<(), SerializationError> {
     output.clear();
 
     match entry {
-        Entry::Tree(tree) => {
-            output.write_all(&[ID_TREE])?;
-            let tree = storage.get_tree(*tree)?;
+        Entry::Tree(tree_id) => {
+            if let Some(inode_id) = tree_id.get_inode_id() {
+                serialize_inode(
+                    inode_id,
+                    output,
+                    entry_hash_id,
+                    storage,
+                    stats,
+                    batch,
+                    referenced_older_entries,
+                )?;
+            } else {
+                output.write_all(&[ID_TREE])?;
+                let tree = storage.get_small_tree(*tree_id)?;
 
-            let mut keys_length: usize = 0;
-            let mut hash_ids_length: usize = 0;
-            let mut highest_hash_id: u32 = 0;
-            let mut nblobs_inlined: usize = 0;
-            let mut blobs_length: usize = 0;
+                serialize_directory(tree, output, storage, stats)?;
 
-            for (key_id, node_id) in tree {
-                let key = storage.get_str(*key_id)?;
-
-                let node = storage.get_node(*node_id)?;
-
-                let hash_id: u32 = node.hash_id().map(|h| h.as_u32()).unwrap_or(0);
-                let kind = node.node_kind();
-
-                let blob_inline = get_inline_blob(storage, &node);
-                let blob_inline_length = blob_inline.as_ref().map(|b| b.len()).unwrap_or(0);
-
-                match key.len() {
-                    len if len != 0 && len < 16 => {
-                        let byte: [u8; 1] = KeyNodeDescriptor::new()
-                            .with_kind(kind)
-                            .with_key_inline_length(len as u8)
-                            .with_blob_inline_length(blob_inline_length as u8)
-                            .into_bytes();
-                        output.write_all(&byte[..])?;
-                        output.write_all(key.as_bytes())?;
-                        keys_length += len;
-                    }
-                    len => {
-                        let byte: [u8; 1] = KeyNodeDescriptor::new()
-                            .with_kind(kind)
-                            .with_key_inline_length(0)
-                            .with_blob_inline_length(blob_inline_length as u8)
-                            .into_bytes();
-                        output.write_all(&byte[..])?;
-
-                        let key_length: u16 = len.try_into()?;
-                        output.write_all(&key_length.to_ne_bytes())?;
-                        output.write_all(key.as_bytes())?;
-                        keys_length += 2 + key.len();
-                    }
-                }
-
-                hash_ids_length += 4;
-                highest_hash_id = highest_hash_id.max(hash_id);
-
-                if let Some(blob_inline) = blob_inline {
-                    nblobs_inlined += 1;
-                    blobs_length += blob_inline.len();
-
-                    output.write_all(&blob_inline)?;
-                } else if hash_id & 0x7FFFFF == hash_id {
-                    // The HashId fits in 23 bits
-                    hash_ids_length += 3;
-                    highest_hash_id = highest_hash_id.max(hash_id);
-
-                    // Set `COMPACT_HASH_ID_BIT` so the deserializer knows the `HashId` is in 3 bytes
-                    let hash_id: u32 = hash_id | COMPACT_HASH_ID_BIT;
-                    let hash_id: [u8; 4] = hash_id.to_be_bytes();
-
-                    output.write_all(&hash_id[1..])?;
-                } else if hash_id & 0x7FFFFFFF == hash_id {
-                    // HashId fits in 31 bits
-                    hash_ids_length += 4;
-                    highest_hash_id = highest_hash_id.max(hash_id);
-
-                    output.write_all(&hash_id.to_be_bytes())?;
-                } else {
-                    // The HashId must not be 32 bits because we use the
-                    // MSB to determine if the HashId is compact or not
-                    return Err(SerializationError::HashIdTooBig);
-                }
+                batch.push((entry_hash_id, Arc::from(output.as_slice())));
             }
-
-            stats.add_tree(
-                hash_ids_length,
-                keys_length,
-                highest_hash_id,
-                nblobs_inlined,
-                blobs_length,
-            );
         }
         Entry::Blob(blob_id) => {
             debug_assert!(!blob_id.is_inline());
@@ -178,17 +199,18 @@ pub fn serialize_entry(
             output.write_all(blob.as_ref())?;
 
             stats.add_blob(blob.len());
+
+            batch.push((entry_hash_id, Arc::from(output.as_slice())));
         }
         Entry::Commit(commit) => {
             output.write_all(&[ID_COMMIT])?;
-            output.write_all(
-                &commit
-                    .parent_commit_hash
-                    .map(|h| h.as_u32())
-                    .unwrap_or(0)
-                    .to_ne_bytes(),
-            )?;
-            output.write_all(&commit.root_hash.as_u32().to_ne_bytes())?;
+
+            let parent_hash_id = commit.parent_commit_hash.map(|h| h.as_u32()).unwrap_or(0);
+            serialize_hash_id(parent_hash_id, output)?;
+
+            let root_hash_id = commit.root_hash.as_u32();
+            serialize_hash_id(root_hash_id, output)?;
+
             output.write_all(&commit.time.to_ne_bytes())?;
             let author_length: u32 = commit.author.len().try_into()?;
             output.write_all(&author_length.to_ne_bytes())?;
@@ -196,10 +218,119 @@ pub fn serialize_entry(
             let message_length: u32 = commit.message.len().try_into()?;
             output.write_all(&message_length.to_ne_bytes())?;
             output.write_all(commit.message.as_bytes())?;
+
+            batch.push((entry_hash_id, Arc::from(output.as_slice())));
         }
     }
 
     stats.total_bytes += output.len();
+
+    Ok(())
+}
+
+fn serialize_hash_id(hash_id: u32, output: &mut Vec<u8>) -> Result<usize, SerializationError> {
+    if hash_id & FULL_23_BITS == hash_id {
+        // The HashId fits in 23 bits
+
+        // Set `COMPACT_HASH_ID_BIT` so the deserializer knows the `HashId` is in 3 bytes
+        let hash_id: u32 = hash_id | COMPACT_HASH_ID_BIT;
+        let hash_id: [u8; 4] = hash_id.to_be_bytes();
+
+        output.write_all(&hash_id[1..])?;
+        Ok(3)
+    } else if hash_id & FULL_31_BITS == hash_id {
+        // HashId fits in 31 bits
+
+        output.write_all(&hash_id.to_be_bytes())?;
+        Ok(4)
+    } else {
+        // The HashId must not be 32 bits because we use the
+        // MSB to determine if the HashId is compact or not
+        Err(SerializationError::HashIdTooBig)
+    }
+}
+
+fn serialize_inode(
+    inode_id: InodeId,
+    output: &mut Vec<u8>,
+    hash_id: HashId,
+    storage: &Storage,
+    stats: &mut SerializeStats,
+    batch: &mut Vec<(HashId, Arc<[u8]>)>,
+    referenced_older_entries: &mut Vec<HashId>,
+) -> Result<(), SerializationError> {
+    use SerializationError::*;
+
+    output.clear();
+    let inode = storage.get_inode(inode_id)?;
+
+    match inode {
+        Inode::Pointers {
+            depth,
+            nchildren,
+            npointers,
+            pointers,
+        } => {
+            output.write_all(&[ID_INODE_POINTERS])?;
+            output.write_all(&depth.to_ne_bytes())?;
+            output.write_all(&nchildren.to_ne_bytes())?;
+            output.write_all(&npointers.to_ne_bytes())?;
+
+            // TODO - TE-663:
+            // Make a bitfield of 32 bits indicating how many hashes there are
+            // and at what index, instead of wasting 1 byte (the index below) for
+            // each hash
+            for (index, pointer) in pointers.iter().enumerate() {
+                if let Some(pointer) = pointer {
+                    let index: u8 = index as u8;
+
+                    let hash_id = pointer.hash_id().ok_or(MissingHashId)?;
+                    let hash_id = hash_id.as_u32();
+
+                    output.write_all(&index.to_ne_bytes())?;
+                    serialize_hash_id(hash_id, output)?;
+                };
+            }
+
+            batch.push((hash_id, Arc::from(output.as_slice())));
+
+            // Recursively serialize all children
+            for pointer in pointers.iter().filter_map(|p| p.as_ref()) {
+                let hash_id = pointer.hash_id().ok_or(MissingHashId)?;
+
+                if pointer.is_commited() {
+                    // We only want to serialize new inodes.
+                    // We skip inodes that were previously serialized and already
+                    // in the repository.
+                    // Add their hash_id to `referenced_older_entries` so the gargage
+                    // collector won't collect them.
+                    referenced_older_entries.push(hash_id);
+                    continue;
+                }
+
+                let inode_id = pointer.inode_id();
+                serialize_inode(
+                    inode_id,
+                    output,
+                    hash_id,
+                    storage,
+                    stats,
+                    batch,
+                    referenced_older_entries,
+                )?;
+            }
+        }
+        Inode::Directory(tree_id) => {
+            // We don't check if it's a new inode because the parent
+            // caller (recursively) confirmed it's a new one.
+
+            output.write_all(&[ID_INODE_DIRECTORY])?;
+            let tree = storage.get_small_tree(*tree_id)?;
+            serialize_directory(tree, output, storage, stats)?;
+
+            batch.push((hash_id, Arc::from(output.as_slice())));
+        }
+    };
 
     Ok(())
 }
@@ -214,7 +345,9 @@ pub enum DeserializationError {
     MissingRootHash,
     MissingHash,
     NodeIdError,
-    StorageIdError { error: StorageIdError },
+    StorageIdError { error: StorageError },
+    InodeNotFoundInRepository,
+    InodeEmptyInRepository,
 }
 
 impl From<TryFromSliceError> for DeserializationError {
@@ -241,107 +374,126 @@ impl From<NodeIdError> for DeserializationError {
     }
 }
 
-impl From<StorageIdError> for DeserializationError {
-    fn from(error: StorageIdError) -> Self {
+impl From<StorageError> for DeserializationError {
+    fn from(error: StorageError) -> Self {
         Self::StorageIdError { error }
     }
 }
 
-/// Extract values from `data` to store them in `storage`.
-/// Return an `Entry`, which can be ids (refering to data inside `storage`) or a `Commit`
-pub fn deserialize(data: &[u8], storage: &mut Storage) -> Result<Entry, DeserializationError> {
-    let mut pos = 1;
+fn deserialize_hash_id(data: &[u8]) -> Result<(Option<HashId>, usize), DeserializationError> {
+    use DeserializationError::*;
 
+    let byte_hash_id = data.get(0).copied().ok_or(UnexpectedEOF)?;
+
+    if byte_hash_id & 1 << 7 != 0 {
+        // The HashId is in 3 bytes
+        let hash_id = data.get(0..3).ok_or(UnexpectedEOF)?;
+
+        let hash_id: u32 = (hash_id[0] as u32) << 16 | (hash_id[1] as u32) << 8 | hash_id[2] as u32;
+
+        // Clear `COMPACT_HASH_ID_BIT`
+        let hash_id = hash_id & (COMPACT_HASH_ID_BIT - 1);
+        let hash_id = HashId::new(hash_id);
+
+        Ok((hash_id, 3))
+    } else {
+        // The HashId is in 4 bytes
+        let hash_id = data.get(0..4).ok_or(UnexpectedEOF)?;
+        let hash_id = u32::from_be_bytes(hash_id.try_into()?);
+        let hash_id = HashId::new(hash_id);
+
+        Ok((hash_id, 4))
+    }
+}
+
+fn deserialize_directory(
+    data: &[u8],
+    storage: &mut Storage,
+) -> Result<TreeStorageId, DeserializationError> {
     use DeserializationError as Error;
     use DeserializationError::*;
 
+    let mut pos = 1;
+    let data_length = data.len();
+
+    let tree_id = storage.with_new_tree::<_, Result<_, Error>>(|storage, new_tree| {
+        while pos < data_length {
+            let descriptor = data.get(pos..pos + 1).ok_or(UnexpectedEOF)?;
+            let descriptor = KeyNodeDescriptor::from_bytes([descriptor[0]; 1]);
+
+            pos += 1;
+
+            let key_id = match descriptor.key_inline_length() as usize {
+                len if len > 0 => {
+                    // The key is in the next `len` bytes
+                    let key_bytes = data.get(pos..pos + len).ok_or(UnexpectedEOF)?;
+                    let key_str = std::str::from_utf8(key_bytes)?;
+                    pos += len;
+                    storage.get_string_id(key_str)
+                }
+                _ => {
+                    // The key length is in 2 bytes, followed by the key itself
+                    let key_length = data.get(pos..pos + 2).ok_or(UnexpectedEOF)?;
+                    let key_length = u16::from_ne_bytes(key_length.try_into()?);
+                    let key_length = key_length as usize;
+
+                    let key_bytes = data
+                        .get(pos + 2..pos + 2 + key_length)
+                        .ok_or(UnexpectedEOF)?;
+                    let key_str = std::str::from_utf8(key_bytes)?;
+                    pos += 2 + key_length;
+                    storage.get_string_id(key_str)
+                }
+            };
+
+            let kind = descriptor.kind();
+            let blob_inline_length = descriptor.blob_inline_length() as usize;
+
+            let node = if blob_inline_length > 0 {
+                // The blob is inlined
+
+                let blob = data
+                    .get(pos..pos + blob_inline_length)
+                    .ok_or(UnexpectedEOF)?;
+                let blob_id = storage.add_blob_by_ref(blob)?;
+
+                pos += blob_inline_length;
+
+                Node::new_commited(kind, None, Some(Entry::Blob(blob_id)))
+            } else {
+                let bytes = data.get(pos..).ok_or(UnexpectedEOF)?;
+                let (hash_id, nbytes) = deserialize_hash_id(bytes)?;
+
+                pos += nbytes;
+
+                Node::new_commited(kind, Some(hash_id.ok_or(MissingHash)?), None)
+            };
+
+            let node_id = storage.add_node(node)?;
+
+            new_tree.push((key_id, node_id));
+        }
+
+        Ok(storage.append_to_trees(new_tree))
+    })??;
+
+    Ok(tree_id)
+}
+
+/// Extract values from `data` to store them in `storage`.
+/// Return an `Entry`, which can be ids (refering to data inside `storage`) or a `Commit`
+pub fn deserialize(
+    data: &[u8],
+    storage: &mut Storage,
+    store: &ContextKeyValueStore,
+) -> Result<Entry, DeserializationError> {
+    use DeserializationError::*;
+
+    let mut pos = 1;
+
     match data.get(0).copied().ok_or(UnexpectedEOF)? {
         ID_TREE => {
-            let data_length = data.len();
-
-            let tree_id =
-                storage.with_new_tree::<_, Result<_, Error>>(|storage, new_tree| {
-                    while pos < data_length {
-                        let descriptor = data.get(pos..pos + 1).ok_or(UnexpectedEOF)?;
-                        let descriptor = KeyNodeDescriptor::from_bytes([descriptor[0]; 1]);
-
-                        pos += 1;
-
-                        let key_id = match descriptor.key_inline_length() as usize {
-                            len if len > 0 => {
-                                // The key is in the next `len` bytes
-                                let key_bytes = data.get(pos..pos + len).ok_or(UnexpectedEOF)?;
-                                let key_str = std::str::from_utf8(key_bytes)?;
-                                pos += len;
-                                storage.get_string_id(key_str)
-                            }
-                            _ => {
-                                // The key length is in 2 bytes, followed by the key itself
-                                let key_length = data.get(pos..pos + 2).ok_or(UnexpectedEOF)?;
-                                let key_length = u16::from_ne_bytes(key_length.try_into()?);
-                                let key_length = key_length as usize;
-
-                                let key_bytes = data
-                                    .get(pos + 2..pos + 2 + key_length)
-                                    .ok_or(UnexpectedEOF)?;
-                                let key_str = std::str::from_utf8(key_bytes)?;
-                                pos += 2 + key_length;
-                                storage.get_string_id(key_str)
-                            }
-                        };
-
-                        let kind = descriptor.kind();
-                        let blob_inline_length = descriptor.blob_inline_length() as usize;
-
-                        let node = if blob_inline_length > 0 {
-                            // The blob is inlined
-
-                            let blob = data
-                                .get(pos..pos + blob_inline_length)
-                                .ok_or(UnexpectedEOF)?;
-                            let blob_id = storage.add_blob_by_ref(blob)?;
-
-                            pos += blob_inline_length;
-
-                            Node::new_commited(kind, None, Some(Entry::Blob(blob_id)))
-                        } else {
-                            let byte_hash_id = data.get(pos).copied().ok_or(UnexpectedEOF)?;
-
-                            if byte_hash_id & 1 << 7 != 0 {
-                                // The HashId is in 3 bytes
-                                let hash_id = data.get(pos..pos + 3).ok_or(UnexpectedEOF)?;
-
-                                let hash_id: u32 = (hash_id[0] as u32) << 16
-                                    | (hash_id[1] as u32) << 8
-                                    | hash_id[2] as u32;
-
-                                // Clear `COMPACT_HASH_ID_BIT`
-                                let hash_id = hash_id & (COMPACT_HASH_ID_BIT - 1);
-                                let hash_id = HashId::new(hash_id).ok_or(MissingHash)?;
-
-                                pos += 3;
-
-                                Node::new_commited(kind, Some(hash_id), None)
-                            } else {
-                                // The HashId is in 4 bytes
-                                let hash_id = data.get(pos..pos + 4).ok_or(UnexpectedEOF)?;
-                                let hash_id = u32::from_be_bytes(hash_id.try_into()?);
-                                let hash_id = HashId::new(hash_id).ok_or(MissingHash)?;
-
-                                pos += 4;
-
-                                Node::new_commited(kind, Some(hash_id), None)
-                            }
-                        };
-
-                        let node_id = storage.add_node(node)?;
-
-                        new_tree.push((key_id, node_id));
-                    }
-
-                    Ok(storage.add_tree(new_tree))
-                })??;
-
+            let tree_id = deserialize_directory(data, storage)?;
             Ok(Entry::Tree(tree_id))
         }
         ID_BLOB => {
@@ -350,24 +502,28 @@ pub fn deserialize(data: &[u8], storage: &mut Storage) -> Result<Entry, Deserial
             Ok(Entry::Blob(blob_id))
         }
         ID_COMMIT => {
-            let parent_commit_hash = data.get(pos..pos + 4).ok_or(UnexpectedEOF)?;
-            let parent_commit_hash = u32::from_ne_bytes(parent_commit_hash.try_into()?);
+            let bytes = data.get(pos..).ok_or(UnexpectedEOF)?;
+            let (parent_commit_hash, nbytes) = deserialize_hash_id(bytes)?;
 
-            let root_hash = data.get(pos + 4..pos + 8).ok_or(UnexpectedEOF)?;
-            let root_hash = u32::from_ne_bytes(root_hash.try_into()?);
+            pos += nbytes;
 
-            let time = data.get(pos + 8..pos + 16).ok_or(UnexpectedEOF)?;
+            let bytes = data.get(pos..).ok_or(UnexpectedEOF)?;
+            let (root_hash, nbytes) = deserialize_hash_id(bytes)?;
+
+            pos += nbytes;
+
+            let time = data.get(pos..pos + 8).ok_or(UnexpectedEOF)?;
             let time = u64::from_ne_bytes(time.try_into()?);
 
-            let author_length = data.get(pos + 16..pos + 20).ok_or(UnexpectedEOF)?;
+            let author_length = data.get(pos + 8..pos + 12).ok_or(UnexpectedEOF)?;
             let author_length = u32::from_ne_bytes(author_length.try_into()?) as usize;
 
             let author = data
-                .get(pos + 20..pos + 20 + author_length)
+                .get(pos + 12..pos + 12 + author_length)
                 .ok_or(UnexpectedEOF)?;
             let author = author.to_vec();
 
-            pos = pos + 20 + author_length;
+            pos = pos + 12 + author_length;
 
             let message_length = data.get(pos..pos + 4).ok_or(UnexpectedEOF)?;
             let message_length = u32::from_ne_bytes(message_length.try_into()?) as usize;
@@ -378,12 +534,96 @@ pub fn deserialize(data: &[u8], storage: &mut Storage) -> Result<Entry, Deserial
             let message = message.to_vec();
 
             Ok(Entry::Commit(Box::new(Commit {
-                parent_commit_hash: HashId::new(parent_commit_hash),
-                root_hash: HashId::new(root_hash).ok_or(MissingRootHash)?,
+                parent_commit_hash: parent_commit_hash,
+                root_hash: root_hash.ok_or(MissingRootHash)?,
                 time,
                 author: String::from_utf8(author)?,
                 message: String::from_utf8(message)?,
             })))
+        }
+        ID_INODE_POINTERS => {
+            let inode = deserialize_inode_tree(&data[1..], storage, store)?;
+            let inode_id = storage.add_inode(inode)?;
+
+            Ok(Entry::Tree(inode_id.into()))
+        }
+        _ => Err(UnknownID),
+    }
+}
+
+fn deserialize_inode_tree(
+    data: &[u8],
+    storage: &mut Storage,
+    store: &ContextKeyValueStore,
+) -> Result<Inode, DeserializationError> {
+    use DeserializationError::*;
+
+    let mut pos = 0;
+
+    let depth = data.get(pos..pos + 4).ok_or(UnexpectedEOF)?;
+    let depth = u32::from_ne_bytes(depth.try_into()?);
+
+    let nchildren = data.get(pos + 4..pos + 8).ok_or(UnexpectedEOF)?;
+    let nchildren = u32::from_ne_bytes(nchildren.try_into()?);
+
+    let npointers = data.get(pos + 8..pos + 8 + 1).ok_or(UnexpectedEOF)?;
+    let npointers = u8::from_ne_bytes(npointers.try_into()?);
+
+    pos += 9;
+
+    let data_length = data.len();
+    let mut pointers: [Option<PointerToInode>; 32] = Default::default();
+
+    while pos < data_length {
+        let index = data.get(pos..pos + 1).ok_or(UnexpectedEOF)?;
+        let index = u8::from_ne_bytes(index.try_into()?);
+
+        pos += 1;
+
+        let bytes = data.get(pos..).ok_or(UnexpectedEOF)?;
+        let (hash_id, nbytes) = deserialize_hash_id(bytes)?;
+
+        pos += nbytes;
+
+        let inode_id = store
+            .get_value(hash_id.ok_or(MissingHash)?)
+            .map_err(|_| InodeNotFoundInRepository)
+            .and_then(|data| {
+                let data = data.ok_or(InodeEmptyInRepository)?;
+                deserialize_inode(data.as_ref(), storage, store)
+            })?;
+
+        pointers[index as usize] = Some(PointerToInode::new_commited(
+            Some(hash_id.ok_or(MissingHash)?),
+            inode_id,
+        ));
+    }
+
+    Ok(Inode::Pointers {
+        depth,
+        nchildren,
+        npointers,
+        pointers,
+    })
+}
+
+pub fn deserialize_inode(
+    data: &[u8],
+    storage: &mut Storage,
+    store: &ContextKeyValueStore,
+) -> Result<InodeId, DeserializationError> {
+    use DeserializationError::*;
+
+    match data.get(0).copied().ok_or(UnexpectedEOF)? {
+        ID_INODE_POINTERS => {
+            let inode = deserialize_inode_tree(&data[1..], storage, store)?;
+            storage.add_inode(inode).map_err(Into::into)
+        }
+        ID_INODE_DIRECTORY => {
+            let tree_id = deserialize_directory(data, storage)?;
+            storage
+                .add_inode(Inode::Directory(tree_id))
+                .map_err(Into::into)
         }
         _ => Err(UnknownID),
     }
@@ -403,74 +643,80 @@ impl<'a> Iterator for HashIdIterator<'a> {
     type Item = HashId;
 
     fn next(&mut self) -> Option<Self::Item> {
+        let id = self.data.get(0).copied()?;
+
         loop {
             let mut pos = self.pos;
 
             if pos == 0 {
-                let id = self.data.get(0).copied()?;
                 if id == ID_BLOB {
                     // No HashId in Entry::Blob
                     return None;
                 } else if id == ID_COMMIT {
+                    // Deserialize the parent hash to know it's size
+                    let (_, nbytes) = deserialize_hash_id(self.data.get(1..)?).ok()?;
+
                     // Entry::Commit.root_hash
-                    let root_hash = self.data.get(9..9 + 4)?;
-                    let root_hash = u32::from_ne_bytes(root_hash.try_into().ok()?);
+                    let (root_hash, _) = deserialize_hash_id(self.data.get(1 + nbytes..)?).ok()?;
                     self.pos = self.data.len();
 
-                    return HashId::new(root_hash);
+                    return root_hash;
+                } else if id == ID_INODE_POINTERS {
+                    pos += 10;
+                } else {
+                    pos += 1;
                 }
+            }
+
+            if id == ID_INODE_POINTERS {
                 pos += 1;
-            }
 
-            let descriptor = self.data.get(pos..pos + 1)?;
-            let descriptor = KeyNodeDescriptor::from_bytes([descriptor[0]; 1]);
+                let bytes = self.data.get(pos..)?;
+                let (hash_id, nbytes) = deserialize_hash_id(bytes).ok()?;
 
-            pos += 1;
+                self.pos = pos + nbytes;
 
-            let offset = match descriptor.key_inline_length() as usize {
-                len if len > 0 => len,
-                _ => {
-                    let key_length = self.data.get(pos..pos + 2)?;
-                    let key_length = u16::from_ne_bytes(key_length.try_into().ok()?);
-                    2 + key_length as usize
-                }
-            };
-
-            pos += offset;
-
-            let blob_inline_length = descriptor.blob_inline_length() as usize;
-
-            if blob_inline_length > 0 {
-                // No HashId when the blob is inlined, go to next entry
-                self.pos = pos + blob_inline_length;
-                continue;
-            }
-
-            let byte_hash_id = self.data.get(pos)?;
-
-            let hash_id = if byte_hash_id & 1 << 7 != 0 {
-                // HashId in 3 bytes
-                let hash_id = self.data.get(pos..pos + 3)?;
-                self.pos = pos + 3;
-
-                let hash_id: u32 =
-                    (hash_id[0] as u32) << 16 | (hash_id[1] as u32) << 8 | hash_id[2] as u32;
-                hash_id & (COMPACT_HASH_ID_BIT - 1)
+                return hash_id;
             } else {
-                // HashId in 4 bytes
-                let hash_id = self.data.get(pos..pos + 4)?;
+                let descriptor = self.data.get(pos..pos + 1)?;
+                let descriptor = KeyNodeDescriptor::from_bytes([descriptor[0]; 1]);
 
-                self.pos = pos + 4;
-                u32::from_be_bytes(hash_id[..].try_into().ok()?)
-            };
+                pos += 1;
 
-            return HashId::new(hash_id);
+                let offset = match descriptor.key_inline_length() as usize {
+                    len if len > 0 => len,
+                    _ => {
+                        let key_length = self.data.get(pos..pos + 2)?;
+                        let key_length = u16::from_ne_bytes(key_length.try_into().ok()?);
+                        2 + key_length as usize
+                    }
+                };
+
+                pos += offset;
+
+                let blob_inline_length = descriptor.blob_inline_length() as usize;
+
+                if blob_inline_length > 0 {
+                    // No HashId when the blob is inlined, go to next entry
+                    self.pos = pos + blob_inline_length;
+                    continue;
+                }
+
+                let bytes = self.data.get(pos..)?;
+                let (hash_id, nbytes) = deserialize_hash_id(bytes).ok()?;
+
+                self.pos = pos + nbytes;
+
+                return hash_id;
+            }
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::convert::TryFrom;
+
     use tezos_timing::SerializeStats;
 
     use crate::{
@@ -482,25 +728,31 @@ mod tests {
     #[test]
     fn test_serialize() {
         let mut storage = Storage::new();
+        let mut repo = InMemory::try_new().unwrap();
         let mut stats = SerializeStats::default();
+        let mut batch = Vec::new();
+        let mut older_entries = Vec::new();
+        let fake_hash_id = HashId::try_from(1).unwrap();
+
+        // Test Entry::Tree
 
         let tree_id = TreeStorageId::empty();
         let tree_id = storage
-            .insert(
+            .tree_insert(
                 tree_id,
                 "a",
                 Node::new_commited(NodeKind::Leaf, HashId::new(1), None),
             )
             .unwrap();
         let tree_id = storage
-            .insert(
+            .tree_insert(
                 tree_id,
                 "bab",
                 Node::new_commited(NodeKind::Leaf, HashId::new(2), None),
             )
             .unwrap();
         let tree_id = storage
-            .insert(
+            .tree_insert(
                 tree_id,
                 "0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                 Node::new_commited(NodeKind::Leaf, HashId::new(3), None),
@@ -508,9 +760,18 @@ mod tests {
             .unwrap();
 
         let mut data = Vec::with_capacity(1024);
-        serialize_entry(&Entry::Tree(tree_id), &mut data, &storage, &mut stats).unwrap();
+        serialize_entry(
+            &Entry::Tree(tree_id),
+            fake_hash_id,
+            &mut data,
+            &storage,
+            &mut stats,
+            &mut batch,
+            &mut older_entries,
+        )
+        .unwrap();
 
-        let entry = deserialize(&data, &mut storage).unwrap();
+        let entry = deserialize(&data, &mut storage, &repo).unwrap();
 
         if let Entry::Tree(entry) = entry {
             assert_eq!(
@@ -524,12 +785,23 @@ mod tests {
         let iter = iter_hash_ids(&data);
         assert_eq!(iter.map(|h| h.as_u32()).collect::<Vec<_>>(), &[3, 1, 2]);
 
+        // Test Entry::Blob
+
         // Not inlined value
         let blob_id = storage.add_blob_by_ref(&[1, 2, 3, 4, 5, 6, 7, 8]).unwrap();
 
         let mut data = Vec::with_capacity(1024);
-        serialize_entry(&Entry::Blob(blob_id), &mut data, &storage, &mut stats).unwrap();
-        let entry = deserialize(&data, &mut storage).unwrap();
+        serialize_entry(
+            &Entry::Blob(blob_id),
+            fake_hash_id,
+            &mut data,
+            &storage,
+            &mut stats,
+            &mut batch,
+            &mut older_entries,
+        )
+        .unwrap();
+        let entry = deserialize(&data, &mut storage, &repo).unwrap();
         if let Entry::Blob(entry) = entry {
             let blob = storage.get_blob(entry).unwrap();
             assert_eq!(blob.as_ref(), &[1, 2, 3, 4, 5, 6, 7, 8]);
@@ -538,6 +810,8 @@ mod tests {
         }
         let iter = iter_hash_ids(&data);
         assert_eq!(iter.count(), 0);
+
+        // Test Entry::Commit
 
         let mut data = Vec::with_capacity(1024);
 
@@ -551,12 +825,15 @@ mod tests {
 
         serialize_entry(
             &Entry::Commit(Box::new(commit.clone())),
+            fake_hash_id,
             &mut data,
             &storage,
             &mut stats,
+            &mut batch,
+            &mut older_entries,
         )
         .unwrap();
-        let entry = deserialize(&data, &mut storage).unwrap();
+        let entry = deserialize(&data, &mut storage, &repo).unwrap();
         if let Entry::Commit(entry) = entry {
             assert_eq!(*entry, commit);
         } else {
@@ -565,6 +842,132 @@ mod tests {
 
         let iter = iter_hash_ids(&data);
         assert_eq!(iter.map(|h| h.as_u32()).collect::<Vec<_>>(), &[12345]);
+
+        // Test Inode::Tree
+
+        let mut pointers: [Option<PointerToInode>; 32] = Default::default();
+
+        for index in 0..pointers.len() {
+            let inode_value = Inode::Directory(TreeStorageId::empty());
+            let inode_value_id = storage.add_inode(inode_value).unwrap();
+
+            let hash_id = HashId::new((index + 1) as u32).unwrap();
+
+            repo.write_batch(vec![(hash_id, Arc::new([ID_INODE_DIRECTORY]))])
+                .unwrap();
+
+            pointers[index] = Some(PointerToInode::new(Some(hash_id), inode_value_id));
+        }
+
+        let inode = Inode::Pointers {
+            depth: 100,
+            nchildren: 200,
+            npointers: 250,
+            pointers,
+        };
+
+        let inode_id = storage.add_inode(inode).unwrap();
+
+        let hash_id = HashId::new(123).unwrap();
+        batch.clear();
+        serialize_inode(
+            inode_id,
+            &mut data,
+            hash_id,
+            &storage,
+            &mut stats,
+            &mut batch,
+            &mut older_entries,
+        )
+        .unwrap();
+
+        let new_inode_id = deserialize_inode(&batch[0].1, &mut storage, &repo).unwrap();
+        let new_inode = storage.get_inode(new_inode_id).unwrap();
+
+        if let Inode::Pointers {
+            depth,
+            nchildren,
+            npointers,
+            pointers,
+        } = new_inode
+        {
+            assert_eq!(*depth, 100);
+            assert_eq!(*nchildren, 200);
+            assert_eq!(*npointers, 250);
+
+            for (index, pointer) in pointers.iter().enumerate() {
+                let pointer = pointer.as_ref().unwrap();
+                let hash_id = pointer.hash_id().unwrap();
+                assert_eq!(hash_id.as_u32() as usize, index + 1);
+
+                let inode = storage.get_inode(pointer.inode_id()).unwrap();
+                match inode {
+                    Inode::Directory(tree_id) => assert!(tree_id.is_empty()),
+                    _ => panic!(),
+                }
+            }
+        } else {
+            panic!()
+        }
+
+        let iter = iter_hash_ids(&batch[0].1);
+        assert_eq!(
+            iter.map(|h| h.as_u32()).collect::<Vec<_>>(),
+            (1..33).collect::<Vec<_>>()
+        );
+
+        // Test Inode::Value
+
+        let tree_id = TreeStorageId::empty();
+        let tree_id = storage
+            .tree_insert(
+                tree_id,
+                "a",
+                Node::new_commited(NodeKind::Leaf, HashId::new(1), None),
+            )
+            .unwrap();
+        let tree_id = storage
+            .tree_insert(
+                tree_id,
+                "bab",
+                Node::new_commited(NodeKind::Leaf, HashId::new(2), None),
+            )
+            .unwrap();
+        let tree_id = storage
+            .tree_insert(
+                tree_id,
+                "0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                Node::new_commited(NodeKind::Leaf, HashId::new(3), None),
+            )
+            .unwrap();
+
+        let inode = Inode::Directory(tree_id);
+        let inode_id = storage.add_inode(inode).unwrap();
+
+        batch.clear();
+        serialize_inode(
+            inode_id,
+            &mut data,
+            hash_id,
+            &storage,
+            &mut stats,
+            &mut batch,
+            &mut older_entries,
+        )
+        .unwrap();
+
+        let new_inode_id = deserialize_inode(&batch[0].1, &mut storage, &repo).unwrap();
+        let new_inode = storage.get_inode(new_inode_id).unwrap();
+
+        if let Inode::Directory(new_tree_id) = new_inode {
+            assert_eq!(
+                storage.get_owned_tree(tree_id).unwrap(),
+                storage.get_owned_tree(*new_tree_id).unwrap()
+            )
+        }
+
+        let iter = iter_hash_ids(&batch[0].1);
+        assert_eq!(iter.map(|h| h.as_u32()).collect::<Vec<_>>(), &[3, 1, 2]);
     }
 
     #[test]
@@ -572,6 +975,10 @@ mod tests {
         let mut repo = InMemory::try_new().expect("failed to create context");
         let mut storage = Storage::new();
         let mut stats = SerializeStats::default();
+        let mut batch = Vec::new();
+        let mut older_entries = Vec::new();
+
+        let fake_hash_id = HashId::try_from(1).unwrap();
 
         let blob_id = storage.add_blob_by_ref(&[]).unwrap();
         let blob = Entry::Blob(blob_id);
@@ -581,7 +988,7 @@ mod tests {
 
         let tree_id = TreeStorageId::empty();
         let tree_id = storage
-            .insert(
+            .tree_insert(
                 tree_id,
                 "a",
                 Node::new_commited(NodeKind::Leaf, blob_hash_id, None),
@@ -589,9 +996,19 @@ mod tests {
             .unwrap();
 
         let mut data = Vec::with_capacity(1024);
-        serialize_entry(&Entry::Tree(tree_id), &mut data, &storage, &mut stats).unwrap();
 
-        let entry = deserialize(&data, &mut storage).unwrap();
+        serialize_entry(
+            &Entry::Tree(tree_id),
+            fake_hash_id,
+            &mut data,
+            &storage,
+            &mut stats,
+            &mut batch,
+            &mut older_entries,
+        )
+        .unwrap();
+
+        let entry = deserialize(&data, &mut storage, &repo).unwrap();
 
         if let Entry::Tree(entry) = entry {
             assert_eq!(

--- a/tezos/new_context/src/working_tree/storage.rs
+++ b/tezos/new_context/src/working_tree/storage.rs
@@ -2,30 +2,63 @@
 // SPDX-License-Identifier: MIT
 
 use std::{
+    cell::Cell,
     cmp::Ordering,
     convert::{TryFrom, TryInto},
     mem::size_of,
+    ops::Range,
 };
 
 use modular_bitfield::prelude::*;
 use static_assertions::assert_eq_size;
 use tezos_timing::StorageMemoryUsage;
 
-use crate::kv_store::entries::Entries;
+use crate::hash::index as index_of_key;
+use crate::kv_store::{entries::Entries, HashId};
 
 use super::{
     string_interner::{StringId, StringInterner},
+    working_tree::MerkleError,
     Node,
 };
 
-#[bitfield]
+/// Threshold when a tree must be an `Inode`
+const TREE_INODE_THRESHOLD: usize = 256;
+
+/// Threshold when a `Inode::Tree` must be converted to a another `Inode::Pointers`
+const INODE_POINTER_THRESHOLD: usize = 32;
+
+// Bitsmaks used on ids/indexes
+const FULL_60_BITS: usize = 0xFFFFFFFFFFFFFFF;
+const FULL_56_BITS: usize = 0xFFFFFFFFFFFFFF;
+const FULL_32_BITS: usize = 0xFFFFFFFF;
+const FULL_31_BITS: usize = 0x7FFFFFFF;
+const FULL_28_BITS: usize = 0xFFFFFFF;
+const FULL_4_BITS: usize = 0xF;
+
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TreeStorageId {
     /// Note: Must fit in NodeInner.entry_id (61 bits)
-    #[skip]
-    __unused: B14,
-    start: B30,
-    length: B20,
+    ///
+    /// | 3 bits |  1 bit   | 60 bits |
+    /// |--------|----------|---------|
+    /// | empty  | is_inode | value   |
+    ///
+    /// value not inode:
+    /// | 32 bits | 28 bits |
+    /// |---------|---------|
+    /// | start   | length  |
+    ///
+    /// value inode:
+    /// | 60 bits    |
+    /// |------------|
+    /// | an InodeId |
+    ///
+    /// Note that the `InodeId` here can only be the root of an `Inode`.
+    /// A `TreeStorageId` never contains an `InodeId` other than a root.
+    /// The working tree doesn't have knowledge of inodes, it's an implementation
+    /// detail of the `Storage`
+    bits: u64,
 }
 
 impl Default for TreeStorageId {
@@ -35,35 +68,75 @@ impl Default for TreeStorageId {
 }
 
 impl TreeStorageId {
-    fn try_new_tree(start: usize, end: usize) -> Result<Self, StorageIdError> {
+    fn try_new_tree(start: usize, end: usize) -> Result<Self, StorageError> {
         let length = end
             .checked_sub(start)
-            .ok_or(StorageIdError::TreeInvalidStartEnd)?;
+            .ok_or(StorageError::TreeInvalidStartEnd)?;
 
-        if start & !0x3FFFFFFF != 0 {
-            // Must fit in 30 bits
-            return Err(StorageIdError::TreeStartTooBig);
+        if start & !FULL_32_BITS != 0 {
+            // Must fit in 32 bits
+            return Err(StorageError::TreeStartTooBig);
         }
 
-        if length & !0xFFFFF != 0 {
-            // Must fit in 20 bits
-            return Err(StorageIdError::TreeLengthTooBig);
+        if length & !FULL_28_BITS != 0 {
+            // Must fit in 28 bits
+            return Err(StorageError::TreeLengthTooBig);
         }
 
-        let tree_id = Self::new()
-            .with_start(start as u32)
-            .with_length(length as u32);
+        let tree_id = Self {
+            bits: (start as u64) << 28 | length as u64,
+        };
 
         debug_assert_eq!(tree_id.get(), (start as usize, end));
 
         Ok(tree_id)
     }
 
+    fn try_new_inode(index: usize) -> Result<Self, StorageError> {
+        if index & !FULL_60_BITS != 0 {
+            // Must fit in 60 bits
+            return Err(StorageError::InodeIndexTooBig);
+        }
+
+        Ok(Self {
+            bits: 1 << 60 | index as u64,
+        })
+    }
+
+    pub fn is_inode(&self) -> bool {
+        self.bits >> 60 != 0
+    }
+
+    pub fn get_inode_id(self) -> Option<InodeId> {
+        if self.is_inode() {
+            Some(InodeId(self.get_inode_index() as u32))
+        } else {
+            None
+        }
+    }
+
     fn get(self) -> (usize, usize) {
-        let start = self.start() as usize;
-        let length = self.length() as usize;
+        debug_assert!(!self.is_inode());
+
+        let start = (self.bits as usize) >> FULL_28_BITS.count_ones();
+        let length = (self.bits as usize) & FULL_28_BITS;
 
         (start, start + length)
+    }
+
+    /// Return the length of the small tree.
+    ///
+    /// Use `Storage::tree_len` to get the length of all trees (including inodes)
+    fn small_tree_len(self) -> usize {
+        debug_assert!(!self.is_inode());
+
+        (self.bits as usize) & FULL_28_BITS
+    }
+
+    fn get_inode_index(self) -> usize {
+        debug_assert!(self.is_inode());
+
+        self.bits as usize & FULL_60_BITS
     }
 
     pub fn empty() -> Self {
@@ -72,39 +145,54 @@ impl TreeStorageId {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.length() == 0
+        if self.is_inode() {
+            return false;
+        }
+
+        self.small_tree_len() == 0
     }
 }
 
 impl From<TreeStorageId> for u64 {
     fn from(tree_id: TreeStorageId) -> Self {
-        let bytes = tree_id.into_bytes();
-        u64::from_ne_bytes(bytes)
+        tree_id.bits
     }
 }
 
 impl From<u64> for TreeStorageId {
     fn from(entry_id: u64) -> Self {
-        Self::from_bytes(entry_id.to_ne_bytes())
+        Self { bits: entry_id }
+    }
+}
+
+impl From<InodeId> for TreeStorageId {
+    fn from(inode_id: InodeId) -> Self {
+        // Never fails, `InodeId` is 31 bits, `TreeStorageId` expects 60 bits max
+        Self::try_new_inode(inode_id.0 as usize).unwrap()
     }
 }
 
 #[derive(Debug)]
-pub enum StorageIdError {
+pub enum StorageError {
     BlobSliceTooBig,
     BlobStartTooBig,
     BlobLengthTooBig,
     TreeInvalidStartEnd,
     TreeStartTooBig,
     TreeLengthTooBig,
+    InodeIndexTooBig,
     NodeIdError,
     StringNotFound,
     TreeNotFound,
     BlobNotFound,
     NodeNotFound,
+    InodeNotFound,
+    ExpectingTreeGotInode,
+    IterationError,
+    RootOfInodeNotAPointer,
 }
 
-impl From<NodeIdError> for StorageIdError {
+impl From<NodeIdError> for StorageError {
     fn from(_: NodeIdError) -> Self {
         Self::NodeIdError
     }
@@ -149,12 +237,12 @@ enum BlobRef {
 }
 
 impl BlobStorageId {
-    fn try_new_inline(value: &[u8]) -> Result<Self, StorageIdError> {
+    fn try_new_inline(value: &[u8]) -> Result<Self, StorageError> {
         let len = value.len();
 
         // Inline values are 7 bytes maximum
         if len > 7 {
-            return Err(StorageIdError::BlobSliceTooBig);
+            return Err(StorageError::BlobSliceTooBig);
         }
 
         // We copy the slice into an array so we can use u64::from_ne_bytes
@@ -177,17 +265,17 @@ impl BlobStorageId {
         Ok(blob_id)
     }
 
-    fn try_new(start: usize, end: usize) -> Result<Self, StorageIdError> {
+    fn try_new(start: usize, end: usize) -> Result<Self, StorageError> {
         let length = end - start;
 
-        if start & !0xFFFFFFFF != 0 {
+        if start & !FULL_32_BITS != 0 {
             // Start must fit in 32 bits
-            return Err(StorageIdError::BlobStartTooBig);
+            return Err(StorageError::BlobStartTooBig);
         }
 
-        if length & !0xFFFFFFF != 0 {
+        if length & !FULL_28_BITS != 0 {
             // Length must fit in 28 bits
-            return Err(StorageIdError::BlobLengthTooBig);
+            return Err(StorageError::BlobLengthTooBig);
         }
 
         let blob_id = Self {
@@ -201,17 +289,17 @@ impl BlobStorageId {
 
     fn get(self) -> BlobRef {
         if self.is_inline() {
-            let length = ((self.bits >> 56) & 0xF) as u8;
+            let length = ((self.bits >> 56) & FULL_4_BITS as u64) as u8;
 
             // Extract the inline value and make it a slice
-            let value: u64 = self.bits & 0xFFFFFFFFFFFFFF;
+            let value: u64 = self.bits & FULL_56_BITS as u64;
             let value: [u8; 8] = value.to_ne_bytes();
             let value: [u8; 7] = value[..7].try_into().unwrap(); // Never fails, `value` is [u8; 8]
 
             BlobRef::Inline { length, value }
         } else {
-            let start = (self.bits >> 28) as usize;
-            let length = (self.bits & 0xFFFFFFF) as usize;
+            let start = (self.bits >> FULL_28_BITS.count_ones()) as usize;
+            let length = self.bits as usize & FULL_28_BITS;
 
             BlobRef::Ref {
                 start,
@@ -247,6 +335,96 @@ impl TryFrom<usize> for NodeId {
     }
 }
 
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
+pub struct InodeId(u32);
+
+#[bitfield]
+#[derive(Clone, Copy, Debug)]
+pub struct PointerToInodeInner {
+    hash_id: B32,
+    is_commited: bool,
+    inode_id: B31,
+}
+
+#[derive(Clone, Debug)]
+pub struct PointerToInode {
+    inner: Cell<PointerToInodeInner>,
+}
+
+impl PointerToInode {
+    pub fn new(hash_id: Option<HashId>, inode_id: InodeId) -> Self {
+        Self {
+            inner: Cell::new(
+                PointerToInodeInner::new()
+                    .with_hash_id(hash_id.map(|h| h.as_u32()).unwrap_or(0))
+                    .with_is_commited(false)
+                    .with_inode_id(inode_id.0),
+            ),
+        }
+    }
+
+    pub fn new_commited(hash_id: Option<HashId>, inode_id: InodeId) -> Self {
+        Self {
+            inner: Cell::new(
+                PointerToInodeInner::new()
+                    .with_hash_id(hash_id.map(|h| h.as_u32()).unwrap_or(0))
+                    .with_is_commited(true)
+                    .with_inode_id(inode_id.0),
+            ),
+        }
+    }
+
+    pub fn inode_id(&self) -> InodeId {
+        let inner = self.inner.get();
+        let inode_id = inner.inode_id();
+
+        InodeId(inode_id)
+    }
+
+    pub fn hash_id(&self) -> Option<HashId> {
+        let inner = self.inner.get();
+        let hash_id = inner.hash_id();
+
+        HashId::new(hash_id)
+    }
+
+    pub fn set_hash_id(&self, hash_id: Option<HashId>) {
+        let mut inner = self.inner.get();
+        inner.set_hash_id(hash_id.map(|h| h.as_u32()).unwrap_or(0));
+
+        self.inner.set(inner);
+    }
+
+    pub fn is_commited(&self) -> bool {
+        let inner = self.inner.get();
+        inner.is_commited()
+    }
+}
+
+assert_eq_size!([u8; 9], Option<PointerToInode>);
+
+/// Inode representation used for hashing directories with > TREE_INODE_THRESHOLD entries.
+#[allow(clippy::large_enum_variant)]
+#[derive(Clone, Debug)]
+pub enum Inode {
+    /// Directory is a list of (StringId, NodeId)
+    Directory(TreeStorageId),
+    Pointers {
+        depth: u32,
+        nchildren: u32,
+        npointers: u8,
+        /// List of pointers to Inode
+        /// When the pointer is `None`, it means that there is no entries
+        /// under that index.
+        pointers: [Option<PointerToInode>; 32],
+    },
+}
+
+assert_eq_size!([u8; 304], Inode);
+
+/// A range inside `Storage::temp_tree`
+type TempTreeRange = Range<usize>;
+
 /// `Storage` contains all the data from the working tree.
 ///
 /// This is where all trees/blobs/strings are allocated.
@@ -275,6 +453,13 @@ pub struct Storage {
     /// Concatenation of all strings in the working tree.
     /// The working tree has `StringId` which refers to a data inside `StringInterner`.
     strings: StringInterner,
+    /// Concatenation of all inodes.
+    /// Note that the implementation of `Storage` attempt to hide as much as
+    /// possible the existence of inodes to the working tree.
+    /// The working tree doesn't manipulate `InodeId` but `TreeStorageId` only.
+    /// A `TreeStorageId` might contains an `INodeId` but it's only the root
+    /// of an Inode, any children of that root are not visible to the working tree.
+    inodes: Vec<Inode>,
 }
 
 #[derive(Debug)]
@@ -308,6 +493,9 @@ impl Default for Storage {
     }
 }
 
+// Whether or not a non-existing key was added to the inode
+type IsNewKey = bool;
+
 impl Storage {
     pub fn new() -> Self {
         Self {
@@ -316,6 +504,7 @@ impl Storage {
             blobs: Vec::with_capacity(2048),
             strings: Default::default(),
             nodes: Entries::with_capacity(2048),
+            inodes: Vec::with_capacity(256),
         }
     }
 
@@ -324,11 +513,13 @@ impl Storage {
         let trees_cap = self.trees.capacity();
         let blobs_cap = self.blobs.capacity();
         let temp_tree_cap = self.temp_tree.capacity();
+        let inodes_cap = self.inodes.capacity();
         let strings = self.strings.memory_usage();
         let total_bytes = (nodes_cap * size_of::<Node>())
             .saturating_add(trees_cap * size_of::<(StringId, NodeId)>())
             .saturating_add(temp_tree_cap * size_of::<(StringId, NodeId)>())
             .saturating_add(blobs_cap)
+            .saturating_add(inodes_cap * size_of::<Inode>())
             .saturating_add(strings.total_bytes);
 
         StorageMemoryUsage {
@@ -339,6 +530,8 @@ impl Storage {
             temp_tree_cap,
             blobs_len: self.blobs.len(),
             blobs_cap,
+            inodes_len: self.inodes.len(),
+            inodes_cap,
             strings,
             total_bytes,
         }
@@ -348,13 +541,13 @@ impl Storage {
         self.strings.get_string_id(s)
     }
 
-    pub fn get_str(&self, string_id: StringId) -> Result<&str, StorageIdError> {
+    pub fn get_str(&self, string_id: StringId) -> Result<&str, StorageError> {
         self.strings
             .get(string_id)
-            .ok_or(StorageIdError::StringNotFound)
+            .ok_or(StorageError::StringNotFound)
     }
 
-    pub fn add_blob_by_ref(&mut self, blob: &[u8]) -> Result<BlobStorageId, StorageIdError> {
+    pub fn add_blob_by_ref(&mut self, blob: &[u8]) -> Result<BlobStorageId, StorageError> {
         // Do not consider blobs of length zero as inlined, this never
         // happens when the node is running and fix a serialization issue
         // during testing/fuzzing
@@ -369,41 +562,48 @@ impl Storage {
         }
     }
 
-    pub fn get_blob(&self, blob_id: BlobStorageId) -> Result<Blob, StorageIdError> {
+    pub fn get_blob(&self, blob_id: BlobStorageId) -> Result<Blob, StorageError> {
         match blob_id.get() {
             BlobRef::Inline { length, value } => Ok(Blob::Inline { length, value }),
             BlobRef::Ref { start, end } => {
                 let blob = match self.blobs.get(start..end) {
                     Some(blob) => blob,
-                    None => return Err(StorageIdError::BlobNotFound),
+                    None => return Err(StorageError::BlobNotFound),
                 };
                 Ok(Blob::Ref { blob })
             }
         }
     }
 
-    pub fn get_node(&self, node_id: NodeId) -> Result<&Node, StorageIdError> {
-        self.nodes.get(node_id)?.ok_or(StorageIdError::NodeNotFound)
+    pub fn get_node(&self, node_id: NodeId) -> Result<&Node, StorageError> {
+        self.nodes.get(node_id)?.ok_or(StorageError::NodeNotFound)
     }
 
     pub fn add_node(&mut self, node: Node) -> Result<NodeId, NodeIdError> {
         self.nodes.push(node).map_err(|_| NodeIdError)
     }
 
-    pub fn get_tree(
+    /// Return the small tree `tree_id`.
+    ///
+    /// This returns an error when the underlying tree is an Inode.
+    /// To iterate/access all trees (including inodes), `Self::tree_iterate_unsorted`
+    /// and `Self::tree_to_vec_unsorted` must be used.
+    pub fn get_small_tree(
         &self,
         tree_id: TreeStorageId,
-    ) -> Result<&[(StringId, NodeId)], StorageIdError> {
+    ) -> Result<&[(StringId, NodeId)], StorageError> {
+        if tree_id.is_inode() {
+            return Err(StorageError::ExpectingTreeGotInode);
+        }
+
         let (start, end) = tree_id.get();
-        self.trees
-            .get(start..end)
-            .ok_or(StorageIdError::TreeNotFound)
+        self.trees.get(start..end).ok_or(StorageError::TreeNotFound)
     }
 
+    /// [test only] Return the tree with owned values
     #[cfg(test)]
     pub fn get_owned_tree(&self, tree_id: TreeStorageId) -> Option<Vec<(String, Node)>> {
-        let (start, end) = tree_id.get();
-        let tree = self.trees.get(start..end)?;
+        let tree = self.tree_to_vec_sorted(tree_id).unwrap();
 
         Some(
             tree.iter()
@@ -416,11 +616,11 @@ impl Storage {
         )
     }
 
-    fn find_in_tree(
+    fn binary_search_in_tree(
         &self,
         tree: &[(StringId, NodeId)],
         key: &str,
-    ) -> Result<Result<usize, usize>, StorageIdError> {
+    ) -> Result<Result<usize, usize>, StorageError> {
         let mut error = None;
 
         let result = tree.binary_search_by(|value| match self.get_str(value.0) {
@@ -439,17 +639,39 @@ impl Storage {
         Ok(result)
     }
 
-    pub fn get_tree_node_id(&self, tree_id: TreeStorageId, key: &str) -> Option<NodeId> {
-        let tree = self.get_tree(tree_id).ok()?;
-        let index = self.find_in_tree(tree, key).ok()?.ok()?;
+    fn tree_find_node_recursive(&self, inode_id: InodeId, key: &str) -> Option<NodeId> {
+        let inode = self.get_inode(inode_id).ok()?;
 
-        Some(tree[index].1)
+        match inode {
+            Inode::Directory(tree_id) => self.tree_find_node(*tree_id, key),
+            Inode::Pointers {
+                depth, pointers, ..
+            } => {
+                let index_at_depth = index_of_key(*depth, key) as usize;
+
+                let pointer = pointers.get(index_at_depth)?.as_ref()?;
+
+                let inode_id = pointer.inode_id();
+                self.tree_find_node_recursive(inode_id, key)
+            }
+        }
     }
 
-    pub fn add_tree(
+    pub fn tree_find_node(&self, tree_id: TreeStorageId, key: &str) -> Option<NodeId> {
+        if let Some(inode_id) = tree_id.get_inode_id() {
+            self.tree_find_node_recursive(inode_id, key)
+        } else {
+            let tree = self.get_small_tree(tree_id).ok()?;
+            let index = self.binary_search_in_tree(tree, key).ok()?.ok()?;
+
+            Some(tree[index].1)
+        }
+    }
+
+    pub fn append_to_trees(
         &mut self,
         new_tree: &mut Vec<(StringId, NodeId)>,
-    ) -> Result<TreeStorageId, StorageIdError> {
+    ) -> Result<TreeStorageId, StorageError> {
         let start = self.trees.len();
         self.trees.append(new_tree);
         let end = self.trees.len();
@@ -471,25 +693,388 @@ impl Storage {
         result
     }
 
-    pub fn insert(
+    pub(super) fn add_inode(&mut self, inode: Inode) -> Result<InodeId, StorageError> {
+        let current = self.inodes.len();
+        self.inodes.push(inode);
+
+        if current & !FULL_31_BITS != 0 {
+            // Must fit in 31 bits (See PointerToInode)
+            return Err(StorageError::InodeIndexTooBig);
+        }
+
+        Ok(InodeId(current as u32))
+    }
+
+    /// Copy tree from `Self::temp_tree` into `Self::trees` in a sorted order.
+    ///
+    /// `tree_range` is the range of the tree in `Self::temp_tree`
+    fn copy_sorted(&mut self, tree_range: TempTreeRange) -> Result<TreeStorageId, StorageError> {
+        let start = self.trees.len();
+
+        for (key_id, node_id) in &self.temp_tree[tree_range] {
+            let key_str = self.get_str(*key_id)?;
+            let tree = &self.trees[start..];
+
+            match self.binary_search_in_tree(tree, key_str)? {
+                Ok(found) => {
+                    self.trees[start + found].1 = *node_id;
+                }
+                Err(index) => {
+                    self.trees.insert(start + index, (*key_id, *node_id));
+                }
+            }
+        }
+
+        let end = self.trees.len();
+        TreeStorageId::try_new_tree(start, end)
+    }
+
+    fn with_temp_tree_range<Fun>(&mut self, mut fun: Fun) -> Result<TempTreeRange, StorageError>
+    where
+        Fun: FnMut(&mut Self) -> Result<(), StorageError>,
+    {
+        let start = self.temp_tree.len();
+        fun(self)?;
+        let end = self.temp_tree.len();
+
+        Ok(TempTreeRange { start, end })
+    }
+
+    fn create_inode(
+        &mut self,
+        depth: u32,
+        tree_range: TempTreeRange,
+    ) -> Result<InodeId, StorageError> {
+        let tree_range_len = tree_range.end - tree_range.start;
+
+        if tree_range_len <= INODE_POINTER_THRESHOLD {
+            // The tree in `tree_range` is not guaranted to be sorted.
+            // We use `Self::copy_sorted` to copy that tree into `Storage::trees` in
+            // a sorted order.
+
+            let new_tree_id = self.copy_sorted(tree_range)?;
+
+            self.add_inode(Inode::Directory(new_tree_id))
+        } else {
+            let nchildren = tree_range_len as u32;
+            let mut pointers: [Option<PointerToInode>; 32] = Default::default();
+            let mut npointers = 0;
+
+            for index in 0..32u8 {
+                let range = self.with_temp_tree_range(|this| {
+                    for i in tree_range.clone() {
+                        let (key_id, node_id) = this.temp_tree[i];
+                        let key = this.get_str(key_id)?;
+                        if index_of_key(depth, key) as u8 == index {
+                            this.temp_tree.push((key_id, node_id));
+                        }
+                    }
+                    Ok(())
+                })?;
+
+                if range.is_empty() {
+                    continue;
+                }
+
+                npointers += 1;
+                let inode_id = self.create_inode(depth + 1, range)?;
+
+                pointers[index as usize] = Some(PointerToInode::new(None, inode_id));
+            }
+
+            self.add_inode(Inode::Pointers {
+                depth,
+                nchildren,
+                npointers,
+                pointers,
+            })
+        }
+    }
+
+    fn insert_tree_single_node(
+        &mut self,
+        key_id: StringId,
+        node: Node,
+    ) -> Result<TempTreeRange, StorageError> {
+        let node_id = self.nodes.push(node)?;
+
+        self.with_temp_tree_range(|this| {
+            this.temp_tree.push((key_id, node_id));
+            Ok(())
+        })
+    }
+
+    /// Copy tree `tree_id` from `Self::trees` into `Self::temp_Tree`
+    ///
+    /// Note: The callers of this function expect the tree to be copied
+    ///       at the end of `Self::temp_tree`. This is something to keep in mind
+    ///       if the implementation of this function change
+    fn copy_tree_in_temp_tree(
+        &mut self,
+        tree_id: TreeStorageId,
+    ) -> Result<TempTreeRange, StorageError> {
+        let (tree_start, tree_end) = tree_id.get();
+
+        self.with_temp_tree_range(|this| {
+            this.temp_tree
+                .extend_from_slice(&this.trees[tree_start..tree_end]);
+            Ok(())
+        })
+    }
+
+    fn insert_inode(
+        &mut self,
+        depth: u32,
+        inode_id: InodeId,
+        key: &str,
+        key_id: StringId,
+        node: Node,
+    ) -> Result<(InodeId, IsNewKey), StorageError> {
+        let inode = self.get_inode(inode_id)?;
+
+        match inode {
+            Inode::Directory(tree_id) => {
+                let tree_id = *tree_id;
+                let node_id = self.add_node(node)?;
+
+                // Copy the existing tree into `Self::temp_tree` to create an inode
+                let range = self.with_temp_tree_range(|this| {
+                    let range = this.copy_tree_in_temp_tree(tree_id)?;
+
+                    // We're using `Vec::insert` below and we don't want to invalidate
+                    // any existing `TempTreeRange`
+                    debug_assert_eq!(range.end, this.temp_tree.len());
+
+                    let start = range.start;
+                    match this.binary_search_in_tree(&this.temp_tree[range], key)? {
+                        Ok(found) => this.temp_tree[start + found] = (key_id, node_id),
+                        Err(index) => this.temp_tree.insert(start + index, (key_id, node_id)),
+                    }
+
+                    Ok(())
+                })?;
+
+                let new_inode_id = self.create_inode(depth, range)?;
+                let is_new_key = self.inode_len(new_inode_id)? != tree_id.small_tree_len();
+
+                Ok((new_inode_id, is_new_key))
+            }
+            Inode::Pointers {
+                depth,
+                nchildren,
+                mut npointers,
+                pointers,
+            } => {
+                let mut pointers = pointers.clone();
+                let nchildren = *nchildren;
+                let depth = *depth;
+
+                let index_at_depth = index_of_key(depth, key) as usize;
+
+                let (inode_id, is_new_key) = if let Some(pointer) = &pointers[index_at_depth] {
+                    let inode_id = pointer.inode_id();
+                    self.insert_inode(depth + 1, inode_id, key, key_id, node)?
+                } else {
+                    npointers += 1;
+
+                    let new_tree_id = self.insert_tree_single_node(key_id, node)?;
+                    let inode_id = self.create_inode(depth, new_tree_id)?;
+                    (inode_id, true)
+                };
+
+                pointers[index_at_depth] = Some(PointerToInode::new(None, inode_id));
+
+                let inode_id = self.add_inode(Inode::Pointers {
+                    depth,
+                    nchildren: if is_new_key { nchildren + 1 } else { nchildren },
+                    npointers,
+                    pointers,
+                })?;
+
+                Ok((inode_id, is_new_key))
+            }
+        }
+    }
+
+    /// [test only] Remove hash ids in the inode and it's children
+    ///
+    /// This is used to force recomputing hashes
+    #[cfg(test)]
+    pub fn inodes_drop_hash_ids(&self, inode_id: InodeId) {
+        let inode = self.get_inode(inode_id).unwrap();
+
+        if let Inode::Pointers { pointers, .. } = inode {
+            for pointer in pointers.iter().filter_map(|p| p.as_ref()) {
+                pointer.set_hash_id(None);
+
+                let inode_id = pointer.inode_id();
+                self.inodes_drop_hash_ids(inode_id);
+            }
+        };
+    }
+
+    fn iter_inodes_recursive_unsorted<Fun>(
+        &self,
+        inode: &Inode,
+        fun: &mut Fun,
+    ) -> Result<(), MerkleError>
+    where
+        Fun: FnMut(&(StringId, NodeId)) -> Result<(), MerkleError>,
+    {
+        match inode {
+            Inode::Pointers { pointers, .. } => {
+                for pointer in pointers.iter().filter_map(|p| p.as_ref()) {
+                    let inode_id = pointer.inode_id();
+                    let inode = self.get_inode(inode_id)?;
+                    self.iter_inodes_recursive_unsorted(inode, fun)?;
+                }
+            }
+            Inode::Directory(tree_id) => {
+                let tree = self.get_small_tree(*tree_id)?;
+                for elem in tree {
+                    fun(elem)?;
+                }
+            }
+        };
+
+        Ok(())
+    }
+
+    /// Iterate on `tree_id`.
+    ///
+    /// The elements won't be sorted when the underlying tree is an `Inode`.
+    /// `Self::tree_to_vec_sorted` can be used to get the tree sorted.
+    pub fn tree_iterate_unsorted<Fun>(
+        &self,
+        tree_id: TreeStorageId,
+        mut fun: Fun,
+    ) -> Result<(), MerkleError>
+    where
+        Fun: FnMut(&(StringId, NodeId)) -> Result<(), MerkleError>,
+    {
+        if let Some(inode_id) = tree_id.get_inode_id() {
+            let inode = self.get_inode(inode_id)?;
+
+            self.iter_inodes_recursive_unsorted(inode, &mut fun)?;
+        } else {
+            let tree = self.get_small_tree(tree_id)?;
+            for elem in tree {
+                fun(elem)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn inode_len(&self, inode_id: InodeId) -> Result<usize, StorageError> {
+        let inode = self.get_inode(inode_id)?;
+        match inode {
+            Inode::Pointers {
+                nchildren: children,
+                ..
+            } => Ok(*children as usize),
+            Inode::Directory(tree_id) => Ok(tree_id.small_tree_len()),
+        }
+    }
+
+    /// Return the number of nodes in `tree_id`.
+    pub fn tree_len(&self, tree_id: TreeStorageId) -> Result<usize, StorageError> {
+        if let Some(inode_id) = tree_id.get_inode_id() {
+            self.inode_len(inode_id)
+        } else {
+            Ok(tree_id.small_tree_len())
+        }
+    }
+
+    /// Make a vector of `(StringId, NodeId)`
+    ///
+    /// The vector won't be sorted when the underlying tree is an Inode.
+    /// `Self::tree_to_vec_sorted` can be used to get the vector sorted.
+    pub fn tree_to_vec_unsorted(
+        &self,
+        tree_id: TreeStorageId,
+    ) -> Result<Vec<(StringId, NodeId)>, MerkleError> {
+        let mut vec = Vec::with_capacity(self.tree_len(tree_id)?);
+
+        self.tree_iterate_unsorted(tree_id, |&(key_id, node_id)| {
+            vec.push((key_id, node_id));
+            Ok(())
+        })?;
+
+        Ok(vec)
+    }
+
+    /// Make a vector of `(StringId, NodeId)` sorted by the key
+    ///
+    /// This is an expensive method when the underlying tree is an Inode,
+    /// `Self::tree_to_vec_unsorted` should be used when the ordering is
+    /// not important
+    pub fn tree_to_vec_sorted(
+        &self,
+        tree_id: TreeStorageId,
+    ) -> Result<Vec<(StringId, NodeId)>, MerkleError> {
+        if tree_id.get_inode_id().is_some() {
+            let mut tree = self.tree_to_vec_unsorted(tree_id)?;
+
+            let mut error = None;
+
+            tree.sort_unstable_by(|a, b| {
+                let a = match self.get_str(a.0) {
+                    Ok(a) => a,
+                    Err(e) => {
+                        error = Some(e);
+                        ""
+                    }
+                };
+
+                let b = match self.get_str(b.0) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        error = Some(e);
+                        ""
+                    }
+                };
+
+                a.cmp(b)
+            });
+
+            if let Some(e) = error {
+                return Err(e.into());
+            };
+
+            Ok(tree)
+        } else {
+            let tree = self.get_small_tree(tree_id)?;
+            Ok(tree.to_vec())
+        }
+    }
+
+    pub fn get_inode(&self, inode_id: InodeId) -> Result<&Inode, StorageError> {
+        self.inodes
+            .get(inode_id.0 as usize)
+            .ok_or(StorageError::InodeNotFound)
+    }
+
+    pub fn tree_insert(
         &mut self,
         tree_id: TreeStorageId,
         key_str: &str,
-        value: Node,
-    ) -> Result<TreeStorageId, StorageIdError> {
+        node: Node,
+    ) -> Result<TreeStorageId, StorageError> {
         let key_id = self.get_string_id(key_str);
-        let node_id = self.nodes.push(value)?;
 
-        self.with_new_tree(|this, new_tree| {
-            let tree = match this.get_tree(tree_id) {
-                Ok(tree) if !tree.is_empty() => tree,
-                _ => {
-                    new_tree.push((key_id, node_id));
-                    return this.add_tree(new_tree);
-                }
-            };
+        // Are we inserting in an Inode ?
+        if let Some(inode_id) = tree_id.get_inode_id() {
+            let (inode_id, _) = self.insert_inode(0, inode_id, key_str, key_id, node)?;
+            self.temp_tree.clear();
+            return Ok(inode_id.into());
+        }
 
-            let index = this.find_in_tree(tree, key_str)?;
+        let node_id = self.nodes.push(node)?;
+
+        let tree_id = self.with_new_tree(|this, new_tree| {
+            let tree = this.get_small_tree(tree_id)?;
+
+            let index = this.binary_search_in_tree(tree, key_str)?;
 
             match index {
                 Ok(found) => {
@@ -503,22 +1088,180 @@ impl Storage {
                 }
             }
 
-            this.add_tree(new_tree)
+            this.append_to_trees(new_tree)
+        })?;
+
+        // We only check at the end of this function if the new tree length
+        // is > TREE_INODE_THRESHOLD because inserting an element in a tree of length
+        // TREE_INODE_THRESHOLD doesn't necessary mean that the resulting tree will
+        // be bigger (if the key already exist).
+        let tree_len = tree_id.small_tree_len();
+
+        if tree_len <= TREE_INODE_THRESHOLD {
+            Ok(tree_id)
+        } else {
+            // Copy the new tree in `Self::temp_tree`.
+            let range = self.copy_tree_in_temp_tree(tree_id)?;
+            // Remove the newly created tree from `Self::trees` to save memory.
+            // It won't be used anymore as we're creating an inode.
+            self.trees.truncate(self.trees.len() - tree_len);
+
+            let inode_id = self.create_inode(0, range)?;
+            self.temp_tree.clear();
+
+            Ok(inode_id.into())
+        }
+    }
+
+    fn remove_in_inode_recursive(
+        &mut self,
+        inode_id: InodeId,
+        key: &str,
+    ) -> Result<Option<InodeId>, StorageError> {
+        let inode = self.get_inode(inode_id)?;
+
+        match inode {
+            Inode::Directory(tree_id) => {
+                let tree_id = *tree_id;
+                let new_tree_id = self.tree_remove(tree_id, key)?;
+
+                if new_tree_id.is_empty() {
+                    // The tree is now empty, return None to indicate that it
+                    // should be removed from the Inode::Pointers
+                    Ok(None)
+                } else if new_tree_id == tree_id {
+                    // The key was not found in the tree, so it's the same tree.
+                    // Do not create a new inode.
+                    Ok(Some(inode_id))
+                } else {
+                    self.add_inode(Inode::Directory(new_tree_id)).map(Some)
+                }
+            }
+            Inode::Pointers {
+                depth,
+                nchildren,
+                npointers,
+                pointers,
+            } => {
+                let depth = *depth;
+                let mut npointers = *npointers;
+                let nchildren = *nchildren;
+                let new_nchildren = nchildren - 1;
+
+                let new_inode_id = if new_nchildren as usize <= INODE_POINTER_THRESHOLD {
+                    // After removing an element from this `Inode::Pointers`, it remains
+                    // INODE_POINTER_THRESHOLD items, so it should be converted to a
+                    // `Inode::Directory`.
+
+                    let tree_id = self.inodes_to_tree_sorted(inode_id)?;
+                    let new_tree_id = self.tree_remove(tree_id, key)?;
+
+                    if tree_id == new_tree_id {
+                        // The key was not found.
+                        return Ok(Some(inode_id));
+                    }
+
+                    self.add_inode(Inode::Directory(new_tree_id))?
+                } else {
+                    let index_at_depth = index_of_key(depth, key) as usize;
+
+                    let pointer = match pointers[index_at_depth].as_ref() {
+                        Some(pointer) => pointer,
+                        None => return Ok(Some(inode_id)), // The key was not found
+                    };
+
+                    let ptr_inode_id = pointer.inode_id();
+                    let mut pointers = pointers.clone();
+
+                    let new_ptr_inode_id = self.remove_in_inode_recursive(ptr_inode_id, key)?;
+
+                    if let Some(new_ptr_inode_id) = new_ptr_inode_id {
+                        if new_ptr_inode_id == ptr_inode_id {
+                            // The key was not found, don't create a new inode
+                            return Ok(Some(inode_id));
+                        }
+
+                        pointers[index_at_depth] =
+                            Some(PointerToInode::new(None, new_ptr_inode_id));
+                    } else {
+                        // The key was removed and it result in an empty directory.
+                        // Remove the pointer: make it `None`.
+                        pointers[index_at_depth] = None;
+                        npointers -= 1;
+                    }
+
+                    self.add_inode(Inode::Pointers {
+                        depth,
+                        nchildren: new_nchildren,
+                        npointers,
+                        pointers,
+                    })?
+                };
+
+                Ok(Some(new_inode_id))
+            }
+        }
+    }
+
+    /// Convert the Inode into a small tree
+    ///
+    /// This traverses all elements (all children) of this `inode_id` and
+    /// copy them into `Self::trees` in a sorted order.
+    fn inodes_to_tree_sorted(&mut self, inode_id: InodeId) -> Result<TreeStorageId, StorageError> {
+        // Iterator on the inodes children and copy all nodes into `Self::temp_tree`
+        self.with_new_tree::<_, Result<_, StorageError>>(|this, temp_tree| {
+            let inode = this.get_inode(inode_id)?;
+
+            this.iter_inodes_recursive_unsorted(inode, &mut |value| {
+                temp_tree.push(*value);
+                Ok(())
+            })
+            .map_err(|_| StorageError::IterationError)?;
+
+            Ok(())
+        })?;
+
+        // Copy nodes from `Self::temp_tree` into `Self::trees` sorted
+        self.copy_sorted(TempTreeRange {
+            start: 0,
+            end: self.temp_tree.len(),
         })
     }
 
-    pub fn remove(
+    fn remove_in_inode(
+        &mut self,
+        inode_id: InodeId,
+        key: &str,
+    ) -> Result<TreeStorageId, StorageError> {
+        let inode_id = self.remove_in_inode_recursive(inode_id, key)?;
+        let inode_id = inode_id.ok_or(StorageError::RootOfInodeNotAPointer)?;
+
+        if self.inode_len(inode_id)? > TREE_INODE_THRESHOLD {
+            Ok(inode_id.into())
+        } else {
+            // There is now TREE_INODE_THRESHOLD or less items:
+            // Convert the inode into a 'small' tree
+            self.inodes_to_tree_sorted(inode_id)
+        }
+    }
+
+    pub fn tree_remove(
         &mut self,
         tree_id: TreeStorageId,
         key: &str,
-    ) -> Result<TreeStorageId, StorageIdError> {
-        self.with_new_tree(|this, new_tree| {
-            let tree = match this.get_tree(tree_id) {
-                Ok(tree) if !tree.is_empty() => tree,
-                _ => return Ok(tree_id),
-            };
+    ) -> Result<TreeStorageId, StorageError> {
+        if let Some(inode_id) = tree_id.get_inode_id() {
+            return self.remove_in_inode(inode_id, key);
+        };
 
-            let index = match this.find_in_tree(tree, key)? {
+        self.with_new_tree(|this, new_tree| {
+            let tree = this.get_small_tree(tree_id)?;
+
+            if tree.is_empty() {
+                return Ok(tree_id);
+            }
+
+            let index = match this.binary_search_in_tree(tree, key)? {
                 Ok(index) => index,
                 Err(_) => return Ok(tree_id),
             };
@@ -530,7 +1273,7 @@ impl Storage {
                 new_tree.extend_from_slice(&tree[index + 1..]);
             }
 
-            this.add_tree(new_tree)
+            this.append_to_trees(new_tree)
         })
     }
 
@@ -553,6 +1296,12 @@ impl Storage {
             self.trees = Vec::with_capacity(16384);
         } else {
             self.trees.clear();
+        }
+
+        if self.inodes.capacity() > 256 {
+            self.inodes = Vec::with_capacity(256);
+        } else {
+            self.inodes.clear();
         }
     }
 }
@@ -577,9 +1326,9 @@ mod tests {
         let node2 = Node::new(Leaf, entry2.clone());
 
         let tree_id = TreeStorageId::empty();
-        let tree_id = storage.insert(tree_id, "a", node1.clone()).unwrap();
-        let tree_id = storage.insert(tree_id, "b", node2.clone()).unwrap();
-        let tree_id = storage.insert(tree_id, "0", node1.clone()).unwrap();
+        let tree_id = storage.tree_insert(tree_id, "a", node1.clone()).unwrap();
+        let tree_id = storage.tree_insert(tree_id, "b", node2.clone()).unwrap();
+        let tree_id = storage.tree_insert(tree_id, "0", node1.clone()).unwrap();
 
         assert_eq!(
             storage.get_owned_tree(tree_id).unwrap(),

--- a/tezos/timing/src/lib.rs
+++ b/tezos/timing/src/lib.rs
@@ -78,6 +78,8 @@ pub struct StorageMemoryUsage {
     pub temp_tree_cap: usize,
     pub blobs_len: usize,
     pub blobs_cap: usize,
+    pub inodes_len: usize,
+    pub inodes_cap: usize,
     pub strings: StringsMemoryUsage,
     pub total_bytes: usize,
 }


### PR DESCRIPTION
https://viablesystems.atlassian.net/browse/TE-495

The inodes are now implemented in `Storage`.
The working tree is not aware that a tree/directory can be an inode so its logic doesn't change much.

I am planning to rename `tree -> directory` and add more documentations in another PR.


