### PR TITLE
Be more robust on the handling of IPC errors

### DIFF
--- a/ipc/src/lib.rs
+++ b/ipc/src/lib.rs
@@ -38,7 +38,9 @@ pub enum IpcError {
     #[fail(display = "Accept connection timed out, timout: {:?}", timeout)]
     AcceptTimeout { timeout: Duration },
     #[fail(display = "Receive message timed out - handle WouldBlock scenario if needed")]
-    ReceiveMessageTimeouted,
+    ReceiveMessageTimeout,
+    #[fail(display = "Discard message timed out")]
+    DiscardMessageTimeout,
     #[fail(display = "Connection error: {}", reason)]
     ConnectionError { reason: io::Error },
     #[fail(display = "Serialization error: {}", reason)]
@@ -125,7 +127,7 @@ where
     R: for<'de> Deserialize<'de>,
 {
     /// Try to receive message with read_timeout,
-    /// In case of timeout, can be IpcError::ReceiveMessageTimeouted handled
+    /// In case of timeout, can be IpcError::ReceiveMessageTimeout handled
     ///
     /// `read_timeout` - set read timeout before receive
     /// `reset_read_timeout` - set read timeout after receive
@@ -147,7 +149,7 @@ where
         let mut msg_len_buf = [0; 8];
         self.0.read_exact(&mut msg_len_buf).map_err(|err| {
             if err.kind() == io::ErrorKind::WouldBlock {
-                IpcError::ReceiveMessageTimeouted
+                IpcError::ReceiveMessageTimeout
             } else {
                 IpcError::ReceiveMessageLengthError { reason: err }
             }

--- a/ipc/tests/test_ipc.rs
+++ b/ipc/tests/test_ipc.rs
@@ -111,7 +111,7 @@ fn ipc_fork_and_try_read_with_timeout() -> Result<(), failure::Error> {
 
     // 1. try read something with timeout but nothing comes
     match rx.try_receive(Some(Duration::from_secs(1)), None) {
-        Err(IpcError::ReceiveMessageTimeouted {}) => (/* ok */),
+        Err(IpcError::ReceiveMessageTimeout {}) => (/* ok */),
         Err(e) => return Err(format_err!("Unexpected result: {:?}", e)),
         Ok(_) => return Err(format_err!("Unexpected result")),
     }
@@ -131,8 +131,8 @@ fn ipc_fork_and_try_read_with_timeout() -> Result<(), failure::Error> {
 
     // 4. try ready one more
     match rx.receive() {
-        Err(IpcError::ReceiveMessageTimeouted { .. }) => {
-            Err(format_err!("Unexpected IpcError::ReceiveMessageTimeouted"))
+        Err(IpcError::ReceiveMessageTimeout { .. }) => {
+            Err(format_err!("Unexpected IpcError::ReceiveMessageTimeout"))
         }
         Err(_) => {
             assert!(common::wait(child_pid));

--- a/rpc/src/services/protocol/mod.rs
+++ b/rpc/src/services/protocol/mod.rs
@@ -495,8 +495,7 @@ pub(crate) fn call_protocol_rpc_with_cache(
     rpc_request: RpcRequest,
     env: &RpcServiceEnvironment,
 ) -> Result<Arc<(u16, String)>, RpcCallError> {
-    let request =
-        create_protocol_rpc_request(chain_param, chain_id, block_hash, rpc_request, &env)?;
+    let request = create_protocol_rpc_request(chain_param, chain_id, block_hash, rpc_request, env)?;
 
     let controller = env.tezos_readonly_api().pool.get()?;
     let result = controller.api.call_protocol_rpc(request);
@@ -555,7 +554,7 @@ pub(crate) fn call_protocol_rpc(
                 chain_id,
                 block_hash,
                 rpc_request,
-                &env,
+                env,
             ) {
                 Ok(response) => response,
                 Err(RpcCallError::ErrorResponse(failure)) => {
@@ -600,7 +599,7 @@ pub(crate) fn preapply_operations(
     env: &RpcServiceEnvironment,
 ) -> Result<serde_json::value::Value, RpcServiceError> {
     let request =
-        match create_protocol_rpc_request(chain_param, chain_id, block_hash, rpc_request, &env) {
+        match create_protocol_rpc_request(chain_param, chain_id, block_hash, rpc_request, env) {
             Ok(response) => response,
             Err(RpcCallError::ErrorResponse(failure)) => {
                 return Err(RpcServiceError::UnexpectedError {
@@ -774,6 +773,7 @@ impl From<FromBytesError> for ContextParamsError {
     }
 }
 
+#[allow(clippy::from_over_into)]
 impl Into<RpcServiceError> for ContextParamsError {
     fn into(self) -> RpcServiceError {
         match self {
@@ -826,7 +826,7 @@ pub(crate) fn get_context_protocol_params(
         let context_hash = block_header.header.context();
 
         if let Some(data) =
-            context.get_key_from_history(&context_hash, context_key_owned!("protocol"))?
+            context.get_key_from_history(context_hash, context_key_owned!("protocol"))?
         {
             protocol_hash = ProtocolHash::try_from(data)?;
         } else {
@@ -836,7 +836,7 @@ pub(crate) fn get_context_protocol_params(
         }
 
         if let Some(data) =
-            context.get_key_from_history(&context_hash, context_key_owned!("data/v1/constants"))?
+            context.get_key_from_history(context_hash, context_key_owned!("data/v1/constants"))?
         {
             constants = data;
         } else {

--- a/shell/src/chain_feeder.rs
+++ b/shell/src/chain_feeder.rs
@@ -561,7 +561,7 @@ impl BlockApplierThreadSpawner {
 
                 while block_applier_run.load(Ordering::Acquire) {
                     match tezos_writeable_api.pool.get() {
-                        Ok(mut protocol_controller) => match feed_chain_to_protocol(
+                        Ok(protocol_controller) => match feed_chain_to_protocol(
                             &tezos_env,
                             &init_storage_data,
                             &block_applier_run,

--- a/shell/src/chain_feeder.rs
+++ b/shell/src/chain_feeder.rs
@@ -190,7 +190,7 @@ impl ChainFeeder {
                 tezos_writeable_api,
                 log,
             )
-            .spawn_feeder_thread(format!("chain-feedr-ctx"))
+            .spawn_feeder_thread("chain-feedr-ctx".into())
             .map_err(|_| CreateError::Panicked)?;
 
         sys.actor_of_props::<ChainFeeder>(
@@ -621,16 +621,16 @@ fn feed_chain_to_protocol(
     // at first we initialize protocol runtime and ffi context
 
     initialize_protocol_context(
-        &apply_block_run,
+        apply_block_run,
         chain_current_head_manager,
         block_storage,
         block_meta_storage,
         chain_meta_storage,
         operations_meta_storage,
-        &protocol_controller,
-        &log,
-        &tezos_env,
-        &init_storage_data,
+        protocol_controller,
+        log,
+        tezos_env,
+        init_storage_data,
     )?;
 
     // now just check current head (at least genesis should be there)
@@ -702,7 +702,7 @@ fn feed_chain_to_protocol(
                             block_meta_storage,
                             protocol_controller,
                             init_storage_data,
-                            &log,
+                            log,
                         ) {
                             Ok(result) => {
                                 match result {
@@ -942,7 +942,7 @@ fn prepare_apply_request(
     };
 
     // get block_metadata
-    let block_meta = match block_meta_storage.get(&block_hash)? {
+    let block_meta = match block_meta_storage.get(block_hash)? {
         Some(meta) => meta,
         None => {
             return Err(FeedChainError::ProcessingError {
@@ -1077,10 +1077,10 @@ pub(crate) fn initialize_protocol_context(
             let genesis_with_hash = initialize_storage_with_genesis_block(
                 block_storage,
                 block_meta_storage,
-                &init_storage_data,
-                &tezos_env,
+                init_storage_data,
+                tezos_env,
                 &genesis_context_hash,
-                &log,
+                log,
             )?;
 
             // call get additional/json data for genesis (this must be second call, because this triggers context.checkout)
@@ -1093,7 +1093,7 @@ pub(crate) fn initialize_protocol_context(
                 block_meta_storage,
                 chain_meta_storage,
                 operations_meta_storage,
-                &init_storage_data,
+                init_storage_data,
                 commit_data,
             )?;
             let store_result_elapsed = store_result_timer.elapsed();

--- a/shell/src/mempool/mempool_prevalidator.rs
+++ b/shell/src/mempool/mempool_prevalidator.rs
@@ -104,7 +104,7 @@ impl MempoolPrevalidator {
 
                 while validator_run.load(Ordering::Acquire) {
                     match tezos_readonly_api.pool.get() {
-                        Ok(mut protocol_controller) => match process_prevalidation(
+                        Ok(protocol_controller) => match process_prevalidation(
                             &block_storage,
                             &chain_meta_storage,
                             &mempool_storage,

--- a/shell/src/mempool/mempool_prevalidator.rs
+++ b/shell/src/mempool/mempool_prevalidator.rs
@@ -364,14 +364,14 @@ fn process_prevalidation(
 
     // hydrate state
     hydrate_state(
-        &shell_channel,
+        shell_channel,
         block_storage,
         chain_meta_storage,
         mempool_storage,
         current_mempool_state_storage.clone(),
-        &api,
-        &chain_id,
-        &log,
+        api,
+        chain_id,
+        log,
     )?;
 
     // start receiving event
@@ -391,11 +391,11 @@ fn process_prevalidation(
 
                         // try to begin construction new context
                         let (prevalidator, head) = begin_construction(
-                            &api,
-                            &chain_id,
+                            api,
+                            chain_id,
                             header.hash.clone(),
                             header.header.clone(),
-                            &log,
+                            log,
                         )?;
 
                         // reinitialize state for new prevalidator and head
@@ -407,7 +407,7 @@ fn process_prevalidation(
                         operations_to_delete
                             .iter()
                             .for_each(|oph| {
-                                if let Err(err) = mempool_storage.delete(&oph) {
+                                if let Err(err) = mempool_storage.delete(oph) {
                                     warn!(log, "Mempool - delete operation failed"; "hash" => oph.to_base58_check(), "error" => format!("{:?}", err))
                                 }
                             });
@@ -434,10 +434,8 @@ fn process_prevalidation(
                             }) {
                                 warn!(log, "Failed to dispatch result"; "reason" => format!("{}", e));
                             }
-                        } else {
-                            if let Err(e) = dispatch_oneshot_result(result_callback, || Ok(())) {
-                                warn!(log, "Failed to dispatch result"; "reason" => format!("{}", e));
-                            }
+                        } else if let Err(e) = dispatch_oneshot_result(result_callback, || Ok(())) {
+                            warn!(log, "Failed to dispatch result"; "reason" => format!("{}", e));
                         }
                     } else {
                         debug!(log, "Mempool - received validate operation event - operations was previously validated and removed from mempool storage"; "hash" => oph.to_base58_check());
@@ -456,10 +454,10 @@ fn process_prevalidation(
 
         // 2. lets handle pending operations (if any)
         handle_pending_operations(
-            &shell_channel,
-            &api,
+            shell_channel,
+            api,
             current_mempool_state_storage.clone(),
-            &log,
+            log,
         )?;
     }
 
@@ -477,7 +475,7 @@ fn hydrate_state(
     log: &Logger,
 ) -> Result<(), PrevalidationError> {
     // load current head
-    let current_head = match chain_meta_storage.get_current_head(&chain_id)? {
+    let current_head = match chain_meta_storage.get_current_head(chain_id)? {
         Some(head) => block_storage
             .get(head.block_hash())?
             .map(|header| (head, header.header)),
@@ -486,7 +484,7 @@ fn hydrate_state(
 
     // begin construction for a current head
     let (prevalidator, head) = match current_head {
-        Some((head, header)) => begin_construction(api, &chain_id, head.into(), header, &log)?,
+        Some((head, header)) => begin_construction(api, chain_id, head.into(), header, log)?,
         None => (None, None),
     };
 
@@ -510,7 +508,7 @@ fn hydrate_state(
     drop(state);
 
     // and process it immediatly on startup, before any event received to clean old stored unprocessed operations
-    handle_pending_operations(&shell_channel, &api, current_mempool_state_storage, &log)?;
+    handle_pending_operations(shell_channel, api, current_mempool_state_storage, log)?;
 
     Ok(())
 }
@@ -603,10 +601,10 @@ fn handle_pending_operations(
     }
 
     advertise_new_mempool(
-        &shell_channel,
+        shell_channel,
         prevalidator,
         head,
-        (&validation_result.applied, &pendings),
+        (&validation_result.applied, pendings),
     );
 
     Ok(())

--- a/tezos/interop/tests/test_bytes_roundtrips.rs
+++ b/tezos/interop/tests/test_bytes_roundtrips.rs
@@ -79,10 +79,8 @@ fn test_chain_id_roundtrip(iteration: i32) -> Result<(), failure::Error> {
 
     assert!(
         result.is_ok(),
-        format!(
-            "test_chain_id_roundtrip roundtrip iteration: {} failed!",
-            iteration
-        )
+        "test_chain_id_roundtrip roundtrip iteration: {} failed!",
+        iteration
     );
 
     Ok(())
@@ -106,10 +104,8 @@ fn test_block_header_roundtrip(iteration: i32) -> Result<(), failure::Error> {
 
     assert!(
         result.is_ok(),
-        format!(
-            "test_block_header_roundtrip roundtrip iteration: {} failed!",
-            iteration
-        )
+        "test_block_header_roundtrip roundtrip iteration: {} failed!",
+        iteration
     );
 
     Ok(())
@@ -174,10 +170,8 @@ fn test_block_header_with_hash_roundtrip(iteration: i32) -> Result<(), failure::
 
     assert!(
         result.is_ok(),
-        format!(
-            "test_block_header_with_hash_roundtrip roundtrip iteration: {} failed!",
-            iteration
-        )
+        "test_block_header_with_hash_roundtrip roundtrip iteration: {} failed!",
+        iteration
     );
 
     Ok(())
@@ -199,10 +193,8 @@ fn test_operation_roundtrip(iteration: i32) -> Result<(), failure::Error> {
 
     assert!(
         result.is_ok(),
-        format!(
-            "test_operation_roundtrip roundtrip iteration: {} failed!",
-            iteration
-        )
+        "test_operation_roundtrip roundtrip iteration: {} failed!",
+        iteration
     );
 
     Ok(())
@@ -249,10 +241,8 @@ fn test_operations_list_list_roundtrip(
 
     assert!(
         result.is_ok(),
-        format!(
-            "test_operations_list_list_roundtrip roundtrip iteration: {} failed!",
-            iteration
-        )
+        "test_operations_list_list_roundtrip roundtrip iteration: {} failed!",
+        iteration
     );
 
     Ok(())

--- a/tezos/wrapper/src/service.rs
+++ b/tezos/wrapper/src/service.rs
@@ -1083,7 +1083,7 @@ impl ProtocolController {
     ///
     /// Must be called after the writable context has been initialized.
     pub fn init_context_ipc_server(&self) -> Result<(), ProtocolServiceError> {
-        if let Some(_) = self.configuration.storage.get_ipc_socket_path() {
+        if self.configuration.storage.get_ipc_socket_path().is_some() {
             let mut io = self.io.borrow_mut();
             io.send(&ProtocolMessage::InitProtocolContextIpcServer(
                 self.configuration.storage.clone(),

--- a/tezos/wrapper/src/service.rs
+++ b/tezos/wrapper/src/service.rs
@@ -22,7 +22,7 @@ use tezos_new_context::IndexApi;
 use tezos_new_context::{ContextKeyOwned, ContextValue, StringTreeEntry};
 
 use crate::protocol::*;
-use crate::runner::{ProtocolRunner, ProtocolRunnerError};
+use crate::runner::{ExecutableProtocolRunner, ProtocolRunnerError};
 use crate::ProtocolEndpointConfiguration;
 
 lazy_static! {
@@ -432,6 +432,18 @@ pub enum ProtocolServiceError {
     ContextIpcServerError { message: String },
 }
 
+impl ProtocolServiceError {
+    /// Checks if this is an IPC error produced by sequence of timeouts
+    pub fn is_ipc_timeout_chain(&self) -> bool {
+        matches!(
+            self,
+            Self::IpcError {
+                reason: IpcError::DiscardMessageTimeout,
+            }
+        )
+    }
+}
+
 impl<T> From<std::sync::PoisonError<T>> for ProtocolServiceError {
     fn from(source: std::sync::PoisonError<T>) -> Self {
         Self::LockPoisonError {
@@ -514,7 +526,11 @@ impl IpcCmdServer {
             .map_err(|err| IpcError::SocketConfigurationError { reason: err })?;
 
         Ok(ProtocolController {
-            io: RefCell::new(IpcIO { rx, tx }),
+            io: RefCell::new(IpcIO {
+                rx,
+                tx,
+                communication_balance: 0,
+            }),
             configuration: self.1.clone(),
             shutting_down: false,
         })
@@ -524,6 +540,62 @@ impl IpcCmdServer {
 struct IpcIO {
     rx: IpcReceiver<NodeMessage>,
     tx: IpcSender<ProtocolMessage>,
+    /// To keep track of sent/received messages.
+    /// When sending a message this must be 0, otherwise there are outstanding recvs.
+    /// When a message is sent, the balance is increased by 1, and when a message is
+    /// received it is decreased by 1.
+    communication_balance: i32,
+}
+
+impl IpcIO {
+    pub fn send(&mut self, value: &ProtocolMessage) -> Result<(), ipc::IpcError> {
+        // Don't send anything until pending messages have been discarded
+        self.discard_pending_messages(
+            Some(ProtocolController::DISCARD_UNRECEIVED_TIMEOUT),
+            Some(IpcCmdServer::IO_TIMEOUT),
+        )?;
+        self.tx.send(value)?;
+        self.communication_balance += 1;
+        Ok(())
+    }
+
+    pub fn send_without_discard(&mut self, value: &ProtocolMessage) -> Result<(), ipc::IpcError> {
+        self.tx.send(value)?;
+        self.communication_balance += 1;
+        Ok(())
+    }
+
+    pub fn try_receive(
+        &mut self,
+        read_timeout: Option<Duration>,
+        reset_read_timeout: Option<Duration>,
+    ) -> Result<NodeMessage, ipc::IpcError> {
+        let result = self.rx.try_receive(read_timeout, reset_read_timeout)?;
+        self.communication_balance -= 1;
+        Ok(result)
+    }
+
+    /// Discard any pending message from cancelled requests
+    /// If `read_timeout` is reached, this will fail, and this runner should be shut down.
+    fn discard_pending_messages(
+        &mut self,
+        read_timeout: Option<Duration>,
+        reset_read_timeout: Option<Duration>,
+    ) -> Result<(), ipc::IpcError> {
+        while self.communication_balance > 1 {
+            // If there is another timeout, bailout, because we are probably stuck.
+            // Otherwise keep discarding
+            match self.rx.try_receive(read_timeout, reset_read_timeout) {
+                Err(IpcError::ReceiveMessageTimeout) => {
+                    return Err(IpcError::DiscardMessageTimeout)
+                }
+                Err(_) => (),
+                Ok(_) => (),
+            };
+            self.communication_balance -= 1;
+        }
+        Ok(())
+    }
 }
 
 /// Encapsulate IPC communication.
@@ -545,9 +617,11 @@ impl ProtocolController {
     const BEGIN_CONSTRUCTION_TIMEOUT: Duration = Duration::from_secs(120);
     const VALIDATE_OPERATION_TIMEOUT: Duration = Duration::from_secs(120);
     const CALL_PROTOCOL_RPC_TIMEOUT: Duration = Duration::from_secs(30);
+    const CALL_PROTOCOL_HEAVY_RPC_TIMEOUT: Duration = Duration::from_secs(600);
     const COMPUTE_PATH_TIMEOUT: Duration = Duration::from_secs(30);
     const JSON_ENCODE_DATA_TIMEOUT: Duration = Duration::from_secs(30);
     const ASSERT_ENCODING_FOR_PROTOCOL_DATA_TIMEOUT: Duration = Duration::from_secs(15);
+    const DISCARD_UNRECEIVED_TIMEOUT: Duration = Duration::from_secs(5);
 
     /// Apply block
     pub fn apply_block(
@@ -555,10 +629,10 @@ impl ProtocolController {
         request: ApplyBlockRequest,
     ) -> Result<ApplyBlockResponse, ProtocolServiceError> {
         let mut io = self.io.borrow_mut();
-        io.tx.send(&ProtocolMessage::ApplyBlockCall(request))?;
+        io.send(&ProtocolMessage::ApplyBlockCall(request))?;
 
         // this might take a while, so we will use unusually long timeout
-        match io.rx.try_receive(
+        match io.try_receive(
             Some(Self::APPLY_BLOCK_TIMEOUT),
             Some(IpcCmdServer::IO_TIMEOUT),
         )? {
@@ -577,14 +651,13 @@ impl ProtocolController {
         protocol_data: RustBytes,
     ) -> Result<(), ProtocolServiceError> {
         let mut io = self.io.borrow_mut();
-        io.tx
-            .send(&ProtocolMessage::AssertEncodingForProtocolDataCall(
-                protocol_hash,
-                protocol_data,
-            ))?;
+        io.send(&ProtocolMessage::AssertEncodingForProtocolDataCall(
+            protocol_hash,
+            protocol_data,
+        ))?;
 
         // this might take a while, so we will use unusually long timeout
-        match io.rx.try_receive(
+        match io.try_receive(
             Some(Self::ASSERT_ENCODING_FOR_PROTOCOL_DATA_TIMEOUT),
             Some(IpcCmdServer::IO_TIMEOUT),
         )? {
@@ -603,11 +676,10 @@ impl ProtocolController {
         request: BeginApplicationRequest,
     ) -> Result<BeginApplicationResponse, ProtocolServiceError> {
         let mut io = self.io.borrow_mut();
-        io.tx
-            .send(&ProtocolMessage::BeginApplicationCall(request))?;
+        io.send(&ProtocolMessage::BeginApplicationCall(request))?;
 
         // this might take a while, so we will use unusually long timeout
-        match io.rx.try_receive(
+        match io.try_receive(
             Some(Self::BEGIN_APPLICATION_TIMEOUT),
             Some(IpcCmdServer::IO_TIMEOUT),
         )? {
@@ -626,11 +698,10 @@ impl ProtocolController {
         request: BeginConstructionRequest,
     ) -> Result<PrevalidatorWrapper, ProtocolServiceError> {
         let mut io = self.io.borrow_mut();
-        io.tx
-            .send(&ProtocolMessage::BeginConstructionCall(request))?;
+        io.send(&ProtocolMessage::BeginConstructionCall(request))?;
 
         // this might take a while, so we will use unusually long timeout
-        match io.rx.try_receive(
+        match io.try_receive(
             Some(Self::BEGIN_CONSTRUCTION_TIMEOUT),
             Some(IpcCmdServer::IO_TIMEOUT),
         )? {
@@ -649,11 +720,10 @@ impl ProtocolController {
         request: ValidateOperationRequest,
     ) -> Result<ValidateOperationResponse, ProtocolServiceError> {
         let mut io = self.io.borrow_mut();
-        io.tx
-            .send(&ProtocolMessage::ValidateOperationCall(request))?;
+        io.send(&ProtocolMessage::ValidateOperationCall(request))?;
 
         // this might take a while, so we will use unusually long timeout
-        match io.rx.try_receive(
+        match io.try_receive(
             Some(Self::VALIDATE_OPERATION_TIMEOUT),
             Some(IpcCmdServer::IO_TIMEOUT),
         )? {
@@ -672,10 +742,10 @@ impl ProtocolController {
         request: ComputePathRequest,
     ) -> Result<ComputePathResponse, ProtocolServiceError> {
         let mut io = self.io.borrow_mut();
-        io.tx.send(&ProtocolMessage::ComputePathCall(request))?;
+        io.send(&ProtocolMessage::ComputePathCall(request))?;
 
         // this might take a while, so we will use unusually long timeout
-        match io.rx.try_receive(
+        match io.try_receive(
             Some(Self::COMPUTE_PATH_TIMEOUT),
             Some(IpcCmdServer::IO_TIMEOUT),
         )? {
@@ -697,17 +767,16 @@ impl ProtocolController {
         next_protocol_hash: ProtocolHash,
     ) -> Result<String, ProtocolServiceError> {
         let mut io = self.io.borrow_mut();
-        io.tx
-            .send(&ProtocolMessage::JsonEncodeApplyBlockResultMetadata {
-                context_hash,
-                max_operations_ttl,
-                metadata_bytes,
-                protocol_hash,
-                next_protocol_hash,
-            })?;
+        io.send(&ProtocolMessage::JsonEncodeApplyBlockResultMetadata {
+            context_hash,
+            max_operations_ttl,
+            metadata_bytes,
+            protocol_hash,
+            next_protocol_hash,
+        })?;
 
         // this might take a while, so we will use unusually long timeout
-        match io.rx.try_receive(
+        match io.try_receive(
             Some(Self::JSON_ENCODE_DATA_TIMEOUT),
             Some(IpcCmdServer::IO_TIMEOUT),
         )? {
@@ -735,17 +804,16 @@ impl ProtocolController {
         next_protocol_hash: ProtocolHash,
     ) -> Result<String, ProtocolServiceError> {
         let mut io = self.io.borrow_mut();
-        io.tx
-            .send(&ProtocolMessage::JsonEncodeApplyBlockOperationsMetadata {
-                chain_id,
-                operations,
-                operations_metadata_bytes,
-                protocol_hash,
-                next_protocol_hash,
-            })?;
+        io.send(&ProtocolMessage::JsonEncodeApplyBlockOperationsMetadata {
+            chain_id,
+            operations,
+            operations_metadata_bytes,
+            protocol_hash,
+            next_protocol_hash,
+        })?;
 
         // this might take a while, so we will use unusually long timeout
-        match io.rx.try_receive(
+        match io.try_receive(
             Some(Self::JSON_ENCODE_DATA_TIMEOUT),
             Some(IpcCmdServer::IO_TIMEOUT),
         )? {
@@ -769,11 +837,11 @@ impl ProtocolController {
         msg: ProtocolMessage,
     ) -> Result<ProtocolRpcResponse, ProtocolServiceError> {
         let mut io = self.io.borrow_mut();
-        io.tx.send(&msg)?;
+        io.send(&msg)?;
 
         // this might take a while, so we will use unusually long timeout
-        match io.rx.try_receive(
-            Some(Self::CALL_PROTOCOL_RPC_TIMEOUT),
+        match io.try_receive(
+            Some(Self::CALL_PROTOCOL_HEAVY_RPC_TIMEOUT),
             Some(IpcCmdServer::IO_TIMEOUT),
         )? {
             NodeMessage::RpcResponse(result) => result.map_err(|err| {
@@ -806,10 +874,10 @@ impl ProtocolController {
         msg: ProtocolMessage,
     ) -> Result<HelpersPreapplyResponse, ProtocolServiceError> {
         let mut io = self.io.borrow_mut();
-        io.tx.send(&msg)?;
+        io.send(&msg)?;
 
         // this might take a while, so we will use unusually long timeout
-        match io.rx.try_receive(
+        match io.try_receive(
             Some(Self::CALL_PROTOCOL_RPC_TIMEOUT),
             Some(IpcCmdServer::IO_TIMEOUT),
         )? {
@@ -844,10 +912,9 @@ impl ProtocolController {
         settings: TezosRuntimeConfiguration,
     ) -> Result<(), ProtocolServiceError> {
         let mut io = self.io.borrow_mut();
-        io.tx
-            .send(&ProtocolMessage::ChangeRuntimeConfigurationCall(settings))?;
+        io.send(&ProtocolMessage::ChangeRuntimeConfigurationCall(settings))?;
 
-        match io.rx.try_receive(
+        match io.try_receive(
             Some(IpcCmdServer::IO_TIMEOUT),
             Some(IpcCmdServer::IO_TIMEOUT),
         )? {
@@ -892,7 +959,7 @@ impl ProtocolController {
 
         // call init
         let mut io = self.io.borrow_mut();
-        io.tx.send(&ProtocolMessage::InitProtocolContextCall(
+        io.send(&ProtocolMessage::InitProtocolContextCall(
             InitProtocolContextParams {
                 storage,
                 genesis: tezos_environment.genesis.clone(),
@@ -914,7 +981,7 @@ impl ProtocolController {
 
         // wait for response
         // this might take a while, so we will use unusually long timeout
-        match io.rx.try_receive(
+        match io.try_receive(
             Some(Self::INIT_PROTOCOL_CONTEXT_TIMEOUT),
             Some(IpcCmdServer::IO_TIMEOUT),
         )? {
@@ -955,9 +1022,15 @@ impl ProtocolController {
         self.shutting_down = true;
 
         let mut io = self.io.borrow_mut();
-        io.tx.send(&ProtocolMessage::ShutdownCall)?;
 
-        match io.rx.try_receive(
+        // For shutdown messages we don't care if there are pending reads
+        io.send_without_discard(&ProtocolMessage::ShutdownCall)?;
+        io.discard_pending_messages(
+            Some(ProtocolController::DISCARD_UNRECEIVED_TIMEOUT),
+            Some(IpcCmdServer::IO_TIMEOUT),
+        )?;
+
+        match io.try_receive(
             Some(IpcCmdServer::IO_TIMEOUT),
             Some(IpcCmdServer::IO_TIMEOUT),
         )? {
@@ -1012,11 +1085,11 @@ impl ProtocolController {
     pub fn init_context_ipc_server(&self) -> Result<(), ProtocolServiceError> {
         if let Some(_) = self.configuration.storage.get_ipc_socket_path() {
             let mut io = self.io.borrow_mut();
-            io.tx.send(&ProtocolMessage::InitProtocolContextIpcServer(
+            io.send(&ProtocolMessage::InitProtocolContextIpcServer(
                 self.configuration.storage.clone(),
             ))?;
 
-            match io.rx.try_receive(
+            match io.try_receive(
                 Some(IpcCmdServer::IO_TIMEOUT),
                 Some(IpcCmdServer::IO_TIMEOUT),
             )? {
@@ -1052,7 +1125,7 @@ impl ProtocolController {
         })?;
 
         let mut io = self.io.borrow_mut();
-        io.tx.send(&ProtocolMessage::GenesisResultDataCall(
+        io.send(&ProtocolMessage::GenesisResultDataCall(
             GenesisResultDataParams {
                 genesis_context_hash: genesis_context_hash.clone(),
                 chain_id: main_chain_id,
@@ -1066,7 +1139,7 @@ impl ProtocolController {
             },
         ))?;
 
-        match io.rx.try_receive(
+        match io.try_receive(
             Some(IpcCmdServer::IO_TIMEOUT),
             Some(IpcCmdServer::IO_TIMEOUT),
         )? {
@@ -1085,14 +1158,14 @@ impl ProtocolController {
         key: ContextKeyOwned,
     ) -> Result<Option<ContextValue>, ProtocolServiceError> {
         let mut io = self.io.borrow_mut();
-        io.tx.send(&ProtocolMessage::ContextGetKeyFromHistory(
+        io.send(&ProtocolMessage::ContextGetKeyFromHistory(
             ContextGetKeyFromHistoryRequest {
                 context_hash: context_hash.clone(),
                 key,
             },
         ))?;
 
-        match io.rx.try_receive(
+        match io.try_receive(
             Some(IpcCmdServer::IO_TIMEOUT_LONG),
             Some(IpcCmdServer::IO_TIMEOUT),
         )? {
@@ -1110,14 +1183,14 @@ impl ProtocolController {
         prefix: ContextKeyOwned,
     ) -> Result<Option<Vec<(ContextKeyOwned, ContextValue)>>, ProtocolServiceError> {
         let mut io = self.io.borrow_mut();
-        io.tx.send(&ProtocolMessage::ContextGetKeyValuesByPrefix(
+        io.send(&ProtocolMessage::ContextGetKeyValuesByPrefix(
             ContextGetKeyValuesByPrefixRequest {
                 context_hash: context_hash.clone(),
                 prefix,
             },
         ))?;
 
-        match io.rx.try_receive(
+        match io.try_receive(
             Some(IpcCmdServer::IO_TIMEOUT_LONG),
             Some(IpcCmdServer::IO_TIMEOUT),
         )? {
@@ -1137,7 +1210,7 @@ impl ProtocolController {
         depth: Option<usize>,
     ) -> Result<StringTreeEntry, ProtocolServiceError> {
         let mut io = self.io.borrow_mut();
-        io.tx.send(&ProtocolMessage::ContextGetTreeByPrefix(
+        io.send(&ProtocolMessage::ContextGetTreeByPrefix(
             ContextGetTreeByPrefixRequest {
                 context_hash: context_hash.clone(),
                 prefix,
@@ -1145,7 +1218,7 @@ impl ProtocolController {
             },
         ))?;
 
-        match io.rx.try_receive(
+        match io.try_receive(
             Some(IpcCmdServer::IO_TIMEOUT_LONG),
             Some(IpcCmdServer::IO_TIMEOUT),
         )? {
@@ -1169,24 +1242,24 @@ impl Drop for ProtocolController {
 }
 
 /// Endpoint consists of a protocol runner and IPC communication (command and event channels).
-pub struct ProtocolRunnerEndpoint<Runner: ProtocolRunner> {
-    runner: Runner,
+pub struct ProtocolRunnerEndpoint {
+    runner: ExecutableProtocolRunner,
     log: Logger,
 
     pub commands: IpcCmdServer,
 }
 
-impl<Runner: ProtocolRunner + 'static> ProtocolRunnerEndpoint<Runner> {
+impl ProtocolRunnerEndpoint {
     pub fn try_new(
         endpoint_name: &str,
         configuration: ProtocolEndpointConfiguration,
         tokio_runtime: tokio::runtime::Handle,
         log: Logger,
-    ) -> Result<ProtocolRunnerEndpoint<Runner>, IpcError> {
+    ) -> Result<ProtocolRunnerEndpoint, IpcError> {
         let cmd_server = IpcCmdServer::try_new(configuration.clone())?;
 
         Ok(ProtocolRunnerEndpoint {
-            runner: Runner::new(
+            runner: ExecutableProtocolRunner::new(
                 configuration,
                 cmd_server.0.client().path(),
                 endpoint_name.to_string(),
@@ -1198,7 +1271,7 @@ impl<Runner: ProtocolRunner + 'static> ProtocolRunnerEndpoint<Runner> {
     }
 
     /// Starts protocol runner sub-process just once and you can take care of it
-    pub fn start(&self) -> Result<Runner::Subprocess, ProtocolRunnerError> {
+    pub fn start(&self) -> Result<tokio::process::Child, ProtocolRunnerError> {
         debug!(self.log, "Starting protocol runner process");
         self.runner.spawn(self.log.clone())
     }


### PR DESCRIPTION
- Use a higher timeout for IPC calls used by heavy RPCs.
- When sending messages, if there are outstanding recvs, try to discard
   them before sending the message.
- If there is a timeout when discarding outstanding recvs, this signals
   a different kind of timeout.
- If an IPC call for a heavy RPC fails with a "discard timeout",
   shutdown the protocol runner that failed.
    
 Note that this is only done for `GET` RPC calls that are routed  through the OCaml implementation, not for others. It is not    a complete solution, just one that improves the situation.