### PR TITLE
Fix benchmarking error

### DIFF
--- a/networking/benches/common.rs
+++ b/networking/benches/common.rs
@@ -23,11 +23,13 @@ use networking::p2p::stream::{
 use slog::{debug, o, Drain};
 use tezos_messages::p2p::{
     binary_message::BinaryChunk,
-    encoding::peer::{PeerMessage, PeerMessageResponse},
+    encoding::{
+        limits::BLOCK_HEADER_PROTOCOL_DATA_MAX_SIZE,
+        peer::{PeerMessage, PeerMessageResponse},
+    },
 };
 
 use tezos_messages::p2p::binary_message::BinaryRead;
-use tezos_messages::p2p::encoding::limits::BLOCK_HEADER_MAX_SIZE;
 use tokio::{runtime::Builder, time::Instant};
 
 pub struct BinaryChunks<'a> {
@@ -157,7 +159,7 @@ pub fn block_header_message_encoded(data_size: usize) -> Vec<u8> {
             .as_ref(),
     ); // context
 
-    let data_size = std::cmp::min(data_size, BLOCK_HEADER_MAX_SIZE - res.len());
+    let data_size = std::cmp::min(data_size, BLOCK_HEADER_PROTOCOL_DATA_MAX_SIZE);
     res.extend(std::iter::repeat(0xff).take(data_size));
 
     let mut res1: Vec<u8> = vec![];


### PR DESCRIPTION
This is to fix the error in stream benchmarking caused by incorrect block header construction that violates boundaries.