### PR TITLE
Rework monitoring docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 /.git
 /target
 /docker
+/apps

--- a/apps/node_monitoring/.dockerignore
+++ b/apps/node_monitoring/.dockerignore
@@ -1,0 +1,2 @@
+/target
+/docker

--- a/apps/node_monitoring/Dockerfile
+++ b/apps/node_monitoring/Dockerfile
@@ -1,35 +1,34 @@
-ARG BASE_IMAGE=tezedge/tezedge-libs:latest
+# ARG BASE_IMAGE=tezedge/tezedge-libs:latest
 
-FROM tezedge/tezos-opam-builder:debian10 as build-env
+# FROM tezedge/tezos-opam-builder:debian10 as build-env
 
+FROM debian:10 as build-env
 USER root
-RUN apt-get update && apt-get install -y libssl-dev
+RUN apt-get update && apt-get install -y libssl-dev pkg-config libsodium-dev git curl
 
 # Checkout and compile tezedge source code
 ARG tezedge_git="https://github.com/tezedge/tezedge.git"
 ARG rust_toolchain="nightly-2020-12-31"
 ARG SOURCE_BRANCH
 RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain ${rust_toolchain} -y
-ENV PATH=/home/appuser/.cargo/bin:$PATH
-ENV RUST_BACKTRACE=1
+ENV PATH=/root/.cargo/bin:$PATH
 ENV SODIUM_USE_PKG_CONFIG=1
-ENV OCAML_BUILD_CHAIN=remote
-ARG RUSTFLAGS=""
-ENV OCAML_WHERE_PATH=/tmp/ocaml-includes
-RUN wget https://gitlab.com/tezedge/tezos/uploads/1bf4d1d130e75129be82a148149b04b3/libtezos-ffi-headers.tar.gz
-RUN mkdir -p $OCAML_WHERE_PATH; tar xvzf libtezos-ffi-headers.tar.gz -C $OCAML_WHERE_PATH
-RUN cd /home/appuser && git clone ${tezedge_git} --branch ${SOURCE_BRANCH} && cd tezedge && RUSTFLAGS=${RUSTFLAGS} && cd apps/node_monitoring && cargo build --release #7
+RUN apt-get install -y clang libclang-dev
+RUN git clone ${tezedge_git} --branch ${SOURCE_BRANCH} && cd tezedge && cd apps/node_monitoring && cargo build --release #7
 
-WORKDIR /home/appuser/tezedge
+# WORKDIR /home/appuser/tezedge
 
-FROM ${BASE_IMAGE} as light-node
+FROM debian:10
 
+USER root
+RUN apt-get update && apt-get install -y libssl-dev curl
 # Copy binaries
-COPY --from=build-env /home/appuser/tezedge/target/release/node-monitoring /
+COPY --from=build-env /tezedge/apps/node_monitoring/target/release/node-monitoring /node-monitoring
 
 # Copy shared libraries
 COPY --from=build-env /usr/lib/x86_64-linux-gnu/libssl.so.1.1 /usr/lib/x86_64-linux-gnu/libssl.so.1.1
 COPY --from=build-env /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1
+COPY --from=build-env /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
 
 # Default entry point runs monitoring with default config + several default values, which can be overriden by CMD
 ENTRYPOINT [ "/node-monitoring" ]


### PR DESCRIPTION
Fixes slack messaging in monitoring. Due to wrong docker image, monitoring was not able to send slack messages.  