### PR TITLE
Fuzz target

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,6 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            default: true
+            override: true
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["named-profiles"]
+
 [workspace]
 members = [
     "ipc",
@@ -40,3 +42,18 @@ members = [
 [patch.crates-io]
 ocaml-boxroot-sys = { git = "https://gitlab.com/bruno.deferrari/ocaml-boxroot.git", branch = "ocaml-410-headers" }
 librocksdb-sys = { git = "https://github.com/tezedge/rust-rocksdb.git", tag = "tezedge-v0.17.0-1" }
+
+
+[profile.fuzz]
+inherits = "release"
+opt-level = 3
+debug = 2
+debug-assertions = true  # TODO: test and disable if too slow
+overflow-checks = true
+lto = true
+panic = "abort"
+incremental = false
+codegen-units = 1
+
+
+

--- a/coverage/poll.sh
+++ b/coverage/poll.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+rm -f ../target/fuzz/deps/*.gcda
+kill -SIGUSR2 $(pidof light-node)
+rm -f *.gcov
+sleep 1
+rust-cov gcov -p ../target/fuzz/deps/*.gcno

--- a/light_node/Cargo.toml
+++ b/light_node/Cargo.toml
@@ -32,3 +32,4 @@ shell = { path = "../shell" }
 monitoring = { path = "../monitoring" }
 rpc = { path = "../rpc" }
 ipc = { path = "../ipc" }
+signal-hook = "0.3.9"

--- a/run.sh
+++ b/run.sh
@@ -29,10 +29,12 @@ help() {
   echo -e " \e[32mdocker\e[0m     Run tezedge node as a docker container. It is possible to specify additional commandline arguments."
   echo    "              # $0 docker -t 4 -T 12"
   echo    "              # $0 docker --help"
+  echo -e " \e[32mfuzz\e[0m       Start tezedge node in fuzz mode. You can specify additional arguments here."
+  echo    "            Fuzz mode means that the node binary is compiled with most debug options but enabling optimizations."
 }
 
 configure_env_variables() {
-  options=$(getopt --longoptions debug,release,addrsanitizer --options "" --name $0 -- "$@")
+  options=$(getopt --longoptions debug,release,fuzz,addrsanitizer --options "" --name $0 -- "$@")
   eval set -- "$options"
   while true ; do
     case $1 in
@@ -44,6 +46,12 @@ configure_env_variables() {
       --release)
         export PROFILE="release"
         export CARGO_PROFILE_ARG="--release"
+        shift
+        ;;
+      --fuzz)
+        export RUSTFLAGS="-Zprofile -C force-frame-pointers --cfg dyncov"
+        export PROFILE="fuzz"
+        export CARGO_PROFILE_ARG="-Z unstable-options --profile=fuzz"
         shift
         ;;
       --addrsanitizer)
@@ -215,6 +223,14 @@ case $1 in
   release)
     warn_if_not_using_recommended_rust
     configure_env_variables --release
+    print_configuration
+    build_all
+    run_node "$@"
+    ;;
+
+  fuzz)
+    warn_if_not_using_recommended_rust
+    configure_env_variables --fuzz
     print_configuration
     build_all
     run_node "$@"


### PR DESCRIPTION
A new _fuzz_ profile is included to generate an optimized build of TE while keeping debug symbols, frame pointers, and runtime checks. Some _rustc_ flags can't be applied directly in the `Cargo.toml` so changes were also needed in run.sh and this should be the way to build it: `./run.sh fuzz [rest of node arguments]`

This also introduces "dynamic" coverage by installing a signal handler (SIGUSR2) in light-node which calls the llvm-gcov internal functions that dump the program counters into `.gcda` files.
A new `poll.sh` script is included inside a `coverage/` directory, when run it will send the signal to the light-node process and generate `.gcov` files via `rust-cov`.

This requires (not needed for normal builds):
- `cargo install cargo-binutils`
- `rustup component add llvm-tools-preview`

With this new basic functionality we can:
- Run fuzzers against builds that keep most debugging features but are faster.
- Write new tools to monitor the node's coverage dynamically by calling the `poll.sh` script and parsing the resulting `.gcov` files.
-  