### PR TITLE
Fix bug in the deletion of non-existing paths of the context tree.

### DIFF
--- a/tezos/lib_storage_ffi/src/lib.rs
+++ b/tezos/lib_storage_ffi/src/lib.rs
@@ -388,23 +388,41 @@ fn test_context_calls() {
         .as_secs();
 
     let tezedge_ctxt = context::checkout(cr, &tezedge_index, &tezedge_genesis_hash).unwrap();
+    let tezedge_ctxt = context::add(cr, &tezedge_ctxt, &key!("empty/value"), "".as_bytes());
     let tezedge_ctxt = context::add(cr, &tezedge_ctxt, &key!("some/path"), "value".as_bytes());
+    let tezedge_ctxt = context::remove(cr, &tezedge_ctxt, &key!("some/path/nested"));
     let tezedge_ctxt = context::add(cr, &tezedge_ctxt, &key!("some/path2"), "value".as_bytes());
     let tezedge_ctxt = context::remove(cr, &tezedge_ctxt, &key!("some/path2"));
     let tezedge_ctxt = context::add(cr, &tezedge_ctxt, &key!("some/path3"), "value".as_bytes());
     let tezedge_empty_tree = tree::empty(cr, &tezedge_ctxt);
     let tezedge_ctxt =
         context::add_tree(cr, &tezedge_ctxt, &key!("some/path3"), &tezedge_empty_tree);
+    let tezedge_ctxt = context::add(
+        cr,
+        &tezedge_ctxt,
+        &key!("some/path4/nest"),
+        "value".as_bytes(),
+    );
+    let tezedge_ctxt = context::add(cr, &tezedge_ctxt, &key!("some/path4"), "value".as_bytes());
     let tezedge_ctxt_hash = context::hash(cr, time as i64, None, &tezedge_ctxt);
     let tezedge_commit_hash = context::commit(cr, time as i64, &"commit", &tezedge_ctxt);
 
     let irmin_ctxt = context::checkout(cr, &irmin_index, &irmin_genesis_hash).unwrap();
+    let irmin_ctxt = context::add(cr, &irmin_ctxt, &key!("empty/value"), "".as_bytes());
     let irmin_ctxt = context::add(cr, &irmin_ctxt, &key!("some/path"), "value".as_bytes());
+    let irmin_ctxt = context::remove(cr, &irmin_ctxt, &key!("some/path/nested"));
     let irmin_ctxt = context::add(cr, &irmin_ctxt, &key!("some/path2"), "value".as_bytes());
     let irmin_ctxt = context::remove(cr, &irmin_ctxt, &key!("some/path2"));
     let irmin_ctxt = context::add(cr, &irmin_ctxt, &key!("some/path3"), "value".as_bytes());
     let irmin_empty_tree = tree::empty(cr, &irmin_ctxt);
     let irmin_ctxt = context::add_tree(cr, &irmin_ctxt, &key!("some/path3"), &irmin_empty_tree);
+    let irmin_ctxt = context::add(
+        cr,
+        &irmin_ctxt,
+        &key!("some/path4/nest"),
+        "value".as_bytes(),
+    );
+    let irmin_ctxt = context::add(cr, &irmin_ctxt, &key!("some/path4"), "value".as_bytes());
     let irmin_ctxt_hash = context::hash(cr, time as i64, None, &irmin_ctxt);
     let irmin_commit_hash = context::commit(cr, time as i64, &"commit", &irmin_ctxt);
 

--- a/tezos/new_context/src/working_tree/working_tree.rs
+++ b/tezos/new_context/src/working_tree/working_tree.rs
@@ -933,6 +933,12 @@ impl WorkingTree {
         let root = self.get_working_tree_root_ref();
         let tree = self.find_raw_tree(root, path, storage)?;
 
+        // If this was a deletion, and the path doesn't contain anything
+        // there is nothing to do. We don't want to recurse in this case.
+        if tree.is_empty() && new_node.is_none() {
+            return Ok(Entry::Tree(self.get_working_tree_root_ref()));
+        }
+
         let tree = match new_node {
             None => storage.remove(tree, last)?,
             Some(new_node) => storage.insert(tree, last, new_node)?,


### PR DESCRIPTION
Bug:

- ADD /some/path
- REMOVE /some/path/nested

This would remove all entries up to the root because at each point
an empty tree was found, which triggered the recursive deletion.