### PR TITLE
Rework rights RPCs

### DIFF
--- a/.drone.longrunning.yml
+++ b/.drone.longrunning.yml
@@ -32,7 +32,6 @@ steps:
     - mkdir -p drone-cache/test_data/tests/resources
     - mkdir -p drone-cache/tests
     - mkdir -p drone-cache/sandbox_files
-    # - mkdir -p $${SANDBOX_ARTIFACTS_PATH}
     # copy binaries
     - cp ./target/release/light-node drone-cache/build_files
     - cp ./target/release/sandbox drone-cache/build_files
@@ -100,21 +99,29 @@ steps:
       - 'drone-cache' # <- builds a cache from this directory
 
 trigger:
-  # TODO: replace with master? when do we want to trigger this pipeline? 
-  branch: fix/rights-rpcs
+  branch: develop
   event: push
 
 ---
-
+###################################################################################################################
+# This pipeline runs a long running RPC call comparison test that compares tezedge results with octez, ensuring the 
+# data the RPC returns is correct
+###################################################################################################################
 kind: pipeline
-name: rights-rpc-test
+name: corr/baking-endorsing-rights-rpc-test
 
 environment:
-  TO_BLOCK_HEADER_FOR_RPC: 1677709
+  TO_BLOCK_HEADER_FOR_RPC: 1672200
   TEZEDGE_NODE_RPC_CONTEXT_ROOT: http://tezedge-updated-node-mainnet-run:18732
   OCTEZ_NODE_RPC_CONTEXT_ROOT: http://octez-node-mainnet-run-1:8732
 
 steps:
+
+- name: prepare-cache-dir
+  image: alpine/git
+  user: root
+  commands:
+    - mkdir -p drone-cache
 
 - name: restore-cache
   image: meltwater/drone-cache
@@ -148,9 +155,8 @@ steps:
   commands:
     - rm -f /home/tezos/data/lock
     - cp drone-cache/build_files/identities/identity_1.json /home/tezos/data/identity.json
-    - tezos-node config reset --data-dir /home/tezos/data --network mainnet --no-bootstrap-peers
-    # TODO: add --history-mode archive, when data is available
-    - tezos-node run --data-dir /home/tezos/data --rpc-addr 0.0.0.0:8732 --net-addr 0.0.0.0:9734 --network mainnet --no-bootstrap-peers
+    - tezos-node config reset --data-dir /home/tezos/data --network mainnet --no-bootstrap-peers --history-mode archive
+    - tezos-node run --history-mode archive --data-dir /home/tezos/data --rpc-addr 0.0.0.0:8732 --allow-all-rpc 0.0.0.0:8732 --net-addr 0.0.0.0:9734 --network mainnet --no-bootstrap-peers
 
 - name: tezedge-updated-node-mainnet-run
   image: tezedge/tezedge-ci-builder:nightly-2021-08-04-v9.5-tezos
@@ -158,16 +164,21 @@ steps:
   user: root
   detach: true
   volumes:
-    - name: cache
-      path: /data/cache
+    - name: tezedge-node-mainnet-snapshot-data
+      path: /data/tezedge-data
   environment:
     SODIUM_USE_PKG_CONFIG: 1
   commands:
-    - cp drone-cache/build_files/protocol-runner /data/cache
     - rust_libs=$(echo "`rustup show home`/toolchains/`rustup show active-toolchain | tr " " "\n" | head -1`/lib")
     - export LD_LIBRARY_PATH="drone-cache/build_files/ffi:$rust_libs"
     - echo "LD_LIBRARY_PATH - $LD_LIBRARY_PATH"
-    - drone-cache/build_files/light-node --config-file "drone-cache/build_files/tezedge/tezedge_drone.config" --disable-bootstrap-lookup --peer-thresh-low=0 --peer-thresh-high=0 --identity-file "drone-cache/build_files/identities/identity_4.json" --network "mainnet" --protocol-runner "/data/cache/protocol-runner" --p2p-port 19732 --init-sapling-spend-params-file drone-cache/build_files/ffi/sapling-spend.params --init-sapling-output-params-file drone-cache/build_files/ffi/sapling-output.params
+    - drone-cache/build_files/light-node --config-file "drone-cache/build_files/tezedge/tezedge_drone.config" --disable-bootstrap-lookup --peer-thresh-low=0 --peer-thresh-high=0 --identity-file "drone-cache/build_files/identities/identity_4.json" --network "mainnet" --protocol-runner "drone-cache/build_files/protocol-runner" --p2p-port 19732 --init-sapling-spend-params-file drone-cache/build_files/ffi/sapling-spend.params --init-sapling-output-params-file drone-cache/build_files/ffi/sapling-output.params --tezos-data-dir /data/tezedge-data --bootstrap-db-path bootstrap_db
+
+- name: wait-for-snapshoted-nodes
+  image: tezedge/tezos-node-bootstrap:latest
+  commands:
+    - export TO_BLOCK_HEADER=$${TO_BLOCK_HEADER_FOR_RPC}
+    - tezos-node-bootstrap bootstrap --level=$${TO_BLOCK_HEADER} --nodes $${OCTEZ_NODE_RPC_CONTEXT_ROOT} $${TEZEDGE_NODE_RPC_CONTEXT_ROOT}
 
 - name: rpc-test
   image: tezedge/tezedge-ci-builder:nightly-2021-08-04-v9.5-tezos
@@ -176,22 +187,21 @@ steps:
   environment:
     RUST_BACKTRACE: 1
   commands:
-    - export NODE_RPC_CONTEXT_ROOT_1=$${OCTEZ_NODE_RPC_CONTEXT_ROOT}
-    - export NODE_RPC_CONTEXT_ROOT_2=$${TEZEDGE_NODE_RPC_CONTEXT_ROOT}
+    - export NODE_RPC_CONTEXT_ROOT_1=$${TEZEDGE_NODE_RPC_CONTEXT_ROOT}
+    - export NODE_RPC_CONTEXT_ROOT_2=$${OCTEZ_NODE_RPC_CONTEXT_ROOT}
     - export IGNORE_PATH_PATTERNS=votes/listings,/minimal_valid_time,/operations_metadata_hash,/metadata_hash,/operation_metadata_hashes,/context/raw/bytes
     - export TO_BLOCK_HEADER=$${TO_BLOCK_HEADER_FOR_RPC}
+    - export LD_LIBRARY_PATH="drone-cache/build_files/ffi:$rust_libs"
     - drone-cache/tests/rpc_integration_test --nocapture --ignored test_rpc_compare_rights_mainnet
 
 volumes:
   - name: octez-node-mainnet-snapshot-data
     host:
-      path: /home/dev/octez-data/mainnet-1677709-full
+      path: /home/dev/octez-data/archive-1672200
   - name: tezedge-node-mainnet-snapshot-data
     host:
-      # TODO: properly rename
-      path: /home/dev/tezedge-data/tezedge_new_cycle_storage_data
+      path: /home/dev/tezedge-data/tezedge-1678542
 
 trigger:
-  # TODO: replace with master? when do we want to trigger this pipeline? 
-  branch: fix/rights-rpcs
+  branch: develop
   event: push

--- a/.drone.longrunning.yml
+++ b/.drone.longrunning.yml
@@ -1,0 +1,197 @@
+kind: pipeline
+name: build-tezedge-binaries
+
+workspace:
+  path: /drone/src
+
+steps:
+
+- name: build-artifacts
+  image: tezedge/tezedge-ci-builder:nightly-2021-08-04-v9.5-tezos
+  pull: if-not-exists
+  user: root
+  environment:
+    RUST_BACKTRACE: 1
+    SODIUM_USE_PKG_CONFIG: 1
+    OCAML_BUILD_CHAIN: remote
+    LOG_LEVEL: info
+    OCAML_LOG_ENABLED: false
+  commands:
+    # prepare rust toolchain dir
+    - echo "`rustup show home`/toolchains/`rustup show active-toolchain | tr " " "\n" | head -1`/lib"
+    # build and unit-test
+    - cargo clean
+    - cargo build --release --workspace
+    - cargo test --release --workspace --no-run
+    # collect binary artefacts
+    # directory in the workspace to cache all the binary artefacts
+    # TODO: use snake-case for directories
+    - mkdir -p drone-cache/build_files/ffi
+    - mkdir -p drone-cache/build_files/tezedge
+    - mkdir -p drone-cache/build_files/identities
+    - mkdir -p drone-cache/test_data/tests/resources
+    - mkdir -p drone-cache/tests
+    - mkdir -p drone-cache/sandbox_files
+    # - mkdir -p $${SANDBOX_ARTIFACTS_PATH}
+    # copy binaries
+    - cp ./target/release/light-node drone-cache/build_files
+    - cp ./target/release/sandbox drone-cache/build_files
+    - cp ./target/release/protocol-runner drone-cache/build_files
+    - cp ./tezos/sys/lib_tezos/artifacts/libtezos.so drone-cache/build_files/ffi
+    - cp ./sandbox/artifacts/tezos-client drone-cache/build_files
+    # copy sapling init files
+    - cp ./tezos/sys/lib_tezos/artifacts/sapling-spend.params drone-cache/build_files/ffi
+    - cp ./tezos/sys/lib_tezos/artifacts/sapling-output.params drone-cache/build_files/ffi
+    # copy sandbox resources
+    - cp ./light_node/etc/tezedge_sandbox/sandbox-patch-context.json drone-cache/sandbox_files
+    - cp ./light_node/etc/tezedge_sandbox/006-carthage-protocol-parameters.json drone-cache/sandbox_files
+    - cp ./light_node/etc/tezedge_sandbox/008-edo-protocol-parameters.json drone-cache/sandbox_files
+    - cp ./light_node/etc/tezedge_sandbox/009-florence-protocol-parameters.json drone-cache/sandbox_files
+    - cp ./light_node/etc/tezedge_sandbox/010-granada-protocol-parameters.json drone-cache/sandbox_files
+    - cp ./light_node/etc/tezedge_sandbox/tezedge_drone_sandbox.config drone-cache/sandbox_files
+    - cp ./light_node/etc/tezedge_sandbox/sandbox_start_light_node_args.json drone-cache/sandbox_files
+    - cp ./light_node/etc/tezedge_sandbox/sandbox_init_client_request.json drone-cache/sandbox_files
+    - cp ./light_node/etc/tezedge_sandbox/sandbox_activate_protocol_request.json drone-cache/sandbox_files
+    - cp ./light_node/etc/tezedge_sandbox/sandbox_activate_protocol_009_request.json drone-cache/sandbox_files
+    - cp ./light_node/etc/tezedge_sandbox/sandbox_activate_protocol_010_request.json drone-cache/sandbox_files
+    - cp ./light_node/etc/tezedge_sandbox/sandbox_bake_empty_block.json drone-cache/sandbox_files
+    # copy other resources
+    - cp ./light_node/etc/drone/assert_equals.sh drone-cache/build_files/ && chmod 755 drone-cache/build_files/assert_equals.sh
+    - cp ./light_node/etc/drone/assert_contains.sh drone-cache/build_files/ && chmod 755 drone-cache/build_files/assert_contains.sh
+    - cp ./light_node/etc/drone/wait_file.sh drone-cache/build_files/ && chmod 755 drone-cache/build_files/wait_file.sh
+    - cp ./light_node/etc/drone/assert_cyclic_test_result.sh drone-cache/build_files/ && chmod 755 drone-cache/build_files/assert_cyclic_test_result.sh
+    - cp ./light_node/etc/drone/identities/* drone-cache/build_files/identities/
+    - cp ./light_node/etc/tezedge/tezedge_drone.config drone-cache/build_files/tezedge/
+    # copy test binaries
+    - cp `find ./target/release/deps/ | grep integration_test | grep -v "\.d" | head -1` drone-cache/tests/rpc_integration_test
+    - cp `find ./target/release/deps/ | grep chain_test | grep -v "\.d" | head -1` drone-cache/tests/shell_chain_test
+    - cp `find ./target/release/deps/ | grep protocol_runner_test | grep -v "\.d" | head -1` drone-cache/tests/protocol_runner_test
+    - cp `find ./target/release/deps/ | grep p2p_test | grep -v "\.d" | head -1` drone-cache/tests/p2p_test
+    # copy test resources
+    - cp ./shell/tests/resources/apply_block_request_until_1326.zip drone-cache/test_data/tests/resources
+    - cp ./shell/tests/resources/sandbox_branch_1_level3.zip drone-cache/test_data/tests/resources
+    - cp ./shell/tests/resources/sandbox_branch_2_level4.zip drone-cache/test_data/tests/resources
+    - cp ./shell/tests/resources/sandbox-patch-context.json drone-cache/test_data/tests/resources
+    # collect modified python tests stuff
+    - mkdir -p drone-cache/python-tests/daemons
+    - mkdir -p drone-cache/python-tests/launchers
+    - mkdir -p drone-cache/python-tests/tools
+    - cp -r ./tezos/python-tests/daemons/node.py drone-cache/python-tests/daemons/node.py
+    - cp -r ./tezos/python-tests/launchers/sandbox.py drone-cache/python-tests/launchers/sandbox.py
+    - cp -r ./tezos/python-tests/tools/constants.py drone-cache/python-tests/tools/constants.py
+
+- name: rebuild-artifacts-cache
+  image: meltwater/drone-cache
+  pull: true
+  environment:
+    SFTP_USERNAME:
+      from_secret: sftp_username
+    SFTP_PASSWORD:
+      from_secret: sftp_password
+    SFTP_AUTH_METHOD: PASSWORD
+    SFTP_HOST: 65.21.165.82
+    SFTP_PORT: 22
+    SFTP_CACHE_ROOT: "/upload"
+  settings:
+    rebuild: true
+    backend: "sftp"
+    cache_key: 'build-{{ .Build.Number }}'
+    mount:
+      - 'drone-cache' # <- builds a cache from this directory
+
+trigger:
+  # TODO: replace with master? when do we want to trigger this pipeline? 
+  branch: fix/rights-rpcs
+  event: push
+
+---
+
+kind: pipeline
+name: rights-rpc-test
+
+environment:
+  TO_BLOCK_HEADER_FOR_RPC: 1677709
+  TEZEDGE_NODE_RPC_CONTEXT_ROOT: http://tezedge-updated-node-mainnet-run:18732
+  OCTEZ_NODE_RPC_CONTEXT_ROOT: http://octez-node-mainnet-run-1:8732
+
+steps:
+
+- name: restore-cache
+  image: meltwater/drone-cache
+  pull: true
+  environment:
+    SFTP_USERNAME:
+      from_secret: sftp_username
+    SFTP_PASSWORD:
+      from_secret: sftp_password
+    SFTP_AUTH_METHOD: PASSWORD
+    SFTP_HOST: 65.21.165.82
+    SFTP_PORT: 22
+    SFTP_CACHE_ROOT: "/upload"
+  settings:
+    restore: true
+    debug: true
+    backend: "sftp"
+    cache_key: 'build-{{ .Build.Number }}'
+    mount:
+      - 'drone-cache' # <- builds a cache from this directory
+
+- name: octez-node-mainnet-run-1
+  user: root
+  image: tezos/tezos:v10.2
+  detach: true
+  volumes:
+    - name: octez-node-mainnet-snapshot-data
+      path: /home/tezos/data
+    - name: cache
+      path: /data/cache
+  commands:
+    - rm -f /home/tezos/data/lock
+    - cp drone-cache/build_files/identities/identity_1.json /home/tezos/data/identity.json
+    - tezos-node config reset --data-dir /home/tezos/data --network mainnet --no-bootstrap-peers
+    # TODO: add --history-mode archive, when data is available
+    - tezos-node run --data-dir /home/tezos/data --rpc-addr 0.0.0.0:8732 --net-addr 0.0.0.0:9734 --network mainnet --no-bootstrap-peers
+
+- name: tezedge-updated-node-mainnet-run
+  image: tezedge/tezedge-ci-builder:nightly-2021-08-04-v9.5-tezos
+  pull: if-not-exists
+  user: root
+  detach: true
+  volumes:
+    - name: cache
+      path: /data/cache
+  environment:
+    SODIUM_USE_PKG_CONFIG: 1
+  commands:
+    - cp drone-cache/build_files/protocol-runner /data/cache
+    - rust_libs=$(echo "`rustup show home`/toolchains/`rustup show active-toolchain | tr " " "\n" | head -1`/lib")
+    - export LD_LIBRARY_PATH="drone-cache/build_files/ffi:$rust_libs"
+    - echo "LD_LIBRARY_PATH - $LD_LIBRARY_PATH"
+    - drone-cache/build_files/light-node --config-file "drone-cache/build_files/tezedge/tezedge_drone.config" --disable-bootstrap-lookup --peer-thresh-low=0 --peer-thresh-high=0 --identity-file "drone-cache/build_files/identities/identity_4.json" --network "mainnet" --protocol-runner "/data/cache/protocol-runner" --p2p-port 19732 --init-sapling-spend-params-file drone-cache/build_files/ffi/sapling-spend.params --init-sapling-output-params-file drone-cache/build_files/ffi/sapling-output.params
+
+- name: rpc-test
+  image: tezedge/tezedge-ci-builder:nightly-2021-08-04-v9.5-tezos
+  pull: if-not-exists
+  user: root
+  environment:
+    RUST_BACKTRACE: 1
+  commands:
+    - export NODE_RPC_CONTEXT_ROOT_1=$${OCTEZ_NODE_RPC_CONTEXT_ROOT}
+    - export NODE_RPC_CONTEXT_ROOT_2=$${TEZEDGE_NODE_RPC_CONTEXT_ROOT}
+    - export IGNORE_PATH_PATTERNS=votes/listings,/minimal_valid_time,/operations_metadata_hash,/metadata_hash,/operation_metadata_hashes,/context/raw/bytes
+    - export TO_BLOCK_HEADER=$${TO_BLOCK_HEADER_FOR_RPC}
+    - drone-cache/tests/rpc_integration_test --nocapture --ignored test_rpc_compare_rights_mainnet
+
+volumes:
+  - name: octez-node-mainnet-snapshot-data
+    host:
+      path: /home/dev/octez-data/mainnet-1677709-full
+  - name: tezedge-node-mainnet-snapshot-data
+    host:
+      # TODO: properly rename
+      path: /home/dev/tezedge-data/tezedge_new_cycle_storage_data
+
+trigger:
+  # TODO: replace with master? when do we want to trigger this pipeline? 
+  branch: fix/rights-rpcs
+  event: push

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,7 +748,7 @@ dependencies = [
  "anyhow",
  "base58",
  "hex",
- "num-bigint",
+ "num-bigint 0.3.3",
  "num-traits 0.2.14",
  "rand 0.7.3",
  "serde 1.0.130",
@@ -2042,6 +2042,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-bigint 0.4.2",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits 0.2.14",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2055,12 +2069,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74e768dff5fb39a41b3bcd30bb25cf989706c90d028d1ad71971987aa309d535"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits 0.2.14",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
+dependencies = [
+ "num-traits 0.2.14",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
+ "num-traits 0.2.14",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits 0.2.14",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
+dependencies = [
+ "autocfg",
+ "num-bigint 0.4.2",
+ "num-integer",
  "num-traits 0.2.14",
 ]
 
@@ -2660,6 +2717,7 @@ dependencies = [
  "hyper",
  "itertools 0.10.1",
  "lazy_static",
+ "num",
  "path-tree",
  "rand 0.7.3",
  "riker",
@@ -3396,7 +3454,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "nom 6.1.2",
- "num-bigint",
+ "num-bigint 0.3.3",
  "num-traits 0.2.14",
  "serde 1.0.130",
  "tezos_encoding_derive",
@@ -3473,7 +3531,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "nom 6.1.2",
- "num-bigint",
+ "num-bigint 0.3.3",
  "num-traits 0.2.14",
  "serde 1.0.130",
  "serde_json",

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -14,6 +14,7 @@ futures = "0.3"
 hex = "0.4"
 hyper = { version = "0.14", features = ["server", "http1", "http2", "stream", "tcp", "runtime"] }
 itertools = "0.10"
+num = "0.4"
 path-tree = "0.1.9"
 riker = "0.4"
 serde = { version = "1.0", features = ["derive", "rc"] }

--- a/rpc/src/server/dev_handler.rs
+++ b/rpc/src/server/dev_handler.rs
@@ -46,7 +46,7 @@ pub async fn dev_blocks(
 
     // get cycle length
     let cycle_length = dev_services::get_cycle_length_for_block(&from_block_id, &env, env.log())
-        .map_err(|e| format_err!("Failed to get constants, reason: {}", e))?;
+        .map_err(|e| format_err!("Failed to get cycle length, reason: {}", e))?;
     let every_nth_level = match query.get_str("every_nth") {
         Some("cycle") => Some(cycle_length),
         Some("voting-period") => Some(cycle_length * 8),

--- a/rpc/src/server/dev_handler.rs
+++ b/rpc/src/server/dev_handler.rs
@@ -246,7 +246,7 @@ pub async fn cycle_eras(
     let block_hash = parse_block_hash(&chain_id, required_param!(params, "block_id")?, &env)
         .map_err(|e| format_err!("Failed to parse_block_hash, reason: {}", e))?;
 
-    result_option_to_json_response(
+    result_to_json_response(
         dev_services::get_cycle_eras(&block_hash, &env, env.log()),
         env.log(),
     )

--- a/rpc/src/server/dev_handler.rs
+++ b/rpc/src/server/dev_handler.rs
@@ -236,6 +236,22 @@ pub async fn block_actions(
     result_option_to_json_response(context::make_block_stats(db_path, block_hash), env.log())
 }
 
+pub async fn cycle_eras(
+    _: Request<Body>,
+    params: Params,
+    _: Query,
+    env: Arc<RpcServiceEnvironment>,
+) -> ServiceResult {
+    let chain_id = parse_chain_id(required_param!(params, "chain_id")?, &env)?;
+    let block_hash = parse_block_hash(&chain_id, required_param!(params, "block_id")?, &env)
+        .map_err(|e| format_err!("Failed to parse_block_hash, reason: {}", e))?;
+
+    result_option_to_json_response(
+        dev_services::get_cycle_eras(&block_hash, &env, env.log()),
+        env.log(),
+    )
+}
+
 /// Get the version string
 pub async fn dev_version(
     _: Request<Body>,

--- a/rpc/src/server/dev_handler.rs
+++ b/rpc/src/server/dev_handler.rs
@@ -45,8 +45,9 @@ pub async fn dev_blocks(
     };
 
     // get cycle length
-    let cycle_length = dev_services::get_cycle_length_for_block(&from_block_id, &env, env.log())
-        .map_err(|e| format_err!("Failed to get cycle length, reason: {}", e))?;
+    let cycle_length =
+        dev_services::get_cycle_length_for_block(&chain_id, &from_block_id, &env, env.log())
+            .map_err(|e| format_err!("Failed to get cycle length, reason: {}", e))?;
     let every_nth_level = match query.get_str("every_nth") {
         Some("cycle") => Some(cycle_length),
         Some("voting-period") => Some(cycle_length * 8),
@@ -247,7 +248,7 @@ pub async fn cycle_eras(
         .map_err(|e| format_err!("Failed to parse_block_hash, reason: {}", e))?;
 
     result_to_json_response(
-        dev_services::get_cycle_eras(&block_hash, &env, env.log()),
+        dev_services::get_cycle_eras(&chain_id, &block_hash, &env, env.log()),
         env.log(),
     )
 }

--- a/rpc/src/server/protocol_handler.rs
+++ b/rpc/src/server/protocol_handler.rs
@@ -63,7 +63,6 @@ pub async fn baking_rights(
     let has_all = query.contains_key("all");
 
     match services::protocol::check_and_get_baking_rights(
-        &chain_id,
         &block_hash,
         level,
         delegate,
@@ -120,7 +119,6 @@ pub async fn endorsing_rights(
 
     // get RPC response and unpack it from RpcResponseData enum
     match services::protocol::check_and_get_endorsing_rights(
-        &chain_id,
         &block_hash,
         level,
         delegate,

--- a/rpc/src/server/protocol_handler.rs
+++ b/rpc/src/server/protocol_handler.rs
@@ -26,7 +26,8 @@ pub async fn context_constants(
         parse_block_hash_or_fail!(&chain_id, required_param!(params, "block_id")?, &env);
 
     // try to call our implementation
-    let result = services::protocol::get_context_constants_just_for_rpc(&block_hash, &env);
+    let result =
+        services::protocol::get_context_constants_just_for_rpc(&chain_id, &block_hash, &env);
 
     // fallback, if protocol is not supported, we trigger rpc protocol router
     if let Err(ContextParamsError::UnsupportedProtocolError { .. }) = result {
@@ -63,6 +64,7 @@ pub async fn baking_rights(
     let has_all = query.contains_key("all");
 
     match services::protocol::check_and_get_baking_rights(
+        &chain_id,
         &block_hash,
         level,
         delegate,
@@ -119,6 +121,7 @@ pub async fn endorsing_rights(
 
     // get RPC response and unpack it from RpcResponseData enum
     match services::protocol::check_and_get_endorsing_rights(
+        &chain_id,
         &block_hash,
         level,
         delegate,

--- a/rpc/src/server/protocol_handler.rs
+++ b/rpc/src/server/protocol_handler.rs
@@ -63,14 +63,18 @@ pub async fn baking_rights(
     let has_all = query.contains_key("all");
 
     match services::protocol::check_and_get_baking_rights(
+        &chain_id,
         &block_hash,
         level,
         delegate,
         cycle,
         max_priority,
         has_all,
+        // block_metadata,
         &env,
-    ) {
+    )
+    .await
+    {
         Ok(Some(rights)) => result_to_json_response(Ok(Some(rights)), env.log()),
         Ok(None) => {
             let res: Result<Option<String>, RpcServiceError> = Ok(None);
@@ -116,13 +120,16 @@ pub async fn endorsing_rights(
 
     // get RPC response and unpack it from RpcResponseData enum
     match services::protocol::check_and_get_endorsing_rights(
+        &chain_id,
         &block_hash,
         level,
         delegate,
         cycle,
         has_all,
         &env,
-    ) {
+    )
+    .await
+    {
         Ok(Some(rights)) => result_to_json_response(Ok(Some(rights)), env.log()),
         Ok(None) => {
             let res: Result<Option<String>, RpcServiceError> = Ok(None);

--- a/rpc/src/server/router.rs
+++ b/rpc/src/server/router.rs
@@ -226,6 +226,16 @@ pub(crate) fn create_routes(tezedge_is_enabled: bool) -> PathTree<MethodHandler>
     );
 
     // Protocol rpcs - implemented
+    routes.handle(
+        hash_set![Method::GET],
+        "/chains/:chain_id/blocks/:block_id/helpers/baking_rights",
+        protocol_handler::baking_rights,
+    );
+    routes.handle(
+        hash_set![Method::GET],
+        "/chains/:chain_id/blocks/:block_id/helpers/endorsing_rights",
+        protocol_handler::endorsing_rights,
+    );
 
     // TODO - TE-261: we are routing these to OCaml for now, even when the TezEdge
     // context is available. Once these handlers have been tested better and revised, enable again.
@@ -235,16 +245,6 @@ pub(crate) fn create_routes(tezedge_is_enabled: bool) -> PathTree<MethodHandler>
             hash_set![Method::GET],
             "/chains/:chain_id/blocks/:block_id/context/constants",
             protocol_handler::context_constants,
-        );
-        routes.handle(
-            hash_set![Method::GET],
-            "/chains/:chain_id/blocks/:block_id/helpers/baking_rights",
-            protocol_handler::baking_rights,
-        );
-        routes.handle(
-            hash_set![Method::GET],
-            "/chains/:chain_id/blocks/:block_id/helpers/endorsing_rights",
-            protocol_handler::endorsing_rights,
         );
         routes.handle(
             hash_set![Method::GET],
@@ -285,6 +285,11 @@ pub(crate) fn create_routes(tezedge_is_enabled: bool) -> PathTree<MethodHandler>
         hash_set![Method::GET],
         "/dev/version",
         dev_handler::dev_version,
+    );
+    routes.handle(
+        hash_set![Method::GET],
+        "/dev/chains/:chain_id/blocks/:block_id/cycle_eras",
+        dev_handler::cycle_eras,
     );
     routes.handle(
         hash_set![Method::GET],

--- a/rpc/src/services/protocol/mod.rs
+++ b/rpc/src/services/protocol/mod.rs
@@ -842,11 +842,8 @@ pub(crate) struct ContextProtocolParam {
 }
 
 #[derive(Debug, Error)]
+#[allow(clippy::enum_variant_names)]
 pub enum ContextParamsError {
-    // #[error("Protocol not found in context for block: {0}")]
-    // NoProtocolForBlock(String),
-    // #[error("Protocol constants not found in context for block: {0}")]
-    // NoConstantsForBlock(String),
     #[error("Storage error occurred, reason: {reason}")]
     StorageError { reason: storage::StorageError },
     #[error("Context error occurred, reason: {reason}")]
@@ -978,12 +975,12 @@ pub(crate) fn get_context_protocol_params(
     })
 }
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 #[allow(clippy::enum_variant_names)]
 pub enum MetadataParsingError {
-    #[fail(display = "Cannot parse block metadata, key: {}", key)]
+    #[error("Cannot parse block metadata, key: {key}")]
     ParsingError { key: &'static str },
-    #[fail(display = "Key not found in block metadata, key: {}", key)]
+    #[error("Key not found in block metadata, key: {key}")]
     KeyNotFoundError { key: &'static str },
 }
 

--- a/rpc/src/services/protocol/mod.rs
+++ b/rpc/src/services/protocol/mod.rs
@@ -91,6 +91,13 @@ impl From<anyhow::Error> for RightsError {
 ///
 /// Prepare all data to generate baking rights and then use Tezos PRNG to generate them.
 #[allow(clippy::too_many_arguments)]
+#[cached(
+    name = "BAKING_RIGHTS_CACHE",
+    type = "TimedSizedCache<(ChainId, BlockHash, Option<String>, Option<String>, Option<String>, Option<String>, bool), Option<Vec<RpcJsonMap>>>",
+    create = "{TimedSizedCache::with_size_and_lifespan(TIMED_SIZED_CACHE_SIZE, TIMED_SIZED_CACHE_TTL_IN_SECS)}",
+    convert = "{(chain_id.clone(), block_hash.clone(), level.map(|v| v.to_string()), delegate.map(|v| v.to_string()), cycle.map(|v| v.to_string()), max_priority.map(|v| v.to_string()), has_all)}",
+    result = true,
+)]
 pub(crate) async fn check_and_get_baking_rights(
     chain_id: &ChainId,
     block_hash: &BlockHash,
@@ -269,7 +276,13 @@ pub(crate) async fn check_and_get_baking_rights(
 /// * `state` - Current RPC collected state (head).
 ///
 /// Prepare all data to generate endorsing rights and then use Tezos PRNG to generate them.
-#[allow(clippy::too_many_arguments)]
+#[cached(
+    name = "ENDORSING_RIGHTS_CACHE",
+    type = "TimedSizedCache<(ChainId, BlockHash, Option<String>, Option<String>, Option<String>, bool), Option<Vec<RpcJsonMap>>>",
+    create = "{TimedSizedCache::with_size_and_lifespan(TIMED_SIZED_CACHE_SIZE, TIMED_SIZED_CACHE_TTL_IN_SECS)}",
+    convert = "{(chain_id.clone(), block_hash.clone(), level.map(|v| v.to_string()), delegate.map(|v| v.to_string()), cycle.map(|v| v.to_string()), has_all)}",
+    result = true,
+)]
 pub(crate) async fn check_and_get_endorsing_rights(
     chain_id: &ChainId,
     block_hash: &BlockHash,

--- a/rpc/src/services/protocol/proto_001/helpers.rs
+++ b/rpc/src/services/protocol/proto_001/helpers.rs
@@ -50,14 +50,15 @@ impl RightsConstants {
     pub(crate) fn parse_rights_constants(
         context_proto_param: &ContextProtocolParam,
     ) -> Result<Self, anyhow::Error> {
-        let protocol_constants: ProtocolConstants = serde_json::from_str(&context_proto_param.constants_data)?;
+        let protocol_constants: ProtocolConstants =
+            serde_json::from_str(&context_proto_param.constants_data)?;
 
         Ok(Self {
             blocks_per_cycle: protocol_constants.blocks_per_cycle,
             preserved_cycles: protocol_constants.preserved_cycles,
             nonce_length: protocol_constants.nonce_length,
             time_between_blocks: protocol_constants.time_between_blocks,
-            endorsers_per_block: protocol_constants.endorsers_per_block ,
+            endorsers_per_block: protocol_constants.endorsers_per_block,
         })
     }
 }
@@ -68,11 +69,7 @@ pub(crate) fn get_cycle_data(
     cycle_meta_storage: &CycleMetaStorage,
 ) -> Result<CycleData, anyhow::Error> {
     // prepare cycle for which rollers are selected
-    let requested_cycle = if let Some(cycle) = *parameters.requested_cycle() {
-        cycle
-    } else {
-        block_cycle
-    };
+    let requested_cycle = parameters.requested_cycle().unwrap_or(block_cycle);
 
     if let Some(cycle_meta_data) = cycle_meta_storage.get(&requested_cycle)? {
         Ok(cycle_meta_data)
@@ -381,9 +378,6 @@ pub fn init_prng(
     let state = cycle_meta_data.seed_bytes();
     let zero_bytes: Vec<u8> = vec![0; nonce_size];
 
-    // the position of the block in its cycle; has to be i32
-    // let cycle_position: i32 = level_position(level, blocks_per_cycle)?;
-
     // take the state (initially the random seed), zero bytes, the use string and the blocks position in the cycle as bytes, merge them together and hash the result
     let rd = blake2b::digest_256(&merge_slices!(
         state,
@@ -456,7 +450,6 @@ impl RightsMetadata {
         requested_level: i32,
     ) -> Result<Self, RightsConstantError> {
         Ok(Self {
-            // (cycle_from_level(requested_level, blocks_per_cycle)?, level_position(requested_level, blocks_per_cycle)?)
             block_cycle: cycle_from_level(requested_level, blocks_per_cycle)?,
             block_cycle_position: level_position(requested_level, blocks_per_cycle)?,
         })

--- a/rpc/src/services/protocol/proto_001/helpers.rs
+++ b/rpc/src/services/protocol/proto_001/helpers.rs
@@ -23,6 +23,8 @@ use crate::services::protocol::{
     parse_block_metadata_level, ContextProtocolParam, MetadataParsingError,
 };
 
+use super::ProtocolConstants;
+
 /// Context constants used in baking and endorsing rights
 #[derive(Debug, Clone, Getters)]
 pub struct RightsConstants {
@@ -42,10 +44,6 @@ pub struct RightsConstants {
 pub enum RightsConstantError {
     #[error("The value is illegal, key: {key}")]
     WrongValue { key: &'static str },
-    #[error("Key cannot be parsed, key: {key}")]
-    Parsing { key: &'static str },
-    #[error("Key cannot be found in constants, key: {key}")]
-    KeyNotFound { key: &'static str },
 }
 
 impl RightsConstants {
@@ -58,80 +56,14 @@ impl RightsConstants {
     pub(crate) fn parse_rights_constants(
         context_proto_param: &ContextProtocolParam,
     ) -> Result<Self, anyhow::Error> {
-        if let Some(constatns_deserialized) =
-            serde_json::from_str::<serde_json::Value>(&context_proto_param.constants_data)?
-                .as_object()
-        {
-            let blocks_per_cycle = get_constant_i64(constatns_deserialized, "blocks_per_cycle")?;
-            let preserved_cycles = get_constant_i64(constatns_deserialized, "preserved_cycles")?;
-            let nonce_length = get_constant_i64(constatns_deserialized, "nonce_length")?;
-            let time_between_blocks = get_time_between_blocks(constatns_deserialized)?;
-            let endorsers_per_block =
-                get_constant_i64(constatns_deserialized, "endorsers_per_block")?;
+        let protocol_constants: ProtocolConstants = serde_json::from_str(&context_proto_param.constants_data)?;
 
-            Ok(Self {
-                blocks_per_cycle: blocks_per_cycle as i32,
-                preserved_cycles: preserved_cycles as u8,
-                nonce_length: nonce_length as u8,
-                time_between_blocks,
-                endorsers_per_block: endorsers_per_block as u16,
-            })
-        } else {
-            bail!("Constants not an object")
-        }
-    }
-}
-
-fn get_constant_i64(
-    constants: &serde_json::Map<String, serde_json::Value>,
-    key: &'static str,
-) -> Result<i64, RightsConstantError> {
-    if let Some(value) = constants.get(key) {
-        if let Some(i64_value) = value.as_i64() {
-            Ok(i64_value)
-        } else {
-            if let Some(str_num) = value.as_str() {
-                return str_num
-                    .parse()
-                    .map_err(|_| RightsConstantError::Parsing { key });
-            }
-            Err(RightsConstantError::Parsing { key })
-        }
-    } else {
-        Err(RightsConstantError::KeyNotFound { key })
-    }
-}
-
-fn get_time_between_blocks(
-    constants: &serde_json::Map<String, serde_json::Value>,
-) -> Result<Vec<i64>, RightsConstantError> {
-    let mut ret: Vec<i64> = Vec::new();
-    if let Some(value) = constants.get("time_between_blocks") {
-        if let Some(array) = value.as_array() {
-            for e in array {
-                if let Some(str_element) = e.as_str() {
-                    let parsed =
-                        str_element
-                            .parse::<i64>()
-                            .map_err(|_| RightsConstantError::Parsing {
-                                key: "time_between_blocks",
-                            })?;
-                    ret.push(parsed);
-                } else {
-                    return Err(RightsConstantError::Parsing {
-                        key: "time_between_blocks",
-                    });
-                }
-            }
-            Ok(ret)
-        } else {
-            Err(RightsConstantError::Parsing {
-                key: "time_between_blocks",
-            })
-        }
-    } else {
-        Err(RightsConstantError::KeyNotFound {
-            key: "time_between_blocks",
+        Ok(Self {
+            blocks_per_cycle: protocol_constants.blocks_per_cycle,
+            preserved_cycles: protocol_constants.preserved_cycles,
+            nonce_length: protocol_constants.nonce_length,
+            time_between_blocks: protocol_constants.time_between_blocks,
+            endorsers_per_block: protocol_constants.endorsers_per_block ,
         })
     }
 }

--- a/rpc/src/services/protocol/proto_001/helpers.rs
+++ b/rpc/src/services/protocol/proto_001/helpers.rs
@@ -1,26 +1,27 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::sync::Arc;
 
-use anyhow::{bail, format_err};
+use crypto::hash::ChainId;
+use anyhow::bail;
 use getset::Getters;
 use thiserror::Error;
 
-use crypto::hash::ContextHash;
 use crypto::{
     blake2b::{self, Blake2bError},
     crypto_box::PublicKeyError,
 };
-use storage::{num_from_slice, BlockHeaderWithHash};
-use tezos_context::context_key_owned;
-use tezos_messages::base::signature_public_key_hash::SignaturePublicKeyHash;
-use tezos_messages::p2p::binary_message::BinaryRead;
+use storage::cycle_storage::CycleData;
+use storage::{num_from_slice, BlockHeaderWithHash, CycleMetaStorage};
 
+use crate::helpers::{parse_block_hash, BlockMetadata};
 use crate::merge_slices;
-use crate::services::protocol::ContextProtocolParam;
-use tezos_wrapper::TezedgeContextClient;
+use crate::server::RpcServiceEnvironment;
+use crate::services::protocol::{
+    parse_block_metadata_level, ContextProtocolParam, MetadataParsingError,
+};
 
 /// Context constants used in baking and endorsing rights
 #[derive(Debug, Clone, Getters)]
@@ -34,31 +35,20 @@ pub struct RightsConstants {
     #[get = "pub(crate)"]
     time_between_blocks: Vec<i64>,
     #[get = "pub(crate)"]
-    blocks_per_roll_snapshot: i32,
-    #[get = "pub(crate)"]
     endorsers_per_block: u16,
 }
 
-impl RightsConstants {
-    /// simple constructor to create RightsConstants
-    pub fn new(
-        blocks_per_cycle: i32,
-        preserved_cycles: u8,
-        nonce_length: u8,
-        time_between_blocks: Vec<i64>,
-        blocks_per_roll_snapshot: i32,
-        endorsers_per_block: u16,
-    ) -> Self {
-        Self {
-            blocks_per_cycle,
-            preserved_cycles,
-            nonce_length,
-            time_between_blocks,
-            blocks_per_roll_snapshot,
-            endorsers_per_block,
-        }
-    }
+#[derive(Debug, Error)]
+pub enum RightsConstantError {
+    #[error("The value is illegal, key: {key}")]
+    WrongValue { key: &'static str },
+    #[error("Key cannot be parsed, key: {key}")]
+    Parsing { key: &'static str },
+    #[error("Key cannot be found in constants, key: {key}")]
+    KeyNotFound { key: &'static str },
+}
 
+impl RightsConstants {
     /// Get all context constants which are used in endorsing and baking rights generation
     ///
     /// # Arguments
@@ -68,168 +58,103 @@ impl RightsConstants {
     pub(crate) fn parse_rights_constants(
         context_proto_param: &ContextProtocolParam,
     ) -> Result<Self, anyhow::Error> {
-        let dynamic =
-            tezos_messages::protocol::proto_001::constants::ParametricConstants::from_bytes(
-                &context_proto_param.constants_data,
-            )?;
-        // in proto 001, the constants are hard coded but a few exceptions modifiable in the context
-        let dynamic_all = tezos_messages::protocol::proto_001::constants::ParametricConstants::create_with_default_and_merge(dynamic);
-        let fixed = tezos_messages::protocol::proto_001::constants::FIXED;
-
-        // TODO: fix unwraps()
-        Ok(RightsConstants::new(
-            dynamic_all.blocks_per_cycle().unwrap(),
-            dynamic_all.preserved_cycles().unwrap(),
-            fixed.nonce_length(),
-            dynamic_all.time_between_blocks().as_ref().unwrap().clone(),
-            dynamic_all.blocks_per_roll_snapshot().unwrap(),
-            dynamic_all.endorsers_per_block().unwrap(),
-        ))
-    }
-}
-
-/// Data from context DB for completing baking and endorsing rights
-#[derive(Debug, Clone, Getters)]
-pub struct RightsContextData {
-    /// Random seed for Tezos PRNG
-    #[get = "pub(crate)"]
-    random_seed: Vec<u8>,
-
-    /// Number of last roll so Tezos PRNG will not overflow
-    #[get = "pub(crate)"]
-    last_roll: i32,
-
-    /// List of rolls mapped to rollers contract id
-    #[get = "pub(crate)"]
-    rolls: HashMap<i32, String>,
-}
-
-impl RightsContextData {
-    /// Simple constructor to create RightsContextData
-    pub fn new(random_seed: Vec<u8>, last_roll: i32, rolls: HashMap<i32, String>) -> Self {
-        Self {
-            random_seed,
-            last_roll,
-            rolls,
-        }
-    }
-
-    /// Get context data roll_snapshot, random_seed, last_roll and rolls from context list
-    ///
-    /// # Arguments
-    ///
-    /// * `parameters` - Parameters created by [RightsParams](RightsParams::parse_rights_parameters).
-    /// * `constants` - Context constants used in baking and endorsing rights.
-    /// * `list` - Context list handler.
-    ///
-    /// Return RightsContextData.
-    pub(crate) fn prepare_context_data_for_rights(
-        parameters: RightsParams,
-        constants: RightsConstants,
-        (ctx_hash, context): (&ContextHash, &TezedgeContextClient),
-    ) -> Result<Self, anyhow::Error> {
-        // prepare constants that are used
-        let blocks_per_cycle = *constants.blocks_per_cycle();
-
-        // prepare parameters that are used
-        let requested_level = *parameters.requested_level();
-
-        // prepare cycle for which rollers are selected
-        let requested_cycle = if let Some(cycle) = *parameters.requested_cycle() {
-            cycle
-        } else {
-            cycle_from_level(requested_level, blocks_per_cycle)?
-        };
-
-        // get index of roll snapshot
-        let roll_snapshot: i16 = {
-            if let Some(data) = context.get_key_from_history(
-                &ctx_hash,
-                context_key_owned!("data/cycle/{}/roll_snapshot", requested_cycle),
-            )? {
-                num_from_slice!(data, 0, i16)
-            } else {
-                // key not found - prepare error for later processing
-                return Err(format_err!("roll_snapshot"));
-            }
-        };
-
-        let random_seed = {
-            if let Some(data) = context.get_key_from_history(
-                &ctx_hash,
-                context_key_owned!("data/cycle/{}/random_seed", requested_cycle),
-            )? {
-                data
-            } else {
-                // key not found - prepare error for later processing
-                return Err(format_err!("random_seed"));
-            }
-        };
-
-        // Snapshots of last_roll are listed from 0 same as roll_snapshot.
-        let last_roll = {
-            if let Some(data) = context.get_key_from_history(
-                &ctx_hash,
-                context_key_owned!("data/cycle/{}/last_roll/{}", requested_cycle, roll_snapshot),
-            )? {
-                num_from_slice!(data, 0, i32)
-            } else {
-                // key not found - prepare error for later processing
-                return Err(format_err!("last_roll"));
-            }
-        };
-
-        // get list of rolls from context list
-        let context_rolls = if let Some(rolls) =
-            Self::get_context_rolls((&ctx_hash, &context), requested_cycle, roll_snapshot)?
+        if let Some(constatns_deserialized) =
+            serde_json::from_str::<serde_json::Value>(&context_proto_param.constants_data)?
+                .as_object()
         {
-            rolls
-        } else {
-            return Err(format_err!("rolls"));
-        };
+            let blocks_per_cycle = get_constant_i64(constatns_deserialized, "blocks_per_cycle")?;
+            let preserved_cycles = get_constant_i64(constatns_deserialized, "preserved_cycles")?;
+            let nonce_length = get_constant_i64(constatns_deserialized, "nonce_length")?;
+            let time_between_blocks = get_time_between_blocks(constatns_deserialized)?;
+            let endorsers_per_block =
+                get_constant_i64(constatns_deserialized, "endorsers_per_block")?;
 
-        Ok(Self::new(random_seed.to_vec(), last_roll, context_rolls))
+            Ok(Self {
+                blocks_per_cycle: blocks_per_cycle as i32,
+                preserved_cycles: preserved_cycles as u8,
+                nonce_length: nonce_length as u8,
+                time_between_blocks,
+                endorsers_per_block: endorsers_per_block as u16,
+            })
+        } else {
+            bail!("Constants not an object")
+        }
     }
+}
 
-    /// get list of rollers from context list selected by snapshot level
-    ///
-    /// # Arguments
-    ///
-    /// * `context` - context list HashMap from [get_context_as_hashmap](RightsContextData::get_context_as_hashmap)
-    ///
-    /// Return rollers for [RightsContextData.rolls](RightsContextData.rolls)
-    fn get_context_rolls(
-        (ctx_hash, context): (&ContextHash, &TezedgeContextClient),
-        cycle: i64,
-        snapshot: i16,
-    ) -> Result<Option<HashMap<i32, String>>, anyhow::Error> {
-        let rolls = if let Some(val) = context.get_key_values_by_prefix(
-            &ctx_hash,
-            context_key_owned!("data/rolls/owner/snapshot/{}/{}", cycle, snapshot),
-        )? {
-            val
+fn get_constant_i64(
+    constants: &serde_json::Map<String, serde_json::Value>,
+    key: &'static str,
+) -> Result<i64, RightsConstantError> {
+    if let Some(value) = constants.get(key) {
+        if let Some(i64_value) = value.as_i64() {
+            Ok(i64_value)
         } else {
-            bail!("No rolls found in context")
-        };
-
-        let mut roll_owners: HashMap<i32, String> = HashMap::new();
-
-        // iterate through all the owners,the roll_num is the last component of the key, decode the value (it is a public key) to get the public key hash address (tz1...)
-        for (key, value) in rolls.into_iter() {
-            if key.last().is_none() {
-                continue;
+            if let Some(str_num) = value.as_str() {
+                return str_num
+                    .parse()
+                    .map_err(|_| RightsConstantError::Parsing { key });
             }
-            let roll_num = key.last().unwrap();
+            Err(RightsConstantError::Parsing { key })
+        }
+    } else {
+        Err(RightsConstantError::KeyNotFound { key })
+    }
+}
 
-            // the values are public keys
-            let delegate = SignaturePublicKeyHash::from_tagged_bytes(value.clone())?
-                .to_string_representation();
-            roll_owners.insert(roll_num.parse()?, delegate);
+fn get_time_between_blocks(
+    constants: &serde_json::Map<String, serde_json::Value>,
+) -> Result<Vec<i64>, RightsConstantError> {
+    let mut ret: Vec<i64> = Vec::new();
+    if let Some(value) = constants.get("time_between_blocks") {
+        if let Some(array) = value.as_array() {
+            for e in array {
+                if let Some(str_element) = e.as_str() {
+                    let parsed =
+                        str_element
+                            .parse::<i64>()
+                            .map_err(|_| RightsConstantError::Parsing {
+                                key: "time_between_blocks",
+                            })?;
+                    ret.push(parsed);
+                } else {
+                    return Err(RightsConstantError::Parsing {
+                        key: "time_between_blocks",
+                    });
+                }
+            }
+            Ok(ret)
+        } else {
+            Err(RightsConstantError::Parsing {
+                key: "time_between_blocks",
+            })
         }
-        if roll_owners.is_empty() {
-            bail!("No rolls assigned, all rolls happened to be DELETED")
-        }
-        Ok(Some(roll_owners))
+    } else {
+        Err(RightsConstantError::KeyNotFound {
+            key: "time_between_blocks",
+        })
+    }
+}
+
+pub(crate) fn get_cycle_data(
+    parameters: RightsParams,
+    block_cycle: i32,
+    cycle_meta_storage: &CycleMetaStorage,
+) -> Result<CycleData, anyhow::Error> {
+    // prepare cycle for which rollers are selected
+    let requested_cycle = if let Some(cycle) = *parameters.requested_cycle() {
+        cycle
+    } else {
+        block_cycle
+    };
+
+    if let Some(cycle_meta_data) = cycle_meta_storage.get(&requested_cycle)? {
+        Ok(cycle_meta_data)
+    } else {
+        bail!(
+            "No cycle data found for requested_cycle: {}",
+            requested_cycle
+        )
     }
 }
 
@@ -238,7 +163,7 @@ impl RightsContextData {
 pub struct RightsParams {
     /// Level (height) of block. Parsed from url path parameter 'block_id'.
     #[get = "pub(crate)"]
-    block_level: i64,
+    block_level: i32,
 
     /// Header timestamp of block. Parsed from url path parameter 'block_id'.
     #[get = "pub(crate)"]
@@ -250,41 +175,46 @@ pub struct RightsParams {
 
     /// Cycle for whitch all rights will be listed. Url query parameter 'cycle'.
     #[get = "pub(crate)"]
-    requested_cycle: Option<i64>,
+    requested_cycle: Option<i32>,
 
     /// Level (height) of block for whitch all rights will be listed. Url query parameter 'level'.
     #[get = "pub(crate)"]
-    requested_level: i64,
+    requested_level: i32,
 
     /// Level to be displayed in output.
     #[get = "pub(crate)"]
-    display_level: i64,
+    display_level: i32,
 
     /// Level for estimated_time computation. Endorsing rights only.
     #[get = "pub(crate)"]
-    timestamp_level: i64,
+    timestamp_level: i32,
 
     /// Max priority to which baking rights are listed. Url query parameter 'max_priority'.
     #[get = "pub(crate)"]
-    max_priority: i64,
+    max_priority: i32,
 
     /// Indicate that baking rights for maximum priority should be listed. Url query parameter 'all'.
     #[get = "pub(crate)"]
     has_all: bool,
+
+    #[get = "pub(crate)"]
+    rights_metadata: RightsMetadata,
 }
 
 impl RightsParams {
     /// Simple constructor to create RightsParams
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
-        block_level: i64,
+        block_level: i32,
         block_timestamp: i64,
         requested_delegate: Option<String>,
-        requested_cycle: Option<i64>,
-        requested_level: i64,
-        display_level: i64,
-        timestamp_level: i64,
-        max_priority: i64,
+        requested_cycle: Option<i32>,
+        requested_level: i32,
+        display_level: i32,
+        timestamp_level: i32,
+        max_priority: i32,
         has_all: bool,
+        rights_metadata: RightsMetadata,
     ) -> Self {
         Self {
             block_level,
@@ -296,6 +226,7 @@ impl RightsParams {
             timestamp_level,
             max_priority,
             has_all,
+            rights_metadata,
         }
     }
 
@@ -315,7 +246,8 @@ impl RightsParams {
     /// * `is_baking_rights` - flag to identify if are parsed baking or endorsing rights
     ///
     /// Return RightsParams
-    pub(crate) fn parse_rights_parameters(
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn parse_rights_parameters(
         param_level: Option<&str>,
         param_delegate: Option<&str>,
         param_cycle: Option<&str>,
@@ -323,30 +255,25 @@ impl RightsParams {
         param_has_all: bool,
         rights_constants: &RightsConstants,
         block_header: &BlockHeaderWithHash,
+        chain_id: &ChainId,
+        env: &RpcServiceEnvironment,
         is_baking_rights: bool,
     ) -> Result<Self, anyhow::Error> {
-        let block_level: i64 = block_header.header.level().into();
+        let block_level = block_header.header.level();
         let preserved_cycles = *rights_constants.preserved_cycles();
         let blocks_per_cycle = *rights_constants.blocks_per_cycle();
 
         // this is the cycle of block_id level
-        let current_cycle = cycle_from_level(block_level, blocks_per_cycle)?;
 
         // display_level is here because of corner case where all levels < 1 are computed as level 1 but oputputed as they are
-        let mut display_level: i64 = block_level;
+        let mut display_level: i32 = block_level;
         // endorsing rights only: timestamp_level is the base level for timestamp computation is taken from last known block (block_id) timestamp + time_between_blocks[0]
-        let mut timestamp_level: i64 = block_level;
+        let mut timestamp_level: i32 = block_level;
         // Check the param_level, if there is a level specified validate it, if no set it to the block_level
         // requested_level is used to get data from context list
-        let requested_level: i64 = match param_level {
+        let requested_level: i32 = match param_level {
             Some(level) => {
                 let level = level.parse()?;
-                // check the bounds for the requested level (if it is in the previous/next preserved cycles)
-                Self::validate_cycle(
-                    cycle_from_level(level, blocks_per_cycle)?,
-                    current_cycle,
-                    preserved_cycles,
-                )?;
                 // display level is always same as level requested
                 display_level = level;
                 // endorsing rights: to compute timestamp for level parameter there need to be taken timestamp of previous block
@@ -371,11 +298,37 @@ impl RightsParams {
             }
         };
 
+        let block_metadata = match crate::services::base_services::get_block_metadata(
+            chain_id,
+            &parse_block_hash(chain_id, &requested_level.to_string(), env)?,
+            env,
+        )
+        .await
+        {
+            Ok(metadata) => Some(metadata),
+            Err(_) => None,
+        };
+
+        let rights_metadata = if let Some(metadata) = block_metadata {
+            RightsMetadata::extract_from_block_metadata(metadata)?
+        } else if param_level.is_some() {
+            RightsMetadata::calculate(blocks_per_cycle, requested_level)?
+        } else {
+            // this should never happen. When block_metadata is not available it means we requested a future level (thus level is always Some())
+            bail!("No level parameter in url")
+        };
+
+        Self::validate_cycle(
+            cycle_from_level(requested_level, blocks_per_cycle)?,
+            rights_metadata.block_cycle,
+            preserved_cycles,
+        )?;
+
         // validate requested cycle
         let requested_cycle = match param_cycle {
             Some(val) => Some(Self::validate_cycle(
                 val.parse()?,
-                current_cycle,
+                rights_metadata.block_cycle,
                 preserved_cycles,
             )?),
             None => None,
@@ -397,6 +350,7 @@ impl RightsParams {
             timestamp_level, // endorsing rights only
             max_priority,
             param_has_all,
+            rights_metadata,
         ))
     }
 
@@ -412,7 +366,7 @@ impl RightsParams {
     pub fn get_estimated_time(
         &self,
         constants: &RightsConstants,
-        level: Option<i64>,
+        level: Option<i32>,
     ) -> Option<i64> {
         // if is cycle then level is provided as parameter else use prepared timestamp_level
         let timestamp_level = level.unwrap_or(self.timestamp_level);
@@ -431,13 +385,17 @@ impl RightsParams {
     /// Validate if cycle requested as url query parameter (cycle or level) is available in context list by checking preserved_cycles constant
     #[inline]
     fn validate_cycle(
-        requested_cycle: i64,
-        current_cycle: i64,
+        requested_cycle: i32,
+        current_cycle: i32,
         preserved_cycles: u8,
-    ) -> Result<i64, anyhow::Error> {
-        if (requested_cycle - current_cycle).abs() <= (preserved_cycles as i64) {
+    ) -> Result<i32, anyhow::Error> {
+        if (requested_cycle - current_cycle).abs() <= preserved_cycles.into() {
             Ok(requested_cycle)
         } else {
+            // TODO: proper json response is needed for this
+            // Octez is:
+            //    [{ "kind": "permanent", "id": "proto.008-PtEdo2Zk.seed.unknown_seed",
+            //        "oldest": 330, "requested": 200, "latest": 340 }]
             bail!("Requested cycle out of bounds") //TODO: prepare cycle error
         }
     }
@@ -464,47 +422,6 @@ impl EndorserSlots {
     /// Push endorsing slot to slots
     pub fn push_to_slot(&mut self, slot: u16) {
         self.slots.push(slot);
-    }
-}
-
-/// Return cycle in which is given level
-///
-/// # Arguments
-///
-/// * `level` - level to specify cycle for
-/// * `blocks_per_cycle` - context constant
-///
-/// Level 0 (genesis block) is not part of any cycle (cycle 0 starts at level 1),
-/// hence the blocks_per_cycle - 1 for last cycle block.
-pub fn cycle_from_level(level: i64, blocks_per_cycle: i32) -> Result<i64, anyhow::Error> {
-    // check if blocks_per_cycle is not 0 to prevent panic
-    if blocks_per_cycle > 0 {
-        Ok((level - 1) / (blocks_per_cycle as i64))
-    } else {
-        bail!("wrong value blocks_per_cycle={}", blocks_per_cycle)
-    }
-}
-
-/// Return the position of the block in its cycle
-///
-/// # Arguments
-///
-/// * `level` - level to specify cycle for
-/// * `blocks_per_cycle` - context constant
-///
-/// Level 0 (genesis block) is not part of any cycle (cycle 0 starts at level 1),
-/// hence the blocks_per_cycle - 1 for last cycle block.
-pub fn level_position(level: i32, blocks_per_cycle: i32) -> Result<i32, anyhow::Error> {
-    // check if blocks_per_cycle is not 0 to prevent panic
-    if blocks_per_cycle <= 0 {
-        bail!("wrong value blocks_per_cycle={}", blocks_per_cycle);
-    }
-    let cycle_position = (level % blocks_per_cycle) - 1;
-    if cycle_position < 0 {
-        //for last block
-        Ok(blocks_per_cycle - 1)
-    } else {
-        Ok(cycle_position)
     }
 }
 
@@ -546,24 +463,23 @@ pub type TezosPRNGResult = Result<(i32, RandomSeedState), TezosPRNGError>;
 /// Return first random sequence state to use in [get_prng_number](`get_prng_number`)
 #[inline]
 pub fn init_prng(
-    cycle_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
     constants: &RightsConstants,
     use_string_bytes: &[u8],
-    level: i32,
+    cycle_position: i32,
     offset: i32,
 ) -> Result<RandomSeedState, anyhow::Error> {
     // a safe way to convert betwwen types is to use try_from
     let nonce_size = usize::try_from(*constants.nonce_length())?;
-    let blocks_per_cycle = *constants.blocks_per_cycle();
-    let state = cycle_data.random_seed();
+    let state = cycle_meta_data.seed_bytes();
     let zero_bytes: Vec<u8> = vec![0; nonce_size];
 
     // the position of the block in its cycle; has to be i32
-    let cycle_position: i32 = level_position(level, blocks_per_cycle)?;
+    // let cycle_position: i32 = level_position(level, blocks_per_cycle)?;
 
     // take the state (initially the random seed), zero bytes, the use string and the blocks position in the cycle as bytes, merge them together and hash the result
     let rd = blake2b::digest_256(&merge_slices!(
-        &state,
+        state,
         &zero_bytes,
         use_string_bytes,
         &cycle_position.to_be_bytes()
@@ -616,4 +532,89 @@ pub fn get_prng_number(state: RandomSeedState, bound: i32) -> TezosPRNGResult {
         };
     }
     Ok((v, sequence))
+}
+
+#[derive(Debug, Clone, Getters)]
+pub struct RightsMetadata {
+    #[get = "pub(crate)"]
+    block_cycle: i32,
+
+    #[get = "pub(crate)"]
+    block_cycle_position: i32,
+}
+
+impl RightsMetadata {
+    pub fn extract_from_block_metadata(
+        block_metadata: Arc<BlockMetadata>,
+    ) -> Result<Self, MetadataParsingError> {
+        let (block_cycle, block_cycle_position) =
+            match parse_block_metadata_level(&block_metadata, "level_info") {
+                Ok(cycle_data) => cycle_data,
+                Err(MetadataParsingError::KeyNotFoundError { key: _ }) => {
+                    // No level info found, trying the older scheme
+                    parse_block_metadata_level(&block_metadata, "level")?
+                }
+                Err(e) => return Err(e),
+            };
+        Ok(Self {
+            block_cycle,
+            block_cycle_position,
+        })
+    }
+
+    pub fn calculate(
+        blocks_per_cycle: i32,
+        requested_level: i32,
+    ) -> Result<Self, RightsConstantError> {
+        Ok(Self {
+            // (cycle_from_level(requested_level, blocks_per_cycle)?, level_position(requested_level, blocks_per_cycle)?)
+            block_cycle: cycle_from_level(requested_level, blocks_per_cycle)?,
+            block_cycle_position: level_position(requested_level, blocks_per_cycle)?,
+        })
+    }
+}
+
+/// Return cycle in which is given level
+///
+/// # Arguments
+///
+/// * `level` - level to specify cycle for
+/// * `blocks_per_cycle` - context constant
+///
+/// Level 0 (genesis block) is not part of any cycle (cycle 0 starts at level 1),
+/// hence the blocks_per_cycle - 1 for last cycle block.
+pub fn cycle_from_level(level: i32, blocks_per_cycle: i32) -> Result<i32, RightsConstantError> {
+    // check if blocks_per_cycle is not 0 to prevent panic
+    if blocks_per_cycle > 0 {
+        Ok((level - 1) / blocks_per_cycle)
+    } else {
+        Err(RightsConstantError::WrongValue {
+            key: "blocks_per_cycle",
+        })
+    }
+}
+
+/// Return the position of the block in its cycle
+///
+/// # Arguments
+///
+/// * `level` - level to specify cycle for
+/// * `blocks_per_cycle` - context constant
+///
+/// Level 0 (genesis block) is not part of any cycle (cycle 0 starts at level 1),
+/// hence the blocks_per_cycle - 1 for last cycle block.
+pub fn level_position(level: i32, blocks_per_cycle: i32) -> Result<i32, RightsConstantError> {
+    // check if blocks_per_cycle is not 0 to prevent panic
+    if blocks_per_cycle <= 0 {
+        return Err(RightsConstantError::WrongValue {
+            key: "blocks_per_cycle",
+        });
+    }
+    let cycle_position = (level % blocks_per_cycle) - 1;
+    if cycle_position < 0 {
+        //for last block
+        Ok(blocks_per_cycle - 1)
+    } else {
+        Ok(cycle_position)
+    }
 }

--- a/rpc/src/services/protocol/proto_001/mod.rs
+++ b/rpc/src/services/protocol/proto_001/mod.rs
@@ -1,5 +1,69 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
+use serde::Deserialize;
+use getset::CopyGetters;
+use num::BigInt;
+
 mod helpers;
 pub(crate) mod rights_service;
+
+use super::{vec_string_to_int, string_to_int};
+
+#[derive(Debug, Deserialize, Clone, CopyGetters)]
+pub(crate) struct ProtocolConstants {
+    proof_of_work_nonce_size: u8,
+    nonce_length: u8,
+    max_revelations_per_block: u8,
+    max_operation_data_length: i32,
+    preserved_cycles: u8,
+
+    #[get_copy = "pub(crate)"]
+    blocks_per_cycle: i32,
+    
+    blocks_per_commitment: i32,
+    blocks_per_roll_snapshot: i32,
+    blocks_per_voting_period: i32,
+
+    #[serde(with = "vec_string_to_int")]
+    time_between_blocks: Vec<i64>,
+    
+    endorsers_per_block: u16,
+
+    #[serde(with = "string_to_int")]
+    origination_burn: BigInt,
+
+    #[serde(with = "string_to_int")]
+    hard_gas_limit_per_operation: BigInt,
+
+    #[serde(with = "string_to_int")]
+    hard_gas_limit_per_block: BigInt,
+
+    #[serde(with = "string_to_int")]
+    proof_of_work_threshold: BigInt,
+
+    #[serde(with = "string_to_int")]
+    tokens_per_roll: BigInt,
+    michelson_maximum_type_size: u16,
+
+    #[serde(with = "string_to_int")]
+    seed_nonce_revelation_tip: BigInt,
+
+    #[serde(with = "string_to_int")]
+    block_security_deposit: BigInt,
+
+    #[serde(with = "string_to_int")]
+    endorsement_security_deposit: BigInt,
+
+    #[serde(with = "string_to_int")]
+    block_reward: BigInt,
+
+    #[serde(with = "string_to_int")]
+    endorsement_reward: BigInt,
+
+    #[serde(with = "string_to_int")]
+    cost_per_byte: BigInt,
+
+    #[serde(with = "string_to_int")]
+    hard_storage_limit_per_operation: BigInt,
+}

--- a/rpc/src/services/protocol/proto_001/mod.rs
+++ b/rpc/src/services/protocol/proto_001/mod.rs
@@ -1,14 +1,14 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use serde::Deserialize;
 use getset::CopyGetters;
 use num::BigInt;
+use serde::Deserialize;
 
 mod helpers;
 pub(crate) mod rights_service;
 
-use super::{vec_string_to_int, string_to_int};
+use super::{string_to_int, vec_string_to_int};
 
 #[derive(Debug, Deserialize, Clone, CopyGetters)]
 pub(crate) struct ProtocolConstants {
@@ -20,14 +20,14 @@ pub(crate) struct ProtocolConstants {
 
     #[get_copy = "pub(crate)"]
     blocks_per_cycle: i32,
-    
+
     blocks_per_commitment: i32,
     blocks_per_roll_snapshot: i32,
     blocks_per_voting_period: i32,
 
     #[serde(with = "vec_string_to_int")]
     time_between_blocks: Vec<i64>,
-    
+
     endorsers_per_block: u16,
 
     #[serde(with = "string_to_int")]

--- a/rpc/src/services/protocol/proto_001/rights_service.rs
+++ b/rpc/src/services/protocol/proto_001/rights_service.rs
@@ -16,7 +16,6 @@ use std::convert::TryInto;
 use anyhow::format_err;
 use itertools::Itertools;
 
-use crypto::hash::ChainId;
 use tezos_messages::base::rpc_support::{RpcJsonMap, ToRpcJsonMap};
 use tezos_messages::base::signature_public_key_hash::SignaturePublicKeyHash;
 use tezos_messages::protocol::proto_001::rights::{BakingRights, EndorsingRight};
@@ -24,7 +23,6 @@ use tezos_messages::protocol::proto_001::rights::{BakingRights, EndorsingRight};
 use storage::cycle_storage::CycleData;
 use storage::CycleMetaStorage;
 
-use crate::server::RpcServiceEnvironment;
 use crate::services::dev_services::contract_id_to_contract_address_for_index;
 use crate::services::protocol::proto_001::helpers::{
     get_cycle_data, get_prng_number, init_prng, level_position, EndorserSlots, RightsConstants,
@@ -58,8 +56,6 @@ pub(crate) async fn check_and_get_baking_rights(
     max_priority: Option<&str>,
     has_all: bool,
     cycle_meta_storage: &CycleMetaStorage,
-    chain_id: &ChainId,
-    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -72,8 +68,6 @@ pub(crate) async fn check_and_get_baking_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
-        chain_id,
-        env,
         true,
     )
     .await?;
@@ -314,8 +308,6 @@ pub(crate) async fn check_and_get_endorsing_rights(
     cycle: Option<&str>,
     has_all: bool,
     cycle_meta_storage: &CycleMetaStorage,
-    chain_id: &ChainId,
-    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -328,8 +320,6 @@ pub(crate) async fn check_and_get_endorsing_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
-        chain_id,
-        env,
         false,
     )
     .await?;

--- a/rpc/src/services/protocol/proto_001/rights_service.rs
+++ b/rpc/src/services/protocol/proto_001/rights_service.rs
@@ -110,25 +110,17 @@ pub(crate) fn get_baking_rights(
     let cycle_position = *rights_metadata.block_cycle_position();
 
     // build a reverse map of rols so we have access in O(1)
-    // let rolls_map: HashMap<i32, String> = HashMap::new();
-    let rolls_map: HashMap<i32, String> = cycle_meta_data
-        .rolls_data()
-        .iter()
-        .map(|(delegate, rolls)| {
-            rolls
-                .iter()
-                .map(|roll| {
-                    (
-                        *roll,
-                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
-                            .unwrap()
-                            .to_string_representation(),
-                    )
-                })
-                .collect::<HashMap<i32, String>>()
-        })
-        .flatten()
-        .collect();
+    let mut rolls_map: HashMap<i32, String> = HashMap::new();
+
+    for (delegate, rolls) in cycle_meta_data.rolls_data() {
+        for roll in rolls {
+            rolls_map.insert(
+                *roll,
+                SignaturePublicKeyHash::from_tagged_bytes(delegate.to_vec())?
+                    .to_string_representation(),
+            );
+        }
+    }
 
     // iterate through the whole cycle if necessery
     if let Some(cycle) = parameters.requested_cycle() {
@@ -348,24 +340,18 @@ fn get_endorsing_rights(
     // define helper and output variables
     let mut endorsing_rights = Vec::<EndorsingRight>::new();
 
-    let rolls_map: HashMap<i32, String> = cycle_meta_data
-        .rolls_data()
-        .iter()
-        .map(|(delegate, rolls)| {
-            rolls
-                .iter()
-                .map(|roll| {
-                    (
-                        *roll,
-                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
-                            .unwrap()
-                            .to_string_representation(),
-                    )
-                })
-                .collect::<HashMap<i32, String>>()
-        })
-        .flatten()
-        .collect();
+    // build a reverse map of rols so we have access in O(1)
+    let mut rolls_map: HashMap<i32, String> = HashMap::new();
+
+    for (delegate, rolls) in cycle_meta_data.rolls_data() {
+        for roll in rolls {
+            rolls_map.insert(
+                *roll,
+                SignaturePublicKeyHash::from_tagged_bytes(delegate.to_vec())?
+                    .to_string_representation(),
+            );
+        }
+    }
 
     // when query param cycle is specified then iterate over all cycle levels, else only given level
     if let Some(cycle) = parameters.requested_cycle() {

--- a/rpc/src/services/protocol/proto_001/rights_service.rs
+++ b/rpc/src/services/protocol/proto_001/rights_service.rs
@@ -16,16 +16,23 @@ use std::convert::TryInto;
 use anyhow::format_err;
 use itertools::Itertools;
 
-use crate::services::dev_services::contract_id_to_contract_address_for_index;
+use crypto::hash::ChainId;
 use tezos_messages::base::rpc_support::{RpcJsonMap, ToRpcJsonMap};
 use tezos_messages::base::signature_public_key_hash::SignaturePublicKeyHash;
 use tezos_messages::protocol::proto_001::rights::{BakingRights, EndorsingRight};
-use tezos_wrapper::TezedgeContextClient;
 
+use storage::cycle_storage::CycleData;
+use storage::CycleMetaStorage;
+
+use crate::server::RpcServiceEnvironment;
+use crate::services::dev_services::contract_id_to_contract_address_for_index;
 use crate::services::protocol::proto_001::helpers::{
-    get_prng_number, init_prng, EndorserSlots, RightsConstants, RightsContextData, RightsParams,
+    get_cycle_data, get_prng_number, init_prng, level_position, EndorserSlots, RightsConstants,
+    RightsParams,
 };
 use crate::services::protocol::ContextProtocolParam;
+
+use super::helpers::RightsMetadata;
 
 /// Return generated baking rights.
 ///
@@ -42,14 +49,17 @@ use crate::services::protocol::ContextProtocolParam;
 /// * `state` - Current RPC collected state (head).
 ///
 /// Prepare all data to generate baking rights and then use Tezos PRNG to generate them.
-pub(crate) fn check_and_get_baking_rights(
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn check_and_get_baking_rights(
     context_proto_params: ContextProtocolParam,
     level: Option<&str>,
     delegate: Option<&str>,
     cycle: Option<&str>,
     max_priority: Option<&str>,
     has_all: bool,
-    context: &TezedgeContextClient,
+    cycle_meta_storage: &CycleMetaStorage,
+    chain_id: &ChainId,
+    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -62,16 +72,24 @@ pub(crate) fn check_and_get_baking_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
+        chain_id,
+        env,
         true,
-    )?;
+    )
+    .await?;
 
-    let context_data: RightsContextData = RightsContextData::prepare_context_data_for_rights(
+    let cycle_meta_data = get_cycle_data(
         params.clone(),
-        constants.clone(),
-        (&context_proto_params.block_header.header.context(), context),
+        *params.rights_metadata().block_cycle(),
+        cycle_meta_storage,
     )?;
 
-    get_baking_rights(&context_data, &params, &constants)
+    get_baking_rights(
+        &cycle_meta_data,
+        &params,
+        &constants,
+        params.rights_metadata(),
+    )
 }
 
 /// Use prepared data to generate baking rights
@@ -83,9 +101,10 @@ pub(crate) fn check_and_get_baking_rights(
 /// * `constants` - Context constants used in baking and endorsing rights [RightsConstants](RightsConstants::parse_rights_constants).
 #[inline]
 pub(crate) fn get_baking_rights(
-    context_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
     parameters: &RightsParams,
     constants: &RightsConstants,
+    rights_metadata: &RightsMetadata,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let mut baking_rights = Vec::<BakingRights>::new();
 
@@ -94,22 +113,48 @@ pub(crate) fn get_baking_rights(
 
     let timestamp = parameters.block_timestamp();
     let block_level = parameters.block_level();
+    let cycle_position = *rights_metadata.block_cycle_position();
+
+    // build a reverse map of rols so we have access in O(1)
+    // let rolls_map: HashMap<i32, String> = HashMap::new();
+    let rolls_map: HashMap<i32, String> = cycle_meta_data
+        .rolls_data()
+        .iter()
+        .map(|(delegate, rolls)| {
+            rolls
+                .iter()
+                .map(|roll| {
+                    (
+                        *roll,
+                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
+                            .unwrap()
+                            .to_string_representation(),
+                    )
+                })
+                .collect::<HashMap<i32, String>>()
+        })
+        .flatten()
+        .collect();
 
     // iterate through the whole cycle if necessery
     if let Some(cycle) = parameters.requested_cycle() {
-        let first_block_level = cycle * (blocks_per_cycle as i64) + 1;
-        let last_block_level = first_block_level + (blocks_per_cycle as i64);
+        let first_block_level: i32 = cycle * blocks_per_cycle + 1;
+        let last_block_level = first_block_level + blocks_per_cycle;
 
         for level in first_block_level..last_block_level {
-            let seconds_to_add = (level - block_level).abs() * time_between_blocks[0];
+            let block_level_diff: i64 = (level - block_level).abs().into();
+            let seconds_to_add: i64 = block_level_diff * time_between_blocks[0];
             let estimated_timestamp = timestamp + seconds_to_add;
+            let cycle_position = level_position(level, blocks_per_cycle)?;
 
             // assign rolls goes here
             baking_rights_assign_rolls(
-                &parameters,
-                &constants,
-                &context_data,
-                level.try_into()?,
+                parameters,
+                constants,
+                cycle_meta_data,
+                &rolls_map,
+                level,
+                cycle_position,
                 estimated_timestamp,
                 true,
                 &mut baking_rights,
@@ -119,14 +164,17 @@ pub(crate) fn get_baking_rights(
         }
     } else {
         let level = *parameters.requested_level();
-        let seconds_to_add = (level - block_level).abs() * time_between_blocks[0];
+        let block_level_diff: i64 = (level - block_level).abs().into();
+        let seconds_to_add: i64 = block_level_diff * time_between_blocks[0];
         let estimated_timestamp = timestamp + seconds_to_add;
         // assign rolls goes here
         baking_rights_assign_rolls(
-            &parameters,
-            &constants,
-            &context_data,
-            level.try_into()?,
+            parameters,
+            constants,
+            cycle_meta_data,
+            &rolls_map,
+            level,
+            cycle_position,
             estimated_timestamp,
             false,
             &mut baking_rights,
@@ -165,11 +213,14 @@ pub(crate) fn get_baking_rights(
 ///
 /// Baking priorities are are assigned to Roles, the default behavior is to include only the top priority for the delegate
 #[inline]
+#[allow(clippy::too_many_arguments)]
 fn baking_rights_assign_rolls(
     parameters: &RightsParams,
     constants: &RightsConstants,
-    context_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
+    rolls_map: &HashMap<i32, String>,
     level: i32,
+    cycle_position: i32,
     estimated_head_timestamp: i64,
     is_cycle: bool,
     baking_rights: &mut Vec<BakingRights>,
@@ -184,20 +235,19 @@ fn baking_rights_assign_rolls(
     let max_priority = *parameters.max_priority();
     let has_all = parameters.has_all();
     let block_level = *parameters.block_level();
-    let last_roll = *context_data.last_roll();
-    let rolls_map = context_data.rolls();
-    let display_level: i32 = (*parameters.display_level()).try_into()?;
+    let last_roll = *cycle_meta_data.last_roll();
+    let display_level: i32 = *parameters.display_level();
 
     for priority in 0..max_priority {
         // draw the rolls for the requested parameters
         let delegate_to_assign;
         // TODO: priority can overflow in the ocaml code, do a priority % i32::max_value()
         let mut state = init_prng(
-            &context_data,
-            &constants,
+            cycle_meta_data,
+            constants,
             BAKING_USE_STRING,
-            level,
-            priority.try_into()?,
+            cycle_position,
+            priority,
         )?;
 
         loop {
@@ -217,7 +267,7 @@ fn baking_rights_assign_rolls(
         }
 
         // we omit the estimated_time field if the block on the requested level is already baked
-        let priority_timestamp = if block_level < (level as i64) {
+        let priority_timestamp = if block_level < level {
             let time = if time_between_blocks.len() == 1 {
                 time_between_blocks[0]
             } else {
@@ -233,7 +283,7 @@ fn baking_rights_assign_rolls(
 
         baking_rights.push(BakingRights::new(
             rights_level,
-            SignaturePublicKeyHash::from_b58_hash(&delegate_to_assign)?,
+            SignaturePublicKeyHash::from_b58_hash(delegate_to_assign)?,
             priority as u16,
             priority_timestamp,
         ));
@@ -256,13 +306,16 @@ fn baking_rights_assign_rolls(
 /// * `state` - Current RPC collected state (head).
 ///
 /// Prepare all data to generate endorsing rights and then use Tezos PRNG to generate them.
-pub(crate) fn check_and_get_endorsing_rights(
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn check_and_get_endorsing_rights(
     context_proto_params: ContextProtocolParam,
     level: Option<&str>,
     delegate: Option<&str>,
     cycle: Option<&str>,
     has_all: bool,
-    context: &TezedgeContextClient,
+    cycle_meta_storage: &CycleMetaStorage,
+    chain_id: &ChainId,
+    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -275,16 +328,19 @@ pub(crate) fn check_and_get_endorsing_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
+        chain_id,
+        env,
         false,
-    )?;
+    )
+    .await?;
 
-    let context_data: RightsContextData = RightsContextData::prepare_context_data_for_rights(
+    let cycle_meta_data = get_cycle_data(
         params.clone(),
-        constants.clone(),
-        (&context_proto_params.block_header.header.context(), context),
+        *params.rights_metadata().block_cycle(),
+        cycle_meta_storage,
     )?;
 
-    get_endorsing_rights(&context_data, &params, &constants)
+    get_endorsing_rights(&cycle_meta_data, &params, &constants)
 }
 
 /// Use prepared data to generate endosring rights
@@ -295,31 +351,52 @@ pub(crate) fn check_and_get_endorsing_rights(
 /// * `parameters` - Parameters created by [RightsParams](RightsParams::parse_rights_parameters).
 /// * `constants` - Context constants used in baking and endorsing rights [RightsConstants](RightsConstants::parse_rights_constants).
 fn get_endorsing_rights(
-    context_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
     parameters: &RightsParams,
     constants: &RightsConstants,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     // define helper and output variables
     let mut endorsing_rights = Vec::<EndorsingRight>::new();
 
+    let rolls_map: HashMap<i32, String> = cycle_meta_data
+        .rolls_data()
+        .iter()
+        .map(|(delegate, rolls)| {
+            rolls
+                .iter()
+                .map(|roll| {
+                    (
+                        *roll,
+                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
+                            .unwrap()
+                            .to_string_representation(),
+                    )
+                })
+                .collect::<HashMap<i32, String>>()
+        })
+        .flatten()
+        .collect();
+
     // when query param cycle is specified then iterate over all cycle levels, else only given level
     if let Some(cycle) = parameters.requested_cycle() {
         let blocks_per_cycle = *constants.blocks_per_cycle();
-        let first_cycle_level = cycle * (blocks_per_cycle as i64) + 1;
-        let last_cycle_level = first_cycle_level + (blocks_per_cycle as i64);
+        let first_cycle_level = cycle * blocks_per_cycle + 1;
+        let last_cycle_level = first_cycle_level + blocks_per_cycle;
         for level in first_cycle_level..last_cycle_level {
             // get estimated time first because is equal for all endorsers in given level
             // the base level for estimated time computation is level of previous block
             let estimated_time: Option<i64> =
                 parameters.get_estimated_time(constants, Some(level - 1));
+            let cycle_position = level_position(level, blocks_per_cycle)?;
 
             complete_endorsing_rights_for_level(
-                context_data,
+                cycle_meta_data,
                 parameters,
                 constants,
-                level,
+                &rolls_map,
                 level,
                 estimated_time,
+                cycle_position,
                 &mut endorsing_rights,
             )?;
             // endorsing_rights = merge_slices!(&endorsing_rights, &level_endorsing_rights);
@@ -329,12 +406,13 @@ fn get_endorsing_rights(
         let estimated_time: Option<i64> = parameters.get_estimated_time(constants, None);
 
         complete_endorsing_rights_for_level(
-            context_data,
+            cycle_meta_data,
             parameters,
             constants,
-            *parameters.requested_level(),
+            &rolls_map,
             *parameters.display_level(),
             estimated_time,
+            *parameters.rights_metadata().block_cycle_position(),
             &mut endorsing_rights,
         )?;
     };
@@ -358,17 +436,20 @@ fn get_endorsing_rights(
 /// * `display_level` - Level to be displayed in output.
 /// * `estimated_time` - Estimated time of endorsement, is set to None if in past relative to block_id.
 #[inline]
+#[allow(clippy::too_many_arguments)]
 fn complete_endorsing_rights_for_level(
-    context_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
     parameters: &RightsParams,
     constants: &RightsConstants,
-    level: i64,
-    display_level: i64,
+    rolls_map: &HashMap<i32, String>,
+    display_level: i32,
     estimated_time: Option<i64>,
+    cycle_position: i32,
     endorsing_rights: &mut Vec<EndorsingRight>,
 ) -> Result<(), anyhow::Error> {
     // endorsers_slots is needed to group all slots by delegate
-    let endorsers_slots = get_endorsers_slots(constants, context_data, level)?;
+    let endorsers_slots =
+        get_endorsers_slots(constants, cycle_meta_data, rolls_map, cycle_position)?;
 
     // convert contract id to hash contract address hex byte string (needed for ordering)
     let mut endorers_slots_keys_for_order: HashMap<String, String> = HashMap::new();
@@ -399,8 +480,8 @@ fn complete_endorsing_rights_for_level(
         }
 
         endorsing_rights.push(EndorsingRight::new(
-            display_level.try_into()?,
-            SignaturePublicKeyHash::from_b58_hash(&delegate_contract_id)?,
+            display_level,
+            SignaturePublicKeyHash::from_b58_hash(delegate_contract_id)?,
             delegate_data.slots().clone(),
             estimated_time,
         ))
@@ -418,28 +499,29 @@ fn complete_endorsing_rights_for_level(
 #[inline]
 fn get_endorsers_slots(
     constants: &RightsConstants,
-    context_data: &RightsContextData,
-    level: i64,
+    cycle_meta_data: &CycleData,
+    rolls_map: &HashMap<i32, String>,
+    cycle_position: i32,
 ) -> Result<HashMap<String, EndorserSlots>, anyhow::Error> {
     // special byte string used in Tezos PRNG
     const ENDORSEMENT_USE_STRING: &[u8] = b"level endorsement:";
     // prepare helper variable
     let mut endorsers_slots: HashMap<String, EndorserSlots> = HashMap::new();
 
-    for endorser_slot in (0..*constants.endorsers_per_block() as u8).rev() {
+    for endorser_slot in (0..*constants.endorsers_per_block()).rev() {
         // generate PRNG per endorsement slot and take delegates by roll number from context_rolls
         // if roll number is not found then reroll with new state till roll nuber is found in context_rolls
         let mut state = init_prng(
-            &context_data,
-            &constants,
+            cycle_meta_data,
+            constants,
             ENDORSEMENT_USE_STRING,
-            level.try_into()?,
+            cycle_position,
             endorser_slot.try_into()?,
         )?;
         loop {
-            let (random_num, sequence) = get_prng_number(state, *context_data.last_roll())?;
+            let (random_num, sequence) = get_prng_number(state, *cycle_meta_data.last_roll())?;
 
-            if let Some(delegate) = context_data.rolls().get(&random_num) {
+            if let Some(delegate) = rolls_map.get(&random_num) {
                 // collect all slots for each delegate
                 let endorsers_slots_entry = endorsers_slots
                     .entry(delegate.clone())

--- a/rpc/src/services/protocol/proto_002/helpers.rs
+++ b/rpc/src/services/protocol/proto_002/helpers.rs
@@ -50,14 +50,15 @@ impl RightsConstants {
     pub(crate) fn parse_rights_constants(
         context_proto_param: &ContextProtocolParam,
     ) -> Result<Self, anyhow::Error> {
-        let protocol_constants: ProtocolConstants = serde_json::from_str(&context_proto_param.constants_data)?;
+        let protocol_constants: ProtocolConstants =
+            serde_json::from_str(&context_proto_param.constants_data)?;
 
         Ok(Self {
             blocks_per_cycle: protocol_constants.blocks_per_cycle,
             preserved_cycles: protocol_constants.preserved_cycles,
             nonce_length: protocol_constants.nonce_length,
             time_between_blocks: protocol_constants.time_between_blocks,
-            endorsers_per_block: protocol_constants.endorsers_per_block ,
+            endorsers_per_block: protocol_constants.endorsers_per_block,
         })
     }
 }
@@ -68,11 +69,7 @@ pub(crate) fn get_cycle_data(
     cycle_meta_storage: &CycleMetaStorage,
 ) -> Result<CycleData, anyhow::Error> {
     // prepare cycle for which rollers are selected
-    let requested_cycle = if let Some(cycle) = *parameters.requested_cycle() {
-        cycle
-    } else {
-        block_cycle
-    };
+    let requested_cycle = parameters.requested_cycle().unwrap_or(block_cycle);
 
     if let Some(cycle_meta_data) = cycle_meta_storage.get(&requested_cycle)? {
         Ok(cycle_meta_data)
@@ -381,9 +378,6 @@ pub fn init_prng(
     let state = cycle_meta_data.seed_bytes();
     let zero_bytes: Vec<u8> = vec![0; nonce_size];
 
-    // the position of the block in its cycle; has to be i32
-    // let cycle_position: i32 = level_position(level, blocks_per_cycle)?;
-
     // take the state (initially the random seed), zero bytes, the use string and the blocks position in the cycle as bytes, merge them together and hash the result
     let rd = blake2b::digest_256(&merge_slices!(
         state,
@@ -456,7 +450,6 @@ impl RightsMetadata {
         requested_level: i32,
     ) -> Result<Self, RightsConstantError> {
         Ok(Self {
-            // (cycle_from_level(requested_level, blocks_per_cycle)?, level_position(requested_level, blocks_per_cycle)?)
             block_cycle: cycle_from_level(requested_level, blocks_per_cycle)?,
             block_cycle_position: level_position(requested_level, blocks_per_cycle)?,
         })

--- a/rpc/src/services/protocol/proto_002/helpers.rs
+++ b/rpc/src/services/protocol/proto_002/helpers.rs
@@ -23,6 +23,8 @@ use crate::services::protocol::{
     parse_block_metadata_level, ContextProtocolParam, MetadataParsingError,
 };
 
+use super::ProtocolConstants;
+
 /// Context constants used in baking and endorsing rights
 #[derive(Debug, Clone, Getters)]
 pub struct RightsConstants {
@@ -42,10 +44,6 @@ pub struct RightsConstants {
 pub enum RightsConstantError {
     #[error("The value is illegal, key: {key}")]
     WrongValue { key: &'static str },
-    #[error("Key cannot be parsed, key: {key}")]
-    Parsing { key: &'static str },
-    #[error("Key cannot be found in constants, key: {key}")]
-    KeyNotFound { key: &'static str },
 }
 
 impl RightsConstants {
@@ -58,80 +56,14 @@ impl RightsConstants {
     pub(crate) fn parse_rights_constants(
         context_proto_param: &ContextProtocolParam,
     ) -> Result<Self, anyhow::Error> {
-        if let Some(constatns_deserialized) =
-            serde_json::from_str::<serde_json::Value>(&context_proto_param.constants_data)?
-                .as_object()
-        {
-            let blocks_per_cycle = get_constant_i64(constatns_deserialized, "blocks_per_cycle")?;
-            let preserved_cycles = get_constant_i64(constatns_deserialized, "preserved_cycles")?;
-            let nonce_length = get_constant_i64(constatns_deserialized, "nonce_length")?;
-            let time_between_blocks = get_time_between_blocks(constatns_deserialized)?;
-            let endorsers_per_block =
-                get_constant_i64(constatns_deserialized, "endorsers_per_block")?;
+        let protocol_constants: ProtocolConstants = serde_json::from_str(&context_proto_param.constants_data)?;
 
-            Ok(Self {
-                blocks_per_cycle: blocks_per_cycle as i32,
-                preserved_cycles: preserved_cycles as u8,
-                nonce_length: nonce_length as u8,
-                time_between_blocks,
-                endorsers_per_block: endorsers_per_block as u16,
-            })
-        } else {
-            bail!("Constants not an object")
-        }
-    }
-}
-
-fn get_constant_i64(
-    constants: &serde_json::Map<String, serde_json::Value>,
-    key: &'static str,
-) -> Result<i64, RightsConstantError> {
-    if let Some(value) = constants.get(key) {
-        if let Some(i64_value) = value.as_i64() {
-            Ok(i64_value)
-        } else {
-            if let Some(str_num) = value.as_str() {
-                return str_num
-                    .parse()
-                    .map_err(|_| RightsConstantError::Parsing { key });
-            }
-            Err(RightsConstantError::Parsing { key })
-        }
-    } else {
-        Err(RightsConstantError::KeyNotFound { key })
-    }
-}
-
-fn get_time_between_blocks(
-    constants: &serde_json::Map<String, serde_json::Value>,
-) -> Result<Vec<i64>, RightsConstantError> {
-    let mut ret: Vec<i64> = Vec::new();
-    if let Some(value) = constants.get("time_between_blocks") {
-        if let Some(array) = value.as_array() {
-            for e in array {
-                if let Some(str_element) = e.as_str() {
-                    let parsed =
-                        str_element
-                            .parse::<i64>()
-                            .map_err(|_| RightsConstantError::Parsing {
-                                key: "time_between_blocks",
-                            })?;
-                    ret.push(parsed);
-                } else {
-                    return Err(RightsConstantError::Parsing {
-                        key: "time_between_blocks",
-                    });
-                }
-            }
-            Ok(ret)
-        } else {
-            Err(RightsConstantError::Parsing {
-                key: "time_between_blocks",
-            })
-        }
-    } else {
-        Err(RightsConstantError::KeyNotFound {
-            key: "time_between_blocks",
+        Ok(Self {
+            blocks_per_cycle: protocol_constants.blocks_per_cycle,
+            preserved_cycles: protocol_constants.preserved_cycles,
+            nonce_length: protocol_constants.nonce_length,
+            time_between_blocks: protocol_constants.time_between_blocks,
+            endorsers_per_block: protocol_constants.endorsers_per_block ,
         })
     }
 }

--- a/rpc/src/services/protocol/proto_002/helpers.rs
+++ b/rpc/src/services/protocol/proto_002/helpers.rs
@@ -1,26 +1,27 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::sync::Arc;
 
-use anyhow::{bail, format_err};
+use crypto::hash::ChainId;
+use anyhow::bail;
 use getset::Getters;
-use tezos_context::context_key_owned;
 use thiserror::Error;
 
-use crypto::hash::ContextHash;
 use crypto::{
     blake2b::{self, Blake2bError},
     crypto_box::PublicKeyError,
 };
-use storage::{num_from_slice, BlockHeaderWithHash};
-use tezos_messages::base::signature_public_key_hash::SignaturePublicKeyHash;
-use tezos_messages::p2p::binary_message::BinaryRead;
-use tezos_wrapper::TezedgeContextClient;
+use storage::cycle_storage::CycleData;
+use storage::{num_from_slice, BlockHeaderWithHash, CycleMetaStorage};
 
+use crate::helpers::{parse_block_hash, BlockMetadata};
 use crate::merge_slices;
-use crate::services::protocol::ContextProtocolParam;
+use crate::server::RpcServiceEnvironment;
+use crate::services::protocol::{
+    parse_block_metadata_level, ContextProtocolParam, MetadataParsingError,
+};
 
 /// Context constants used in baking and endorsing rights
 #[derive(Debug, Clone, Getters)]
@@ -34,31 +35,20 @@ pub struct RightsConstants {
     #[get = "pub(crate)"]
     time_between_blocks: Vec<i64>,
     #[get = "pub(crate)"]
-    blocks_per_roll_snapshot: i32,
-    #[get = "pub(crate)"]
     endorsers_per_block: u16,
 }
 
-impl RightsConstants {
-    /// simple constructor to create RightsConstants
-    pub fn new(
-        blocks_per_cycle: i32,
-        preserved_cycles: u8,
-        nonce_length: u8,
-        time_between_blocks: Vec<i64>,
-        blocks_per_roll_snapshot: i32,
-        endorsers_per_block: u16,
-    ) -> Self {
-        Self {
-            blocks_per_cycle,
-            preserved_cycles,
-            nonce_length,
-            time_between_blocks,
-            blocks_per_roll_snapshot,
-            endorsers_per_block,
-        }
-    }
+#[derive(Debug, Error)]
+pub enum RightsConstantError {
+    #[error("The value is illegal, key: {key}")]
+    WrongValue { key: &'static str },
+    #[error("Key cannot be parsed, key: {key}")]
+    Parsing { key: &'static str },
+    #[error("Key cannot be found in constants, key: {key}")]
+    KeyNotFound { key: &'static str },
+}
 
+impl RightsConstants {
     /// Get all context constants which are used in endorsing and baking rights generation
     ///
     /// # Arguments
@@ -68,168 +58,103 @@ impl RightsConstants {
     pub(crate) fn parse_rights_constants(
         context_proto_param: &ContextProtocolParam,
     ) -> Result<Self, anyhow::Error> {
-        let dynamic =
-            tezos_messages::protocol::proto_002::constants::ParametricConstants::from_bytes(
-                &context_proto_param.constants_data,
-            )?;
-        // in proto 001, the constants are hard coded but a few exceptions modifiable in the context
-        let dynamic_all = tezos_messages::protocol::proto_002::constants::ParametricConstants::create_with_default_and_merge(dynamic);
-        let fixed = tezos_messages::protocol::proto_002::constants::FIXED;
-
-        // TODO: fix unwraps()
-        Ok(RightsConstants::new(
-            dynamic_all.blocks_per_cycle().unwrap(),
-            dynamic_all.preserved_cycles().unwrap(),
-            fixed.nonce_length(),
-            dynamic_all.time_between_blocks().as_ref().unwrap().clone(),
-            dynamic_all.blocks_per_roll_snapshot().unwrap(),
-            dynamic_all.endorsers_per_block().unwrap(),
-        ))
-    }
-}
-
-/// Data from context DB for completing baking and endorsing rights
-#[derive(Debug, Clone, Getters)]
-pub struct RightsContextData {
-    /// Random seed for Tezos PRNG
-    #[get = "pub(crate)"]
-    random_seed: Vec<u8>,
-
-    /// Number of last roll so Tezos PRNG will not overflow
-    #[get = "pub(crate)"]
-    last_roll: i32,
-
-    /// List of rolls mapped to rollers contract id
-    #[get = "pub(crate)"]
-    rolls: HashMap<i32, String>,
-}
-
-impl RightsContextData {
-    /// Simple constructor to create RightsContextData
-    pub fn new(random_seed: Vec<u8>, last_roll: i32, rolls: HashMap<i32, String>) -> Self {
-        Self {
-            random_seed,
-            last_roll,
-            rolls,
-        }
-    }
-
-    /// Get context data roll_snapshot, random_seed, last_roll and rolls from context list
-    ///
-    /// # Arguments
-    ///
-    /// * `parameters` - Parameters created by [RightsParams](RightsParams::parse_rights_parameters).
-    /// * `constants` - Context constants used in baking and endorsing rights.
-    /// * `list` - Context list handler.
-    ///
-    /// Return RightsContextData.
-    pub(crate) fn prepare_context_data_for_rights(
-        parameters: RightsParams,
-        constants: RightsConstants,
-        (ctx_hash, context): (&ContextHash, &TezedgeContextClient),
-    ) -> Result<Self, anyhow::Error> {
-        // prepare constants that are used
-        let blocks_per_cycle = *constants.blocks_per_cycle();
-
-        // prepare parameters that are used
-        let requested_level = *parameters.requested_level();
-
-        // prepare cycle for which rollers are selected
-        let requested_cycle = if let Some(cycle) = *parameters.requested_cycle() {
-            cycle
-        } else {
-            cycle_from_level(requested_level, blocks_per_cycle)?
-        };
-
-        // get index of roll snapshot
-        let roll_snapshot: i16 = {
-            if let Some(data) = context.get_key_from_history(
-                &ctx_hash,
-                context_key_owned!("data/cycle/{}/roll_snapshot", requested_cycle),
-            )? {
-                num_from_slice!(data, 0, i16)
-            } else {
-                // key not found - prepare error for later processing
-                return Err(format_err!("roll_snapshot"));
-            }
-        };
-
-        let random_seed = {
-            if let Some(data) = context.get_key_from_history(
-                &ctx_hash,
-                context_key_owned!("data/cycle/{}/random_seed", requested_cycle),
-            )? {
-                data
-            } else {
-                // key not found - prepare error for later processing
-                return Err(format_err!("random_seed"));
-            }
-        };
-
-        // Snapshots of last_roll are listed from 0 same as roll_snapshot.
-        let last_roll = {
-            if let Some(data) = context.get_key_from_history(
-                &ctx_hash,
-                context_key_owned!("data/cycle/{}/last_roll/{}", requested_cycle, roll_snapshot),
-            )? {
-                num_from_slice!(data, 0, i32)
-            } else {
-                // key not found - prepare error for later processing
-                return Err(format_err!("last_roll"));
-            }
-        };
-
-        // get list of rolls from context list
-        let context_rolls = if let Some(rolls) =
-            Self::get_context_rolls((&ctx_hash, &context), requested_cycle, roll_snapshot)?
+        if let Some(constatns_deserialized) =
+            serde_json::from_str::<serde_json::Value>(&context_proto_param.constants_data)?
+                .as_object()
         {
-            rolls
-        } else {
-            return Err(format_err!("rolls"));
-        };
+            let blocks_per_cycle = get_constant_i64(constatns_deserialized, "blocks_per_cycle")?;
+            let preserved_cycles = get_constant_i64(constatns_deserialized, "preserved_cycles")?;
+            let nonce_length = get_constant_i64(constatns_deserialized, "nonce_length")?;
+            let time_between_blocks = get_time_between_blocks(constatns_deserialized)?;
+            let endorsers_per_block =
+                get_constant_i64(constatns_deserialized, "endorsers_per_block")?;
 
-        Ok(Self::new(random_seed.to_vec(), last_roll, context_rolls))
+            Ok(Self {
+                blocks_per_cycle: blocks_per_cycle as i32,
+                preserved_cycles: preserved_cycles as u8,
+                nonce_length: nonce_length as u8,
+                time_between_blocks,
+                endorsers_per_block: endorsers_per_block as u16,
+            })
+        } else {
+            bail!("Constants not an object")
+        }
     }
+}
 
-    /// get list of rollers from context list selected by snapshot level
-    ///
-    /// # Arguments
-    ///
-    /// * `context` - context list HashMap from [get_context_as_hashmap](RightsContextData::get_context_as_hashmap)
-    ///
-    /// Return rollers for [RightsContextData.rolls](RightsContextData.rolls)
-    fn get_context_rolls(
-        (ctx_hash, context): (&ContextHash, &TezedgeContextClient),
-        cycle: i64,
-        snapshot: i16,
-    ) -> Result<Option<HashMap<i32, String>>, anyhow::Error> {
-        let rolls = if let Some(val) = context.get_key_values_by_prefix(
-            &ctx_hash,
-            context_key_owned!("data/rolls/owner/snapshot/{}/{}", cycle, snapshot),
-        )? {
-            val
+fn get_constant_i64(
+    constants: &serde_json::Map<String, serde_json::Value>,
+    key: &'static str,
+) -> Result<i64, RightsConstantError> {
+    if let Some(value) = constants.get(key) {
+        if let Some(i64_value) = value.as_i64() {
+            Ok(i64_value)
         } else {
-            bail!("No rolls found in context")
-        };
-
-        let mut roll_owners: HashMap<i32, String> = HashMap::new();
-
-        // iterate through all the owners,the roll_num is the last component of the key, decode the value (it is a public key) to get the public key hash address (tz1...)
-        for (key, value) in rolls.into_iter() {
-            if key.last().is_none() {
-                continue;
+            if let Some(str_num) = value.as_str() {
+                return str_num
+                    .parse()
+                    .map_err(|_| RightsConstantError::Parsing { key });
             }
-            let roll_num = key.last().unwrap();
+            Err(RightsConstantError::Parsing { key })
+        }
+    } else {
+        Err(RightsConstantError::KeyNotFound { key })
+    }
+}
 
-            // the values are public keys
-            let delegate = SignaturePublicKeyHash::from_tagged_bytes(value.clone())?
-                .to_string_representation();
-            roll_owners.insert(roll_num.parse()?, delegate);
+fn get_time_between_blocks(
+    constants: &serde_json::Map<String, serde_json::Value>,
+) -> Result<Vec<i64>, RightsConstantError> {
+    let mut ret: Vec<i64> = Vec::new();
+    if let Some(value) = constants.get("time_between_blocks") {
+        if let Some(array) = value.as_array() {
+            for e in array {
+                if let Some(str_element) = e.as_str() {
+                    let parsed =
+                        str_element
+                            .parse::<i64>()
+                            .map_err(|_| RightsConstantError::Parsing {
+                                key: "time_between_blocks",
+                            })?;
+                    ret.push(parsed);
+                } else {
+                    return Err(RightsConstantError::Parsing {
+                        key: "time_between_blocks",
+                    });
+                }
+            }
+            Ok(ret)
+        } else {
+            Err(RightsConstantError::Parsing {
+                key: "time_between_blocks",
+            })
         }
-        if roll_owners.is_empty() {
-            bail!("No rolls assigned, all rolls happened to be DELETED")
-        }
-        Ok(Some(roll_owners))
+    } else {
+        Err(RightsConstantError::KeyNotFound {
+            key: "time_between_blocks",
+        })
+    }
+}
+
+pub(crate) fn get_cycle_data(
+    parameters: RightsParams,
+    block_cycle: i32,
+    cycle_meta_storage: &CycleMetaStorage,
+) -> Result<CycleData, anyhow::Error> {
+    // prepare cycle for which rollers are selected
+    let requested_cycle = if let Some(cycle) = *parameters.requested_cycle() {
+        cycle
+    } else {
+        block_cycle
+    };
+
+    if let Some(cycle_meta_data) = cycle_meta_storage.get(&requested_cycle)? {
+        Ok(cycle_meta_data)
+    } else {
+        bail!(
+            "No cycle data found for requested_cycle: {}",
+            requested_cycle
+        )
     }
 }
 
@@ -238,7 +163,7 @@ impl RightsContextData {
 pub struct RightsParams {
     /// Level (height) of block. Parsed from url path parameter 'block_id'.
     #[get = "pub(crate)"]
-    block_level: i64,
+    block_level: i32,
 
     /// Header timestamp of block. Parsed from url path parameter 'block_id'.
     #[get = "pub(crate)"]
@@ -250,41 +175,46 @@ pub struct RightsParams {
 
     /// Cycle for whitch all rights will be listed. Url query parameter 'cycle'.
     #[get = "pub(crate)"]
-    requested_cycle: Option<i64>,
+    requested_cycle: Option<i32>,
 
     /// Level (height) of block for whitch all rights will be listed. Url query parameter 'level'.
     #[get = "pub(crate)"]
-    requested_level: i64,
+    requested_level: i32,
 
     /// Level to be displayed in output.
     #[get = "pub(crate)"]
-    display_level: i64,
+    display_level: i32,
 
     /// Level for estimated_time computation. Endorsing rights only.
     #[get = "pub(crate)"]
-    timestamp_level: i64,
+    timestamp_level: i32,
 
     /// Max priority to which baking rights are listed. Url query parameter 'max_priority'.
     #[get = "pub(crate)"]
-    max_priority: i64,
+    max_priority: i32,
 
     /// Indicate that baking rights for maximum priority should be listed. Url query parameter 'all'.
     #[get = "pub(crate)"]
     has_all: bool,
+
+    #[get = "pub(crate)"]
+    rights_metadata: RightsMetadata,
 }
 
 impl RightsParams {
     /// Simple constructor to create RightsParams
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
-        block_level: i64,
+        block_level: i32,
         block_timestamp: i64,
         requested_delegate: Option<String>,
-        requested_cycle: Option<i64>,
-        requested_level: i64,
-        display_level: i64,
-        timestamp_level: i64,
-        max_priority: i64,
+        requested_cycle: Option<i32>,
+        requested_level: i32,
+        display_level: i32,
+        timestamp_level: i32,
+        max_priority: i32,
         has_all: bool,
+        rights_metadata: RightsMetadata,
     ) -> Self {
         Self {
             block_level,
@@ -296,6 +226,7 @@ impl RightsParams {
             timestamp_level,
             max_priority,
             has_all,
+            rights_metadata,
         }
     }
 
@@ -315,7 +246,8 @@ impl RightsParams {
     /// * `is_baking_rights` - flag to identify if are parsed baking or endorsing rights
     ///
     /// Return RightsParams
-    pub(crate) fn parse_rights_parameters(
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn parse_rights_parameters(
         param_level: Option<&str>,
         param_delegate: Option<&str>,
         param_cycle: Option<&str>,
@@ -323,30 +255,25 @@ impl RightsParams {
         param_has_all: bool,
         rights_constants: &RightsConstants,
         block_header: &BlockHeaderWithHash,
+        chain_id: &ChainId,
+        env: &RpcServiceEnvironment,
         is_baking_rights: bool,
     ) -> Result<Self, anyhow::Error> {
-        let block_level: i64 = block_header.header.level().into();
+        let block_level = block_header.header.level();
         let preserved_cycles = *rights_constants.preserved_cycles();
         let blocks_per_cycle = *rights_constants.blocks_per_cycle();
 
         // this is the cycle of block_id level
-        let current_cycle = cycle_from_level(block_level, blocks_per_cycle)?;
 
         // display_level is here because of corner case where all levels < 1 are computed as level 1 but oputputed as they are
-        let mut display_level: i64 = block_level;
+        let mut display_level: i32 = block_level;
         // endorsing rights only: timestamp_level is the base level for timestamp computation is taken from last known block (block_id) timestamp + time_between_blocks[0]
-        let mut timestamp_level: i64 = block_level;
+        let mut timestamp_level: i32 = block_level;
         // Check the param_level, if there is a level specified validate it, if no set it to the block_level
         // requested_level is used to get data from context list
-        let requested_level: i64 = match param_level {
+        let requested_level: i32 = match param_level {
             Some(level) => {
                 let level = level.parse()?;
-                // check the bounds for the requested level (if it is in the previous/next preserved cycles)
-                Self::validate_cycle(
-                    cycle_from_level(level, blocks_per_cycle)?,
-                    current_cycle,
-                    preserved_cycles,
-                )?;
                 // display level is always same as level requested
                 display_level = level;
                 // endorsing rights: to compute timestamp for level parameter there need to be taken timestamp of previous block
@@ -371,11 +298,37 @@ impl RightsParams {
             }
         };
 
+        let block_metadata = match crate::services::base_services::get_block_metadata(
+            chain_id,
+            &parse_block_hash(chain_id, &requested_level.to_string(), env)?,
+            env,
+        )
+        .await
+        {
+            Ok(metadata) => Some(metadata),
+            Err(_) => None,
+        };
+
+        let rights_metadata = if let Some(metadata) = block_metadata {
+            RightsMetadata::extract_from_block_metadata(metadata)?
+        } else if param_level.is_some() {
+            RightsMetadata::calculate(blocks_per_cycle, requested_level)?
+        } else {
+            // this should never happen. When block_metadata is not available it means we requested a future level (thus level is always Some())
+            bail!("No level parameter in url")
+        };
+
+        Self::validate_cycle(
+            cycle_from_level(requested_level, blocks_per_cycle)?,
+            rights_metadata.block_cycle,
+            preserved_cycles,
+        )?;
+
         // validate requested cycle
         let requested_cycle = match param_cycle {
             Some(val) => Some(Self::validate_cycle(
                 val.parse()?,
-                current_cycle,
+                rights_metadata.block_cycle,
                 preserved_cycles,
             )?),
             None => None,
@@ -397,6 +350,7 @@ impl RightsParams {
             timestamp_level, // endorsing rights only
             max_priority,
             param_has_all,
+            rights_metadata,
         ))
     }
 
@@ -412,7 +366,7 @@ impl RightsParams {
     pub fn get_estimated_time(
         &self,
         constants: &RightsConstants,
-        level: Option<i64>,
+        level: Option<i32>,
     ) -> Option<i64> {
         // if is cycle then level is provided as parameter else use prepared timestamp_level
         let timestamp_level = level.unwrap_or(self.timestamp_level);
@@ -431,13 +385,17 @@ impl RightsParams {
     /// Validate if cycle requested as url query parameter (cycle or level) is available in context list by checking preserved_cycles constant
     #[inline]
     fn validate_cycle(
-        requested_cycle: i64,
-        current_cycle: i64,
+        requested_cycle: i32,
+        current_cycle: i32,
         preserved_cycles: u8,
-    ) -> Result<i64, anyhow::Error> {
-        if (requested_cycle - current_cycle).abs() <= (preserved_cycles as i64) {
+    ) -> Result<i32, anyhow::Error> {
+        if (requested_cycle - current_cycle).abs() <= preserved_cycles.into() {
             Ok(requested_cycle)
         } else {
+            // TODO: proper json response is needed for this
+            // Octez is:
+            //    [{ "kind": "permanent", "id": "proto.008-PtEdo2Zk.seed.unknown_seed",
+            //        "oldest": 330, "requested": 200, "latest": 340 }]
             bail!("Requested cycle out of bounds") //TODO: prepare cycle error
         }
     }
@@ -464,47 +422,6 @@ impl EndorserSlots {
     /// Push endorsing slot to slots
     pub fn push_to_slot(&mut self, slot: u16) {
         self.slots.push(slot);
-    }
-}
-
-/// Return cycle in which is given level
-///
-/// # Arguments
-///
-/// * `level` - level to specify cycle for
-/// * `blocks_per_cycle` - context constant
-///
-/// Level 0 (genesis block) is not part of any cycle (cycle 0 starts at level 1),
-/// hence the blocks_per_cycle - 1 for last cycle block.
-pub fn cycle_from_level(level: i64, blocks_per_cycle: i32) -> Result<i64, anyhow::Error> {
-    // check if blocks_per_cycle is not 0 to prevent panic
-    if blocks_per_cycle > 0 {
-        Ok((level - 1) / (blocks_per_cycle as i64))
-    } else {
-        bail!("wrong value blocks_per_cycle={}", blocks_per_cycle)
-    }
-}
-
-/// Return the position of the block in its cycle
-///
-/// # Arguments
-///
-/// * `level` - level to specify cycle for
-/// * `blocks_per_cycle` - context constant
-///
-/// Level 0 (genesis block) is not part of any cycle (cycle 0 starts at level 1),
-/// hence the blocks_per_cycle - 1 for last cycle block.
-pub fn level_position(level: i32, blocks_per_cycle: i32) -> Result<i32, anyhow::Error> {
-    // check if blocks_per_cycle is not 0 to prevent panic
-    if blocks_per_cycle <= 0 {
-        bail!("wrong value blocks_per_cycle={}", blocks_per_cycle);
-    }
-    let cycle_position = (level % blocks_per_cycle) - 1;
-    if cycle_position < 0 {
-        //for last block
-        Ok(blocks_per_cycle - 1)
-    } else {
-        Ok(cycle_position)
     }
 }
 
@@ -546,24 +463,23 @@ pub type TezosPRNGResult = Result<(i32, RandomSeedState), TezosPRNGError>;
 /// Return first random sequence state to use in [get_prng_number](`get_prng_number`)
 #[inline]
 pub fn init_prng(
-    cycle_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
     constants: &RightsConstants,
     use_string_bytes: &[u8],
-    level: i32,
+    cycle_position: i32,
     offset: i32,
 ) -> Result<RandomSeedState, anyhow::Error> {
     // a safe way to convert betwwen types is to use try_from
     let nonce_size = usize::try_from(*constants.nonce_length())?;
-    let blocks_per_cycle = *constants.blocks_per_cycle();
-    let state = cycle_data.random_seed();
+    let state = cycle_meta_data.seed_bytes();
     let zero_bytes: Vec<u8> = vec![0; nonce_size];
 
     // the position of the block in its cycle; has to be i32
-    let cycle_position: i32 = level_position(level, blocks_per_cycle)?;
+    // let cycle_position: i32 = level_position(level, blocks_per_cycle)?;
 
     // take the state (initially the random seed), zero bytes, the use string and the blocks position in the cycle as bytes, merge them together and hash the result
     let rd = blake2b::digest_256(&merge_slices!(
-        &state,
+        state,
         &zero_bytes,
         use_string_bytes,
         &cycle_position.to_be_bytes()
@@ -616,4 +532,89 @@ pub fn get_prng_number(state: RandomSeedState, bound: i32) -> TezosPRNGResult {
         };
     }
     Ok((v, sequence))
+}
+
+#[derive(Debug, Clone, Getters)]
+pub struct RightsMetadata {
+    #[get = "pub(crate)"]
+    block_cycle: i32,
+
+    #[get = "pub(crate)"]
+    block_cycle_position: i32,
+}
+
+impl RightsMetadata {
+    pub fn extract_from_block_metadata(
+        block_metadata: Arc<BlockMetadata>,
+    ) -> Result<Self, MetadataParsingError> {
+        let (block_cycle, block_cycle_position) =
+            match parse_block_metadata_level(&block_metadata, "level_info") {
+                Ok(cycle_data) => cycle_data,
+                Err(MetadataParsingError::KeyNotFoundError { key: _ }) => {
+                    // No level info found, trying the older scheme
+                    parse_block_metadata_level(&block_metadata, "level")?
+                }
+                Err(e) => return Err(e),
+            };
+        Ok(Self {
+            block_cycle,
+            block_cycle_position,
+        })
+    }
+
+    pub fn calculate(
+        blocks_per_cycle: i32,
+        requested_level: i32,
+    ) -> Result<Self, RightsConstantError> {
+        Ok(Self {
+            // (cycle_from_level(requested_level, blocks_per_cycle)?, level_position(requested_level, blocks_per_cycle)?)
+            block_cycle: cycle_from_level(requested_level, blocks_per_cycle)?,
+            block_cycle_position: level_position(requested_level, blocks_per_cycle)?,
+        })
+    }
+}
+
+/// Return cycle in which is given level
+///
+/// # Arguments
+///
+/// * `level` - level to specify cycle for
+/// * `blocks_per_cycle` - context constant
+///
+/// Level 0 (genesis block) is not part of any cycle (cycle 0 starts at level 1),
+/// hence the blocks_per_cycle - 1 for last cycle block.
+pub fn cycle_from_level(level: i32, blocks_per_cycle: i32) -> Result<i32, RightsConstantError> {
+    // check if blocks_per_cycle is not 0 to prevent panic
+    if blocks_per_cycle > 0 {
+        Ok((level - 1) / blocks_per_cycle)
+    } else {
+        Err(RightsConstantError::WrongValue {
+            key: "blocks_per_cycle",
+        })
+    }
+}
+
+/// Return the position of the block in its cycle
+///
+/// # Arguments
+///
+/// * `level` - level to specify cycle for
+/// * `blocks_per_cycle` - context constant
+///
+/// Level 0 (genesis block) is not part of any cycle (cycle 0 starts at level 1),
+/// hence the blocks_per_cycle - 1 for last cycle block.
+pub fn level_position(level: i32, blocks_per_cycle: i32) -> Result<i32, RightsConstantError> {
+    // check if blocks_per_cycle is not 0 to prevent panic
+    if blocks_per_cycle <= 0 {
+        return Err(RightsConstantError::WrongValue {
+            key: "blocks_per_cycle",
+        });
+    }
+    let cycle_position = (level % blocks_per_cycle) - 1;
+    if cycle_position < 0 {
+        //for last block
+        Ok(blocks_per_cycle - 1)
+    } else {
+        Ok(cycle_position)
+    }
 }

--- a/rpc/src/services/protocol/proto_002/mod.rs
+++ b/rpc/src/services/protocol/proto_002/mod.rs
@@ -1,5 +1,69 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
+use serde::Deserialize;
+use getset::CopyGetters;
+use num::BigInt;
+
 mod helpers;
 pub(crate) mod rights_service;
+
+use super::{vec_string_to_int, string_to_int};
+
+#[derive(Debug, Deserialize, Clone, CopyGetters)]
+pub(crate) struct ProtocolConstants {
+    proof_of_work_nonce_size: u8,
+    nonce_length: u8,
+    max_revelations_per_block: u8,
+    max_operation_data_length: i32,
+    preserved_cycles: u8,
+
+    #[get_copy = "pub(crate)"]
+    blocks_per_cycle: i32,
+
+    blocks_per_commitment: i32,
+    blocks_per_roll_snapshot: i32,
+    blocks_per_voting_period: i32,
+
+    #[serde(with = "vec_string_to_int")]
+    time_between_blocks: Vec<i64>,
+    
+    endorsers_per_block: u16,
+
+    #[serde(with = "string_to_int")]
+    origination_burn: BigInt,
+
+    #[serde(with = "string_to_int")]
+    hard_gas_limit_per_operation: BigInt,
+
+    #[serde(with = "string_to_int")]
+    hard_gas_limit_per_block: BigInt,
+
+    #[serde(with = "string_to_int")]
+    proof_of_work_threshold: BigInt,
+
+    #[serde(with = "string_to_int")]
+    tokens_per_roll: BigInt,
+    michelson_maximum_type_size: u16,
+
+    #[serde(with = "string_to_int")]
+    seed_nonce_revelation_tip: BigInt,
+
+    #[serde(with = "string_to_int")]
+    block_security_deposit: BigInt,
+
+    #[serde(with = "string_to_int")]
+    endorsement_security_deposit: BigInt,
+
+    #[serde(with = "string_to_int")]
+    block_reward: BigInt,
+
+    #[serde(with = "string_to_int")]
+    endorsement_reward: BigInt,
+
+    #[serde(with = "string_to_int")]
+    cost_per_byte: BigInt,
+
+    #[serde(with = "string_to_int")]
+    hard_storage_limit_per_operation: BigInt,
+}

--- a/rpc/src/services/protocol/proto_002/mod.rs
+++ b/rpc/src/services/protocol/proto_002/mod.rs
@@ -1,14 +1,14 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use serde::Deserialize;
 use getset::CopyGetters;
 use num::BigInt;
+use serde::Deserialize;
 
 mod helpers;
 pub(crate) mod rights_service;
 
-use super::{vec_string_to_int, string_to_int};
+use super::{string_to_int, vec_string_to_int};
 
 #[derive(Debug, Deserialize, Clone, CopyGetters)]
 pub(crate) struct ProtocolConstants {
@@ -27,7 +27,7 @@ pub(crate) struct ProtocolConstants {
 
     #[serde(with = "vec_string_to_int")]
     time_between_blocks: Vec<i64>,
-    
+
     endorsers_per_block: u16,
 
     #[serde(with = "string_to_int")]

--- a/rpc/src/services/protocol/proto_002/rights_service.rs
+++ b/rpc/src/services/protocol/proto_002/rights_service.rs
@@ -110,25 +110,17 @@ pub(crate) fn get_baking_rights(
     let cycle_position = *rights_metadata.block_cycle_position();
 
     // build a reverse map of rols so we have access in O(1)
-    // let rolls_map: HashMap<i32, String> = HashMap::new();
-    let rolls_map: HashMap<i32, String> = cycle_meta_data
-        .rolls_data()
-        .iter()
-        .map(|(delegate, rolls)| {
-            rolls
-                .iter()
-                .map(|roll| {
-                    (
-                        *roll,
-                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
-                            .unwrap()
-                            .to_string_representation(),
-                    )
-                })
-                .collect::<HashMap<i32, String>>()
-        })
-        .flatten()
-        .collect();
+    let mut rolls_map: HashMap<i32, String> = HashMap::new();
+
+    for (delegate, rolls) in cycle_meta_data.rolls_data() {
+        for roll in rolls {
+            rolls_map.insert(
+                *roll,
+                SignaturePublicKeyHash::from_tagged_bytes(delegate.to_vec())?
+                    .to_string_representation(),
+            );
+        }
+    }
 
     // iterate through the whole cycle if necessery
     if let Some(cycle) = parameters.requested_cycle() {
@@ -348,24 +340,18 @@ fn get_endorsing_rights(
     // define helper and output variables
     let mut endorsing_rights = Vec::<EndorsingRight>::new();
 
-    let rolls_map: HashMap<i32, String> = cycle_meta_data
-        .rolls_data()
-        .iter()
-        .map(|(delegate, rolls)| {
-            rolls
-                .iter()
-                .map(|roll| {
-                    (
-                        *roll,
-                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
-                            .unwrap()
-                            .to_string_representation(),
-                    )
-                })
-                .collect::<HashMap<i32, String>>()
-        })
-        .flatten()
-        .collect();
+    // build a reverse map of rols so we have access in O(1)
+    let mut rolls_map: HashMap<i32, String> = HashMap::new();
+
+    for (delegate, rolls) in cycle_meta_data.rolls_data() {
+        for roll in rolls {
+            rolls_map.insert(
+                *roll,
+                SignaturePublicKeyHash::from_tagged_bytes(delegate.to_vec())?
+                    .to_string_representation(),
+            );
+        }
+    }
 
     // when query param cycle is specified then iterate over all cycle levels, else only given level
     if let Some(cycle) = parameters.requested_cycle() {

--- a/rpc/src/services/protocol/proto_002/rights_service.rs
+++ b/rpc/src/services/protocol/proto_002/rights_service.rs
@@ -16,7 +16,6 @@ use std::convert::TryInto;
 use anyhow::format_err;
 use itertools::Itertools;
 
-use crypto::hash::ChainId;
 use tezos_messages::base::rpc_support::{RpcJsonMap, ToRpcJsonMap};
 use tezos_messages::base::signature_public_key_hash::SignaturePublicKeyHash;
 use tezos_messages::protocol::proto_002::rights::{BakingRights, EndorsingRight};
@@ -24,7 +23,6 @@ use tezos_messages::protocol::proto_002::rights::{BakingRights, EndorsingRight};
 use storage::cycle_storage::CycleData;
 use storage::CycleMetaStorage;
 
-use crate::server::RpcServiceEnvironment;
 use crate::services::dev_services::contract_id_to_contract_address_for_index;
 use crate::services::protocol::proto_002::helpers::{
     get_cycle_data, get_prng_number, init_prng, level_position, EndorserSlots, RightsConstants,
@@ -58,8 +56,6 @@ pub(crate) async fn check_and_get_baking_rights(
     max_priority: Option<&str>,
     has_all: bool,
     cycle_meta_storage: &CycleMetaStorage,
-    chain_id: &ChainId,
-    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -72,8 +68,6 @@ pub(crate) async fn check_and_get_baking_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
-        chain_id,
-        env,
         true,
     )
     .await?;
@@ -314,8 +308,6 @@ pub(crate) async fn check_and_get_endorsing_rights(
     cycle: Option<&str>,
     has_all: bool,
     cycle_meta_storage: &CycleMetaStorage,
-    chain_id: &ChainId,
-    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -328,8 +320,6 @@ pub(crate) async fn check_and_get_endorsing_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
-        chain_id,
-        env,
         false,
     )
     .await?;

--- a/rpc/src/services/protocol/proto_003/helpers.rs
+++ b/rpc/src/services/protocol/proto_003/helpers.rs
@@ -50,14 +50,15 @@ impl RightsConstants {
     pub(crate) fn parse_rights_constants(
         context_proto_param: &ContextProtocolParam,
     ) -> Result<Self, anyhow::Error> {
-        let protocol_constants: ProtocolConstants = serde_json::from_str(&context_proto_param.constants_data)?;
+        let protocol_constants: ProtocolConstants =
+            serde_json::from_str(&context_proto_param.constants_data)?;
 
         Ok(Self {
             blocks_per_cycle: protocol_constants.blocks_per_cycle,
             preserved_cycles: protocol_constants.preserved_cycles,
             nonce_length: protocol_constants.nonce_length,
             time_between_blocks: protocol_constants.time_between_blocks,
-            endorsers_per_block: protocol_constants.endorsers_per_block ,
+            endorsers_per_block: protocol_constants.endorsers_per_block,
         })
     }
 }
@@ -68,11 +69,7 @@ pub(crate) fn get_cycle_data(
     cycle_meta_storage: &CycleMetaStorage,
 ) -> Result<CycleData, anyhow::Error> {
     // prepare cycle for which rollers are selected
-    let requested_cycle = if let Some(cycle) = *parameters.requested_cycle() {
-        cycle
-    } else {
-        block_cycle
-    };
+    let requested_cycle = parameters.requested_cycle().unwrap_or(block_cycle);
 
     if let Some(cycle_meta_data) = cycle_meta_storage.get(&requested_cycle)? {
         Ok(cycle_meta_data)
@@ -381,9 +378,6 @@ pub fn init_prng(
     let state = cycle_meta_data.seed_bytes();
     let zero_bytes: Vec<u8> = vec![0; nonce_size];
 
-    // the position of the block in its cycle; has to be i32
-    // let cycle_position: i32 = level_position(level, blocks_per_cycle)?;
-
     // take the state (initially the random seed), zero bytes, the use string and the blocks position in the cycle as bytes, merge them together and hash the result
     let rd = blake2b::digest_256(&merge_slices!(
         state,
@@ -456,7 +450,6 @@ impl RightsMetadata {
         requested_level: i32,
     ) -> Result<Self, RightsConstantError> {
         Ok(Self {
-            // (cycle_from_level(requested_level, blocks_per_cycle)?, level_position(requested_level, blocks_per_cycle)?)
             block_cycle: cycle_from_level(requested_level, blocks_per_cycle)?,
             block_cycle_position: level_position(requested_level, blocks_per_cycle)?,
         })

--- a/rpc/src/services/protocol/proto_003/helpers.rs
+++ b/rpc/src/services/protocol/proto_003/helpers.rs
@@ -23,6 +23,8 @@ use crate::services::protocol::{
     parse_block_metadata_level, ContextProtocolParam, MetadataParsingError,
 };
 
+use super::ProtocolConstants;
+
 /// Context constants used in baking and endorsing rights
 #[derive(Debug, Clone, Getters)]
 pub struct RightsConstants {
@@ -42,10 +44,6 @@ pub struct RightsConstants {
 pub enum RightsConstantError {
     #[error("The value is illegal, key: {key}")]
     WrongValue { key: &'static str },
-    #[error("Key cannot be parsed, key: {key}")]
-    Parsing { key: &'static str },
-    #[error("Key cannot be found in constants, key: {key}")]
-    KeyNotFound { key: &'static str },
 }
 
 impl RightsConstants {
@@ -58,80 +56,14 @@ impl RightsConstants {
     pub(crate) fn parse_rights_constants(
         context_proto_param: &ContextProtocolParam,
     ) -> Result<Self, anyhow::Error> {
-        if let Some(constatns_deserialized) =
-            serde_json::from_str::<serde_json::Value>(&context_proto_param.constants_data)?
-                .as_object()
-        {
-            let blocks_per_cycle = get_constant_i64(constatns_deserialized, "blocks_per_cycle")?;
-            let preserved_cycles = get_constant_i64(constatns_deserialized, "preserved_cycles")?;
-            let nonce_length = get_constant_i64(constatns_deserialized, "nonce_length")?;
-            let time_between_blocks = get_time_between_blocks(constatns_deserialized)?;
-            let endorsers_per_block =
-                get_constant_i64(constatns_deserialized, "endorsers_per_block")?;
+        let protocol_constants: ProtocolConstants = serde_json::from_str(&context_proto_param.constants_data)?;
 
-            Ok(Self {
-                blocks_per_cycle: blocks_per_cycle as i32,
-                preserved_cycles: preserved_cycles as u8,
-                nonce_length: nonce_length as u8,
-                time_between_blocks,
-                endorsers_per_block: endorsers_per_block as u16,
-            })
-        } else {
-            bail!("Constants not an object")
-        }
-    }
-}
-
-fn get_constant_i64(
-    constants: &serde_json::Map<String, serde_json::Value>,
-    key: &'static str,
-) -> Result<i64, RightsConstantError> {
-    if let Some(value) = constants.get(key) {
-        if let Some(i64_value) = value.as_i64() {
-            Ok(i64_value)
-        } else {
-            if let Some(str_num) = value.as_str() {
-                return str_num
-                    .parse()
-                    .map_err(|_| RightsConstantError::Parsing { key });
-            }
-            Err(RightsConstantError::Parsing { key })
-        }
-    } else {
-        Err(RightsConstantError::KeyNotFound { key })
-    }
-}
-
-fn get_time_between_blocks(
-    constants: &serde_json::Map<String, serde_json::Value>,
-) -> Result<Vec<i64>, RightsConstantError> {
-    let mut ret: Vec<i64> = Vec::new();
-    if let Some(value) = constants.get("time_between_blocks") {
-        if let Some(array) = value.as_array() {
-            for e in array {
-                if let Some(str_element) = e.as_str() {
-                    let parsed =
-                        str_element
-                            .parse::<i64>()
-                            .map_err(|_| RightsConstantError::Parsing {
-                                key: "time_between_blocks",
-                            })?;
-                    ret.push(parsed);
-                } else {
-                    return Err(RightsConstantError::Parsing {
-                        key: "time_between_blocks",
-                    });
-                }
-            }
-            Ok(ret)
-        } else {
-            Err(RightsConstantError::Parsing {
-                key: "time_between_blocks",
-            })
-        }
-    } else {
-        Err(RightsConstantError::KeyNotFound {
-            key: "time_between_blocks",
+        Ok(Self {
+            blocks_per_cycle: protocol_constants.blocks_per_cycle,
+            preserved_cycles: protocol_constants.preserved_cycles,
+            nonce_length: protocol_constants.nonce_length,
+            time_between_blocks: protocol_constants.time_between_blocks,
+            endorsers_per_block: protocol_constants.endorsers_per_block ,
         })
     }
 }

--- a/rpc/src/services/protocol/proto_003/helpers.rs
+++ b/rpc/src/services/protocol/proto_003/helpers.rs
@@ -1,26 +1,27 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::sync::Arc;
 
-use anyhow::{bail, format_err};
+use crypto::hash::ChainId;
+use anyhow::bail;
 use getset::Getters;
-use tezos_context::context_key_owned;
 use thiserror::Error;
 
-use crypto::hash::ContextHash;
 use crypto::{
     blake2b::{self, Blake2bError},
     crypto_box::PublicKeyError,
 };
-use storage::{num_from_slice, BlockHeaderWithHash};
-use tezos_messages::base::signature_public_key_hash::SignaturePublicKeyHash;
-use tezos_messages::p2p::binary_message::BinaryRead;
-use tezos_wrapper::TezedgeContextClient;
+use storage::cycle_storage::CycleData;
+use storage::{num_from_slice, BlockHeaderWithHash, CycleMetaStorage};
 
+use crate::helpers::{parse_block_hash, BlockMetadata};
 use crate::merge_slices;
-use crate::services::protocol::ContextProtocolParam;
+use crate::server::RpcServiceEnvironment;
+use crate::services::protocol::{
+    parse_block_metadata_level, ContextProtocolParam, MetadataParsingError,
+};
 
 /// Context constants used in baking and endorsing rights
 #[derive(Debug, Clone, Getters)]
@@ -34,31 +35,20 @@ pub struct RightsConstants {
     #[get = "pub(crate)"]
     time_between_blocks: Vec<i64>,
     #[get = "pub(crate)"]
-    blocks_per_roll_snapshot: i32,
-    #[get = "pub(crate)"]
     endorsers_per_block: u16,
 }
 
-impl RightsConstants {
-    /// simple constructor to create RightsConstants
-    pub fn new(
-        blocks_per_cycle: i32,
-        preserved_cycles: u8,
-        nonce_length: u8,
-        time_between_blocks: Vec<i64>,
-        blocks_per_roll_snapshot: i32,
-        endorsers_per_block: u16,
-    ) -> Self {
-        Self {
-            blocks_per_cycle,
-            preserved_cycles,
-            nonce_length,
-            time_between_blocks,
-            blocks_per_roll_snapshot,
-            endorsers_per_block,
-        }
-    }
+#[derive(Debug, Error)]
+pub enum RightsConstantError {
+    #[error("The value is illegal, key: {key}")]
+    WrongValue { key: &'static str },
+    #[error("Key cannot be parsed, key: {key}")]
+    Parsing { key: &'static str },
+    #[error("Key cannot be found in constants, key: {key}")]
+    KeyNotFound { key: &'static str },
+}
 
+impl RightsConstants {
     /// Get all context constants which are used in endorsing and baking rights generation
     ///
     /// # Arguments
@@ -68,168 +58,103 @@ impl RightsConstants {
     pub(crate) fn parse_rights_constants(
         context_proto_param: &ContextProtocolParam,
     ) -> Result<Self, anyhow::Error> {
-        let dynamic =
-            tezos_messages::protocol::proto_003::constants::ParametricConstants::from_bytes(
-                &context_proto_param.constants_data,
-            )?;
-        // in proto 001, the constants are hard coded but a few exceptions modifiable in the context
-        let dynamic_all = tezos_messages::protocol::proto_003::constants::ParametricConstants::create_with_default_and_merge(dynamic);
-        let fixed = tezos_messages::protocol::proto_003::constants::FIXED;
-
-        // TODO: fix unwraps()
-        Ok(RightsConstants::new(
-            dynamic_all.blocks_per_cycle().unwrap(),
-            dynamic_all.preserved_cycles().unwrap(),
-            fixed.nonce_length(),
-            dynamic_all.time_between_blocks().as_ref().unwrap().clone(),
-            dynamic_all.blocks_per_roll_snapshot().unwrap(),
-            dynamic_all.endorsers_per_block().unwrap(),
-        ))
-    }
-}
-
-/// Data from context DB for completing baking and endorsing rights
-#[derive(Debug, Clone, Getters)]
-pub struct RightsContextData {
-    /// Random seed for Tezos PRNG
-    #[get = "pub(crate)"]
-    random_seed: Vec<u8>,
-
-    /// Number of last roll so Tezos PRNG will not overflow
-    #[get = "pub(crate)"]
-    last_roll: i32,
-
-    /// List of rolls mapped to rollers contract id
-    #[get = "pub(crate)"]
-    rolls: HashMap<i32, String>,
-}
-
-impl RightsContextData {
-    /// Simple constructor to create RightsContextData
-    pub fn new(random_seed: Vec<u8>, last_roll: i32, rolls: HashMap<i32, String>) -> Self {
-        Self {
-            random_seed,
-            last_roll,
-            rolls,
-        }
-    }
-
-    /// Get context data roll_snapshot, random_seed, last_roll and rolls from context list
-    ///
-    /// # Arguments
-    ///
-    /// * `parameters` - Parameters created by [RightsParams](RightsParams::parse_rights_parameters).
-    /// * `constants` - Context constants used in baking and endorsing rights.
-    /// * `list` - Context list handler.
-    ///
-    /// Return RightsContextData.
-    pub(crate) fn prepare_context_data_for_rights(
-        parameters: RightsParams,
-        constants: RightsConstants,
-        (ctx_hash, context): (&ContextHash, &TezedgeContextClient),
-    ) -> Result<Self, anyhow::Error> {
-        // prepare constants that are used
-        let blocks_per_cycle = *constants.blocks_per_cycle();
-
-        // prepare parameters that are used
-        let requested_level = *parameters.requested_level();
-
-        // prepare cycle for which rollers are selected
-        let requested_cycle = if let Some(cycle) = *parameters.requested_cycle() {
-            cycle
-        } else {
-            cycle_from_level(requested_level, blocks_per_cycle)?
-        };
-
-        // get index of roll snapshot
-        let roll_snapshot: i16 = {
-            if let Some(data) = context.get_key_from_history(
-                &ctx_hash,
-                context_key_owned!("data/cycle/{}/roll_snapshot", requested_cycle),
-            )? {
-                num_from_slice!(data, 0, i16)
-            } else {
-                // key not found - prepare error for later processing
-                return Err(format_err!("roll_snapshot"));
-            }
-        };
-
-        let random_seed = {
-            if let Some(data) = context.get_key_from_history(
-                &ctx_hash,
-                context_key_owned!("data/cycle/{}/random_seed", requested_cycle),
-            )? {
-                data
-            } else {
-                // key not found - prepare error for later processing
-                return Err(format_err!("random_seed"));
-            }
-        };
-
-        // Snapshots of last_roll are listed from 0 same as roll_snapshot.
-        let last_roll = {
-            if let Some(data) = context.get_key_from_history(
-                &ctx_hash,
-                context_key_owned!("data/cycle/{}/last_roll/{}", requested_cycle, roll_snapshot),
-            )? {
-                num_from_slice!(data, 0, i32)
-            } else {
-                // key not found - prepare error for later processing
-                return Err(format_err!("last_roll"));
-            }
-        };
-
-        // get list of rolls from context list
-        let context_rolls = if let Some(rolls) =
-            Self::get_context_rolls((&ctx_hash, &context), requested_cycle, roll_snapshot)?
+        if let Some(constatns_deserialized) =
+            serde_json::from_str::<serde_json::Value>(&context_proto_param.constants_data)?
+                .as_object()
         {
-            rolls
-        } else {
-            return Err(format_err!("rolls"));
-        };
+            let blocks_per_cycle = get_constant_i64(constatns_deserialized, "blocks_per_cycle")?;
+            let preserved_cycles = get_constant_i64(constatns_deserialized, "preserved_cycles")?;
+            let nonce_length = get_constant_i64(constatns_deserialized, "nonce_length")?;
+            let time_between_blocks = get_time_between_blocks(constatns_deserialized)?;
+            let endorsers_per_block =
+                get_constant_i64(constatns_deserialized, "endorsers_per_block")?;
 
-        Ok(Self::new(random_seed.to_vec(), last_roll, context_rolls))
+            Ok(Self {
+                blocks_per_cycle: blocks_per_cycle as i32,
+                preserved_cycles: preserved_cycles as u8,
+                nonce_length: nonce_length as u8,
+                time_between_blocks,
+                endorsers_per_block: endorsers_per_block as u16,
+            })
+        } else {
+            bail!("Constants not an object")
+        }
     }
+}
 
-    /// get list of rollers from context list selected by snapshot level
-    ///
-    /// # Arguments
-    ///
-    /// * `context` - context list HashMap from [get_context_as_hashmap](RightsContextData::get_context_as_hashmap)
-    ///
-    /// Return rollers for [RightsContextData.rolls](RightsContextData.rolls)
-    fn get_context_rolls(
-        (ctx_hash, context): (&ContextHash, &TezedgeContextClient),
-        cycle: i64,
-        snapshot: i16,
-    ) -> Result<Option<HashMap<i32, String>>, anyhow::Error> {
-        let rolls = if let Some(val) = context.get_key_values_by_prefix(
-            &ctx_hash,
-            context_key_owned!("data/rolls/owner/snapshot/{}/{}", cycle, snapshot),
-        )? {
-            val
+fn get_constant_i64(
+    constants: &serde_json::Map<String, serde_json::Value>,
+    key: &'static str,
+) -> Result<i64, RightsConstantError> {
+    if let Some(value) = constants.get(key) {
+        if let Some(i64_value) = value.as_i64() {
+            Ok(i64_value)
         } else {
-            bail!("No rolls found in context")
-        };
-
-        let mut roll_owners: HashMap<i32, String> = HashMap::new();
-
-        // iterate through all the owners,the roll_num is the last component of the key, decode the value (it is a public key) to get the public key hash address (tz1...)
-        for (key, value) in rolls.into_iter() {
-            if key.last().is_none() {
-                continue;
+            if let Some(str_num) = value.as_str() {
+                return str_num
+                    .parse()
+                    .map_err(|_| RightsConstantError::Parsing { key });
             }
-            let roll_num = key.last().unwrap();
+            Err(RightsConstantError::Parsing { key })
+        }
+    } else {
+        Err(RightsConstantError::KeyNotFound { key })
+    }
+}
 
-            // the values are public keys
-            let delegate = SignaturePublicKeyHash::from_tagged_bytes(value.clone())?
-                .to_string_representation();
-            roll_owners.insert(roll_num.parse()?, delegate);
+fn get_time_between_blocks(
+    constants: &serde_json::Map<String, serde_json::Value>,
+) -> Result<Vec<i64>, RightsConstantError> {
+    let mut ret: Vec<i64> = Vec::new();
+    if let Some(value) = constants.get("time_between_blocks") {
+        if let Some(array) = value.as_array() {
+            for e in array {
+                if let Some(str_element) = e.as_str() {
+                    let parsed =
+                        str_element
+                            .parse::<i64>()
+                            .map_err(|_| RightsConstantError::Parsing {
+                                key: "time_between_blocks",
+                            })?;
+                    ret.push(parsed);
+                } else {
+                    return Err(RightsConstantError::Parsing {
+                        key: "time_between_blocks",
+                    });
+                }
+            }
+            Ok(ret)
+        } else {
+            Err(RightsConstantError::Parsing {
+                key: "time_between_blocks",
+            })
         }
-        if roll_owners.is_empty() {
-            bail!("No rolls assigned, all rolls happened to be DELETED")
-        }
-        Ok(Some(roll_owners))
+    } else {
+        Err(RightsConstantError::KeyNotFound {
+            key: "time_between_blocks",
+        })
+    }
+}
+
+pub(crate) fn get_cycle_data(
+    parameters: RightsParams,
+    block_cycle: i32,
+    cycle_meta_storage: &CycleMetaStorage,
+) -> Result<CycleData, anyhow::Error> {
+    // prepare cycle for which rollers are selected
+    let requested_cycle = if let Some(cycle) = *parameters.requested_cycle() {
+        cycle
+    } else {
+        block_cycle
+    };
+
+    if let Some(cycle_meta_data) = cycle_meta_storage.get(&requested_cycle)? {
+        Ok(cycle_meta_data)
+    } else {
+        bail!(
+            "No cycle data found for requested_cycle: {}",
+            requested_cycle
+        )
     }
 }
 
@@ -238,7 +163,7 @@ impl RightsContextData {
 pub struct RightsParams {
     /// Level (height) of block. Parsed from url path parameter 'block_id'.
     #[get = "pub(crate)"]
-    block_level: i64,
+    block_level: i32,
 
     /// Header timestamp of block. Parsed from url path parameter 'block_id'.
     #[get = "pub(crate)"]
@@ -250,41 +175,46 @@ pub struct RightsParams {
 
     /// Cycle for whitch all rights will be listed. Url query parameter 'cycle'.
     #[get = "pub(crate)"]
-    requested_cycle: Option<i64>,
+    requested_cycle: Option<i32>,
 
     /// Level (height) of block for whitch all rights will be listed. Url query parameter 'level'.
     #[get = "pub(crate)"]
-    requested_level: i64,
+    requested_level: i32,
 
     /// Level to be displayed in output.
     #[get = "pub(crate)"]
-    display_level: i64,
+    display_level: i32,
 
     /// Level for estimated_time computation. Endorsing rights only.
     #[get = "pub(crate)"]
-    timestamp_level: i64,
+    timestamp_level: i32,
 
     /// Max priority to which baking rights are listed. Url query parameter 'max_priority'.
     #[get = "pub(crate)"]
-    max_priority: i64,
+    max_priority: i32,
 
     /// Indicate that baking rights for maximum priority should be listed. Url query parameter 'all'.
     #[get = "pub(crate)"]
     has_all: bool,
+
+    #[get = "pub(crate)"]
+    rights_metadata: RightsMetadata,
 }
 
 impl RightsParams {
     /// Simple constructor to create RightsParams
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
-        block_level: i64,
+        block_level: i32,
         block_timestamp: i64,
         requested_delegate: Option<String>,
-        requested_cycle: Option<i64>,
-        requested_level: i64,
-        display_level: i64,
-        timestamp_level: i64,
-        max_priority: i64,
+        requested_cycle: Option<i32>,
+        requested_level: i32,
+        display_level: i32,
+        timestamp_level: i32,
+        max_priority: i32,
         has_all: bool,
+        rights_metadata: RightsMetadata,
     ) -> Self {
         Self {
             block_level,
@@ -296,6 +226,7 @@ impl RightsParams {
             timestamp_level,
             max_priority,
             has_all,
+            rights_metadata,
         }
     }
 
@@ -315,7 +246,8 @@ impl RightsParams {
     /// * `is_baking_rights` - flag to identify if are parsed baking or endorsing rights
     ///
     /// Return RightsParams
-    pub(crate) fn parse_rights_parameters(
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn parse_rights_parameters(
         param_level: Option<&str>,
         param_delegate: Option<&str>,
         param_cycle: Option<&str>,
@@ -323,30 +255,25 @@ impl RightsParams {
         param_has_all: bool,
         rights_constants: &RightsConstants,
         block_header: &BlockHeaderWithHash,
+        chain_id: &ChainId,
+        env: &RpcServiceEnvironment,
         is_baking_rights: bool,
     ) -> Result<Self, anyhow::Error> {
-        let block_level: i64 = block_header.header.level().into();
+        let block_level = block_header.header.level();
         let preserved_cycles = *rights_constants.preserved_cycles();
         let blocks_per_cycle = *rights_constants.blocks_per_cycle();
 
         // this is the cycle of block_id level
-        let current_cycle = cycle_from_level(block_level, blocks_per_cycle)?;
 
         // display_level is here because of corner case where all levels < 1 are computed as level 1 but oputputed as they are
-        let mut display_level: i64 = block_level;
+        let mut display_level: i32 = block_level;
         // endorsing rights only: timestamp_level is the base level for timestamp computation is taken from last known block (block_id) timestamp + time_between_blocks[0]
-        let mut timestamp_level: i64 = block_level;
+        let mut timestamp_level: i32 = block_level;
         // Check the param_level, if there is a level specified validate it, if no set it to the block_level
         // requested_level is used to get data from context list
-        let requested_level: i64 = match param_level {
+        let requested_level: i32 = match param_level {
             Some(level) => {
                 let level = level.parse()?;
-                // check the bounds for the requested level (if it is in the previous/next preserved cycles)
-                Self::validate_cycle(
-                    cycle_from_level(level, blocks_per_cycle)?,
-                    current_cycle,
-                    preserved_cycles,
-                )?;
                 // display level is always same as level requested
                 display_level = level;
                 // endorsing rights: to compute timestamp for level parameter there need to be taken timestamp of previous block
@@ -371,11 +298,37 @@ impl RightsParams {
             }
         };
 
+        let block_metadata = match crate::services::base_services::get_block_metadata(
+            chain_id,
+            &parse_block_hash(chain_id, &requested_level.to_string(), env)?,
+            env,
+        )
+        .await
+        {
+            Ok(metadata) => Some(metadata),
+            Err(_) => None,
+        };
+
+        let rights_metadata = if let Some(metadata) = block_metadata {
+            RightsMetadata::extract_from_block_metadata(metadata)?
+        } else if param_level.is_some() {
+            RightsMetadata::calculate(blocks_per_cycle, requested_level)?
+        } else {
+            // this should never happen. When block_metadata is not available it means we requested a future level (thus level is always Some())
+            bail!("No level parameter in url")
+        };
+
+        Self::validate_cycle(
+            cycle_from_level(requested_level, blocks_per_cycle)?,
+            rights_metadata.block_cycle,
+            preserved_cycles,
+        )?;
+
         // validate requested cycle
         let requested_cycle = match param_cycle {
             Some(val) => Some(Self::validate_cycle(
                 val.parse()?,
-                current_cycle,
+                rights_metadata.block_cycle,
                 preserved_cycles,
             )?),
             None => None,
@@ -397,6 +350,7 @@ impl RightsParams {
             timestamp_level, // endorsing rights only
             max_priority,
             param_has_all,
+            rights_metadata,
         ))
     }
 
@@ -412,7 +366,7 @@ impl RightsParams {
     pub fn get_estimated_time(
         &self,
         constants: &RightsConstants,
-        level: Option<i64>,
+        level: Option<i32>,
     ) -> Option<i64> {
         // if is cycle then level is provided as parameter else use prepared timestamp_level
         let timestamp_level = level.unwrap_or(self.timestamp_level);
@@ -431,13 +385,17 @@ impl RightsParams {
     /// Validate if cycle requested as url query parameter (cycle or level) is available in context list by checking preserved_cycles constant
     #[inline]
     fn validate_cycle(
-        requested_cycle: i64,
-        current_cycle: i64,
+        requested_cycle: i32,
+        current_cycle: i32,
         preserved_cycles: u8,
-    ) -> Result<i64, anyhow::Error> {
-        if (requested_cycle - current_cycle).abs() <= (preserved_cycles as i64) {
+    ) -> Result<i32, anyhow::Error> {
+        if (requested_cycle - current_cycle).abs() <= preserved_cycles.into() {
             Ok(requested_cycle)
         } else {
+            // TODO: proper json response is needed for this
+            // Octez is:
+            //    [{ "kind": "permanent", "id": "proto.008-PtEdo2Zk.seed.unknown_seed",
+            //        "oldest": 330, "requested": 200, "latest": 340 }]
             bail!("Requested cycle out of bounds") //TODO: prepare cycle error
         }
     }
@@ -464,47 +422,6 @@ impl EndorserSlots {
     /// Push endorsing slot to slots
     pub fn push_to_slot(&mut self, slot: u16) {
         self.slots.push(slot);
-    }
-}
-
-/// Return cycle in which is given level
-///
-/// # Arguments
-///
-/// * `level` - level to specify cycle for
-/// * `blocks_per_cycle` - context constant
-///
-/// Level 0 (genesis block) is not part of any cycle (cycle 0 starts at level 1),
-/// hence the blocks_per_cycle - 1 for last cycle block.
-pub fn cycle_from_level(level: i64, blocks_per_cycle: i32) -> Result<i64, anyhow::Error> {
-    // check if blocks_per_cycle is not 0 to prevent panic
-    if blocks_per_cycle > 0 {
-        Ok((level - 1) / (blocks_per_cycle as i64))
-    } else {
-        bail!("wrong value blocks_per_cycle={}", blocks_per_cycle)
-    }
-}
-
-/// Return the position of the block in its cycle
-///
-/// # Arguments
-///
-/// * `level` - level to specify cycle for
-/// * `blocks_per_cycle` - context constant
-///
-/// Level 0 (genesis block) is not part of any cycle (cycle 0 starts at level 1),
-/// hence the blocks_per_cycle - 1 for last cycle block.
-pub fn level_position(level: i32, blocks_per_cycle: i32) -> Result<i32, anyhow::Error> {
-    // check if blocks_per_cycle is not 0 to prevent panic
-    if blocks_per_cycle <= 0 {
-        bail!("wrong value blocks_per_cycle={}", blocks_per_cycle);
-    }
-    let cycle_position = (level % blocks_per_cycle) - 1;
-    if cycle_position < 0 {
-        //for last block
-        Ok(blocks_per_cycle - 1)
-    } else {
-        Ok(cycle_position)
     }
 }
 
@@ -546,24 +463,23 @@ pub type TezosPRNGResult = Result<(i32, RandomSeedState), TezosPRNGError>;
 /// Return first random sequence state to use in [get_prng_number](`get_prng_number`)
 #[inline]
 pub fn init_prng(
-    cycle_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
     constants: &RightsConstants,
     use_string_bytes: &[u8],
-    level: i32,
+    cycle_position: i32,
     offset: i32,
 ) -> Result<RandomSeedState, anyhow::Error> {
     // a safe way to convert betwwen types is to use try_from
     let nonce_size = usize::try_from(*constants.nonce_length())?;
-    let blocks_per_cycle = *constants.blocks_per_cycle();
-    let state = cycle_data.random_seed();
+    let state = cycle_meta_data.seed_bytes();
     let zero_bytes: Vec<u8> = vec![0; nonce_size];
 
     // the position of the block in its cycle; has to be i32
-    let cycle_position: i32 = level_position(level, blocks_per_cycle)?;
+    // let cycle_position: i32 = level_position(level, blocks_per_cycle)?;
 
     // take the state (initially the random seed), zero bytes, the use string and the blocks position in the cycle as bytes, merge them together and hash the result
     let rd = blake2b::digest_256(&merge_slices!(
-        &state,
+        state,
         &zero_bytes,
         use_string_bytes,
         &cycle_position.to_be_bytes()
@@ -616,4 +532,89 @@ pub fn get_prng_number(state: RandomSeedState, bound: i32) -> TezosPRNGResult {
         };
     }
     Ok((v, sequence))
+}
+
+#[derive(Debug, Clone, Getters)]
+pub struct RightsMetadata {
+    #[get = "pub(crate)"]
+    block_cycle: i32,
+
+    #[get = "pub(crate)"]
+    block_cycle_position: i32,
+}
+
+impl RightsMetadata {
+    pub fn extract_from_block_metadata(
+        block_metadata: Arc<BlockMetadata>,
+    ) -> Result<Self, MetadataParsingError> {
+        let (block_cycle, block_cycle_position) =
+            match parse_block_metadata_level(&block_metadata, "level_info") {
+                Ok(cycle_data) => cycle_data,
+                Err(MetadataParsingError::KeyNotFoundError { key: _ }) => {
+                    // No level info found, trying the older scheme
+                    parse_block_metadata_level(&block_metadata, "level")?
+                }
+                Err(e) => return Err(e),
+            };
+        Ok(Self {
+            block_cycle,
+            block_cycle_position,
+        })
+    }
+
+    pub fn calculate(
+        blocks_per_cycle: i32,
+        requested_level: i32,
+    ) -> Result<Self, RightsConstantError> {
+        Ok(Self {
+            // (cycle_from_level(requested_level, blocks_per_cycle)?, level_position(requested_level, blocks_per_cycle)?)
+            block_cycle: cycle_from_level(requested_level, blocks_per_cycle)?,
+            block_cycle_position: level_position(requested_level, blocks_per_cycle)?,
+        })
+    }
+}
+
+/// Return cycle in which is given level
+///
+/// # Arguments
+///
+/// * `level` - level to specify cycle for
+/// * `blocks_per_cycle` - context constant
+///
+/// Level 0 (genesis block) is not part of any cycle (cycle 0 starts at level 1),
+/// hence the blocks_per_cycle - 1 for last cycle block.
+pub fn cycle_from_level(level: i32, blocks_per_cycle: i32) -> Result<i32, RightsConstantError> {
+    // check if blocks_per_cycle is not 0 to prevent panic
+    if blocks_per_cycle > 0 {
+        Ok((level - 1) / blocks_per_cycle)
+    } else {
+        Err(RightsConstantError::WrongValue {
+            key: "blocks_per_cycle",
+        })
+    }
+}
+
+/// Return the position of the block in its cycle
+///
+/// # Arguments
+///
+/// * `level` - level to specify cycle for
+/// * `blocks_per_cycle` - context constant
+///
+/// Level 0 (genesis block) is not part of any cycle (cycle 0 starts at level 1),
+/// hence the blocks_per_cycle - 1 for last cycle block.
+pub fn level_position(level: i32, blocks_per_cycle: i32) -> Result<i32, RightsConstantError> {
+    // check if blocks_per_cycle is not 0 to prevent panic
+    if blocks_per_cycle <= 0 {
+        return Err(RightsConstantError::WrongValue {
+            key: "blocks_per_cycle",
+        });
+    }
+    let cycle_position = (level % blocks_per_cycle) - 1;
+    if cycle_position < 0 {
+        //for last block
+        Ok(blocks_per_cycle - 1)
+    } else {
+        Ok(cycle_position)
+    }
 }

--- a/rpc/src/services/protocol/proto_003/mod.rs
+++ b/rpc/src/services/protocol/proto_003/mod.rs
@@ -1,6 +1,70 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
+use serde::Deserialize;
+use getset::CopyGetters;
+use num::BigInt;
+
 mod helpers;
 pub(crate) mod rights_service;
 pub(crate) mod votes_services;
+
+use super::{vec_string_to_int, string_to_int};
+
+#[derive(Debug, Deserialize, Clone, CopyGetters)]
+pub(crate) struct ProtocolConstants {
+    proof_of_work_nonce_size: u8,
+    nonce_length: u8,
+    max_revelations_per_block: u8,
+    max_operation_data_length: i32,
+    max_proposals_per_delegate: u8,
+    preserved_cycles: u8,
+    
+    #[get_copy = "pub(crate)"]
+    blocks_per_cycle: i32,
+    
+    blocks_per_commitment: i32,
+    blocks_per_roll_snapshot: i32,
+    blocks_per_voting_period: i32,
+
+    #[serde(with = "vec_string_to_int")]
+    time_between_blocks: Vec<i64>,
+    
+    endorsers_per_block: u16,
+
+    #[serde(with = "string_to_int")]
+    hard_gas_limit_per_operation: BigInt,
+
+    #[serde(with = "string_to_int")]
+    hard_gas_limit_per_block: BigInt,
+
+    #[serde(with = "string_to_int")]
+    proof_of_work_threshold: BigInt,
+
+    #[serde(with = "string_to_int")]
+    tokens_per_roll: BigInt,
+    michelson_maximum_type_size: u16,
+
+    #[serde(with = "string_to_int")]
+    seed_nonce_revelation_tip: BigInt,
+
+    origination_size: i32,
+
+    #[serde(with = "string_to_int")]
+    block_security_deposit: BigInt,
+
+    #[serde(with = "string_to_int")]
+    endorsement_security_deposit: BigInt,
+
+    #[serde(with = "string_to_int")]
+    block_reward: BigInt,
+
+    #[serde(with = "string_to_int")]
+    endorsement_reward: BigInt,
+
+    #[serde(with = "string_to_int")]
+    cost_per_byte: BigInt,
+
+    #[serde(with = "string_to_int")]
+    hard_storage_limit_per_operation: BigInt,
+}

--- a/rpc/src/services/protocol/proto_003/mod.rs
+++ b/rpc/src/services/protocol/proto_003/mod.rs
@@ -1,15 +1,15 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use serde::Deserialize;
 use getset::CopyGetters;
 use num::BigInt;
+use serde::Deserialize;
 
 mod helpers;
 pub(crate) mod rights_service;
 pub(crate) mod votes_services;
 
-use super::{vec_string_to_int, string_to_int};
+use super::{string_to_int, vec_string_to_int};
 
 #[derive(Debug, Deserialize, Clone, CopyGetters)]
 pub(crate) struct ProtocolConstants {
@@ -19,17 +19,17 @@ pub(crate) struct ProtocolConstants {
     max_operation_data_length: i32,
     max_proposals_per_delegate: u8,
     preserved_cycles: u8,
-    
+
     #[get_copy = "pub(crate)"]
     blocks_per_cycle: i32,
-    
+
     blocks_per_commitment: i32,
     blocks_per_roll_snapshot: i32,
     blocks_per_voting_period: i32,
 
     #[serde(with = "vec_string_to_int")]
     time_between_blocks: Vec<i64>,
-    
+
     endorsers_per_block: u16,
 
     #[serde(with = "string_to_int")]

--- a/rpc/src/services/protocol/proto_003/rights_service.rs
+++ b/rpc/src/services/protocol/proto_003/rights_service.rs
@@ -16,7 +16,6 @@ use std::convert::TryInto;
 use anyhow::format_err;
 use itertools::Itertools;
 
-use crypto::hash::ChainId;
 use tezos_messages::base::rpc_support::{RpcJsonMap, ToRpcJsonMap};
 use tezos_messages::base::signature_public_key_hash::SignaturePublicKeyHash;
 use tezos_messages::protocol::proto_003::rights::{BakingRights, EndorsingRight};
@@ -24,7 +23,6 @@ use tezos_messages::protocol::proto_003::rights::{BakingRights, EndorsingRight};
 use storage::cycle_storage::CycleData;
 use storage::CycleMetaStorage;
 
-use crate::server::RpcServiceEnvironment;
 use crate::services::dev_services::contract_id_to_contract_address_for_index;
 use crate::services::protocol::proto_003::helpers::{
     get_cycle_data, get_prng_number, init_prng, level_position, EndorserSlots, RightsConstants,
@@ -58,8 +56,6 @@ pub(crate) async fn check_and_get_baking_rights(
     max_priority: Option<&str>,
     has_all: bool,
     cycle_meta_storage: &CycleMetaStorage,
-    chain_id: &ChainId,
-    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -72,8 +68,6 @@ pub(crate) async fn check_and_get_baking_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
-        chain_id,
-        env,
         true,
     )
     .await?;
@@ -314,8 +308,6 @@ pub(crate) async fn check_and_get_endorsing_rights(
     cycle: Option<&str>,
     has_all: bool,
     cycle_meta_storage: &CycleMetaStorage,
-    chain_id: &ChainId,
-    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -328,8 +320,6 @@ pub(crate) async fn check_and_get_endorsing_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
-        chain_id,
-        env,
         false,
     )
     .await?;

--- a/rpc/src/services/protocol/proto_003/rights_service.rs
+++ b/rpc/src/services/protocol/proto_003/rights_service.rs
@@ -16,16 +16,23 @@ use std::convert::TryInto;
 use anyhow::format_err;
 use itertools::Itertools;
 
-use crate::services::dev_services::contract_id_to_contract_address_for_index;
+use crypto::hash::ChainId;
 use tezos_messages::base::rpc_support::{RpcJsonMap, ToRpcJsonMap};
 use tezos_messages::base::signature_public_key_hash::SignaturePublicKeyHash;
 use tezos_messages::protocol::proto_003::rights::{BakingRights, EndorsingRight};
-use tezos_wrapper::TezedgeContextClient;
 
+use storage::cycle_storage::CycleData;
+use storage::CycleMetaStorage;
+
+use crate::server::RpcServiceEnvironment;
+use crate::services::dev_services::contract_id_to_contract_address_for_index;
 use crate::services::protocol::proto_003::helpers::{
-    get_prng_number, init_prng, EndorserSlots, RightsConstants, RightsContextData, RightsParams,
+    get_cycle_data, get_prng_number, init_prng, level_position, EndorserSlots, RightsConstants,
+    RightsParams,
 };
 use crate::services::protocol::ContextProtocolParam;
+
+use super::helpers::RightsMetadata;
 
 /// Return generated baking rights.
 ///
@@ -42,14 +49,17 @@ use crate::services::protocol::ContextProtocolParam;
 /// * `state` - Current RPC collected state (head).
 ///
 /// Prepare all data to generate baking rights and then use Tezos PRNG to generate them.
-pub(crate) fn check_and_get_baking_rights(
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn check_and_get_baking_rights(
     context_proto_params: ContextProtocolParam,
     level: Option<&str>,
     delegate: Option<&str>,
     cycle: Option<&str>,
     max_priority: Option<&str>,
     has_all: bool,
-    context: &TezedgeContextClient,
+    cycle_meta_storage: &CycleMetaStorage,
+    chain_id: &ChainId,
+    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -62,16 +72,24 @@ pub(crate) fn check_and_get_baking_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
+        chain_id,
+        env,
         true,
-    )?;
+    )
+    .await?;
 
-    let context_data: RightsContextData = RightsContextData::prepare_context_data_for_rights(
+    let cycle_meta_data = get_cycle_data(
         params.clone(),
-        constants.clone(),
-        (&context_proto_params.block_header.header.context(), context),
+        *params.rights_metadata().block_cycle(),
+        cycle_meta_storage,
     )?;
 
-    get_baking_rights(&context_data, &params, &constants)
+    get_baking_rights(
+        &cycle_meta_data,
+        &params,
+        &constants,
+        params.rights_metadata(),
+    )
 }
 
 /// Use prepared data to generate baking rights
@@ -83,9 +101,10 @@ pub(crate) fn check_and_get_baking_rights(
 /// * `constants` - Context constants used in baking and endorsing rights [RightsConstants](RightsConstants::parse_rights_constants).
 #[inline]
 pub(crate) fn get_baking_rights(
-    context_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
     parameters: &RightsParams,
     constants: &RightsConstants,
+    rights_metadata: &RightsMetadata,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let mut baking_rights = Vec::<BakingRights>::new();
 
@@ -94,22 +113,48 @@ pub(crate) fn get_baking_rights(
 
     let timestamp = parameters.block_timestamp();
     let block_level = parameters.block_level();
+    let cycle_position = *rights_metadata.block_cycle_position();
+
+    // build a reverse map of rols so we have access in O(1)
+    // let rolls_map: HashMap<i32, String> = HashMap::new();
+    let rolls_map: HashMap<i32, String> = cycle_meta_data
+        .rolls_data()
+        .iter()
+        .map(|(delegate, rolls)| {
+            rolls
+                .iter()
+                .map(|roll| {
+                    (
+                        *roll,
+                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
+                            .unwrap()
+                            .to_string_representation(),
+                    )
+                })
+                .collect::<HashMap<i32, String>>()
+        })
+        .flatten()
+        .collect();
 
     // iterate through the whole cycle if necessery
     if let Some(cycle) = parameters.requested_cycle() {
-        let first_block_level = cycle * (blocks_per_cycle as i64) + 1;
-        let last_block_level = first_block_level + (blocks_per_cycle as i64);
+        let first_block_level: i32 = cycle * blocks_per_cycle + 1;
+        let last_block_level = first_block_level + blocks_per_cycle;
 
         for level in first_block_level..last_block_level {
-            let seconds_to_add = (level - block_level).abs() * time_between_blocks[0];
+            let block_level_diff: i64 = (level - block_level).abs().into();
+            let seconds_to_add: i64 = block_level_diff * time_between_blocks[0];
             let estimated_timestamp = timestamp + seconds_to_add;
+            let cycle_position = level_position(level, blocks_per_cycle)?;
 
             // assign rolls goes here
             baking_rights_assign_rolls(
-                &parameters,
-                &constants,
-                &context_data,
-                level.try_into()?,
+                parameters,
+                constants,
+                cycle_meta_data,
+                &rolls_map,
+                level,
+                cycle_position,
                 estimated_timestamp,
                 true,
                 &mut baking_rights,
@@ -119,14 +164,17 @@ pub(crate) fn get_baking_rights(
         }
     } else {
         let level = *parameters.requested_level();
-        let seconds_to_add = (level - block_level).abs() * time_between_blocks[0];
+        let block_level_diff: i64 = (level - block_level).abs().into();
+        let seconds_to_add: i64 = block_level_diff * time_between_blocks[0];
         let estimated_timestamp = timestamp + seconds_to_add;
         // assign rolls goes here
         baking_rights_assign_rolls(
-            &parameters,
-            &constants,
-            &context_data,
-            level.try_into()?,
+            parameters,
+            constants,
+            cycle_meta_data,
+            &rolls_map,
+            level,
+            cycle_position,
             estimated_timestamp,
             false,
             &mut baking_rights,
@@ -165,11 +213,14 @@ pub(crate) fn get_baking_rights(
 ///
 /// Baking priorities are are assigned to Roles, the default behavior is to include only the top priority for the delegate
 #[inline]
+#[allow(clippy::too_many_arguments)]
 fn baking_rights_assign_rolls(
     parameters: &RightsParams,
     constants: &RightsConstants,
-    context_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
+    rolls_map: &HashMap<i32, String>,
     level: i32,
+    cycle_position: i32,
     estimated_head_timestamp: i64,
     is_cycle: bool,
     baking_rights: &mut Vec<BakingRights>,
@@ -184,20 +235,19 @@ fn baking_rights_assign_rolls(
     let max_priority = *parameters.max_priority();
     let has_all = parameters.has_all();
     let block_level = *parameters.block_level();
-    let last_roll = *context_data.last_roll();
-    let rolls_map = context_data.rolls();
-    let display_level: i32 = (*parameters.display_level()).try_into()?;
+    let last_roll = *cycle_meta_data.last_roll();
+    let display_level: i32 = *parameters.display_level();
 
     for priority in 0..max_priority {
         // draw the rolls for the requested parameters
         let delegate_to_assign;
         // TODO: priority can overflow in the ocaml code, do a priority % i32::max_value()
         let mut state = init_prng(
-            &context_data,
-            &constants,
+            cycle_meta_data,
+            constants,
             BAKING_USE_STRING,
-            level,
-            priority.try_into()?,
+            cycle_position,
+            priority,
         )?;
 
         loop {
@@ -217,7 +267,7 @@ fn baking_rights_assign_rolls(
         }
 
         // we omit the estimated_time field if the block on the requested level is already baked
-        let priority_timestamp = if block_level < (level as i64) {
+        let priority_timestamp = if block_level < level {
             let time = if time_between_blocks.len() == 1 {
                 time_between_blocks[0]
             } else {
@@ -233,7 +283,7 @@ fn baking_rights_assign_rolls(
 
         baking_rights.push(BakingRights::new(
             rights_level,
-            SignaturePublicKeyHash::from_b58_hash(&delegate_to_assign)?,
+            SignaturePublicKeyHash::from_b58_hash(delegate_to_assign)?,
             priority as u16,
             priority_timestamp,
         ));
@@ -256,13 +306,16 @@ fn baking_rights_assign_rolls(
 /// * `state` - Current RPC collected state (head).
 ///
 /// Prepare all data to generate endorsing rights and then use Tezos PRNG to generate them.
-pub(crate) fn check_and_get_endorsing_rights(
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn check_and_get_endorsing_rights(
     context_proto_params: ContextProtocolParam,
     level: Option<&str>,
     delegate: Option<&str>,
     cycle: Option<&str>,
     has_all: bool,
-    context: &TezedgeContextClient,
+    cycle_meta_storage: &CycleMetaStorage,
+    chain_id: &ChainId,
+    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -275,16 +328,19 @@ pub(crate) fn check_and_get_endorsing_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
+        chain_id,
+        env,
         false,
-    )?;
+    )
+    .await?;
 
-    let context_data: RightsContextData = RightsContextData::prepare_context_data_for_rights(
+    let cycle_meta_data = get_cycle_data(
         params.clone(),
-        constants.clone(),
-        (&context_proto_params.block_header.header.context(), context),
+        *params.rights_metadata().block_cycle(),
+        cycle_meta_storage,
     )?;
 
-    get_endorsing_rights(&context_data, &params, &constants)
+    get_endorsing_rights(&cycle_meta_data, &params, &constants)
 }
 
 /// Use prepared data to generate endosring rights
@@ -295,31 +351,52 @@ pub(crate) fn check_and_get_endorsing_rights(
 /// * `parameters` - Parameters created by [RightsParams](RightsParams::parse_rights_parameters).
 /// * `constants` - Context constants used in baking and endorsing rights [RightsConstants](RightsConstants::parse_rights_constants).
 fn get_endorsing_rights(
-    context_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
     parameters: &RightsParams,
     constants: &RightsConstants,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     // define helper and output variables
     let mut endorsing_rights = Vec::<EndorsingRight>::new();
 
+    let rolls_map: HashMap<i32, String> = cycle_meta_data
+        .rolls_data()
+        .iter()
+        .map(|(delegate, rolls)| {
+            rolls
+                .iter()
+                .map(|roll| {
+                    (
+                        *roll,
+                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
+                            .unwrap()
+                            .to_string_representation(),
+                    )
+                })
+                .collect::<HashMap<i32, String>>()
+        })
+        .flatten()
+        .collect();
+
     // when query param cycle is specified then iterate over all cycle levels, else only given level
     if let Some(cycle) = parameters.requested_cycle() {
         let blocks_per_cycle = *constants.blocks_per_cycle();
-        let first_cycle_level = cycle * (blocks_per_cycle as i64) + 1;
-        let last_cycle_level = first_cycle_level + (blocks_per_cycle as i64);
+        let first_cycle_level = cycle * blocks_per_cycle + 1;
+        let last_cycle_level = first_cycle_level + blocks_per_cycle;
         for level in first_cycle_level..last_cycle_level {
             // get estimated time first because is equal for all endorsers in given level
             // the base level for estimated time computation is level of previous block
             let estimated_time: Option<i64> =
                 parameters.get_estimated_time(constants, Some(level - 1));
+            let cycle_position = level_position(level, blocks_per_cycle)?;
 
             complete_endorsing_rights_for_level(
-                context_data,
+                cycle_meta_data,
                 parameters,
                 constants,
-                level,
+                &rolls_map,
                 level,
                 estimated_time,
+                cycle_position,
                 &mut endorsing_rights,
             )?;
             // endorsing_rights = merge_slices!(&endorsing_rights, &level_endorsing_rights);
@@ -329,12 +406,13 @@ fn get_endorsing_rights(
         let estimated_time: Option<i64> = parameters.get_estimated_time(constants, None);
 
         complete_endorsing_rights_for_level(
-            context_data,
+            cycle_meta_data,
             parameters,
             constants,
-            *parameters.requested_level(),
+            &rolls_map,
             *parameters.display_level(),
             estimated_time,
+            *parameters.rights_metadata().block_cycle_position(),
             &mut endorsing_rights,
         )?;
     };
@@ -358,17 +436,20 @@ fn get_endorsing_rights(
 /// * `display_level` - Level to be displayed in output.
 /// * `estimated_time` - Estimated time of endorsement, is set to None if in past relative to block_id.
 #[inline]
+#[allow(clippy::too_many_arguments)]
 fn complete_endorsing_rights_for_level(
-    context_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
     parameters: &RightsParams,
     constants: &RightsConstants,
-    level: i64,
-    display_level: i64,
+    rolls_map: &HashMap<i32, String>,
+    display_level: i32,
     estimated_time: Option<i64>,
+    cycle_position: i32,
     endorsing_rights: &mut Vec<EndorsingRight>,
 ) -> Result<(), anyhow::Error> {
     // endorsers_slots is needed to group all slots by delegate
-    let endorsers_slots = get_endorsers_slots(constants, context_data, level)?;
+    let endorsers_slots =
+        get_endorsers_slots(constants, cycle_meta_data, rolls_map, cycle_position)?;
 
     // convert contract id to hash contract address hex byte string (needed for ordering)
     let mut endorers_slots_keys_for_order: HashMap<String, String> = HashMap::new();
@@ -399,8 +480,8 @@ fn complete_endorsing_rights_for_level(
         }
 
         endorsing_rights.push(EndorsingRight::new(
-            display_level.try_into()?,
-            SignaturePublicKeyHash::from_b58_hash(&delegate_contract_id)?,
+            display_level,
+            SignaturePublicKeyHash::from_b58_hash(delegate_contract_id)?,
             delegate_data.slots().clone(),
             estimated_time,
         ))
@@ -418,28 +499,29 @@ fn complete_endorsing_rights_for_level(
 #[inline]
 fn get_endorsers_slots(
     constants: &RightsConstants,
-    context_data: &RightsContextData,
-    level: i64,
+    cycle_meta_data: &CycleData,
+    rolls_map: &HashMap<i32, String>,
+    cycle_position: i32,
 ) -> Result<HashMap<String, EndorserSlots>, anyhow::Error> {
     // special byte string used in Tezos PRNG
     const ENDORSEMENT_USE_STRING: &[u8] = b"level endorsement:";
     // prepare helper variable
     let mut endorsers_slots: HashMap<String, EndorserSlots> = HashMap::new();
 
-    for endorser_slot in (0..*constants.endorsers_per_block() as u8).rev() {
+    for endorser_slot in (0..*constants.endorsers_per_block()).rev() {
         // generate PRNG per endorsement slot and take delegates by roll number from context_rolls
         // if roll number is not found then reroll with new state till roll nuber is found in context_rolls
         let mut state = init_prng(
-            &context_data,
-            &constants,
+            cycle_meta_data,
+            constants,
             ENDORSEMENT_USE_STRING,
-            level.try_into()?,
+            cycle_position,
             endorser_slot.try_into()?,
         )?;
         loop {
-            let (random_num, sequence) = get_prng_number(state, *context_data.last_roll())?;
+            let (random_num, sequence) = get_prng_number(state, *cycle_meta_data.last_roll())?;
 
-            if let Some(delegate) = context_data.rolls().get(&random_num) {
+            if let Some(delegate) = rolls_map.get(&random_num) {
                 // collect all slots for each delegate
                 let endorsers_slots_entry = endorsers_slots
                     .entry(delegate.clone())

--- a/rpc/src/services/protocol/proto_003/rights_service.rs
+++ b/rpc/src/services/protocol/proto_003/rights_service.rs
@@ -110,25 +110,17 @@ pub(crate) fn get_baking_rights(
     let cycle_position = *rights_metadata.block_cycle_position();
 
     // build a reverse map of rols so we have access in O(1)
-    // let rolls_map: HashMap<i32, String> = HashMap::new();
-    let rolls_map: HashMap<i32, String> = cycle_meta_data
-        .rolls_data()
-        .iter()
-        .map(|(delegate, rolls)| {
-            rolls
-                .iter()
-                .map(|roll| {
-                    (
-                        *roll,
-                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
-                            .unwrap()
-                            .to_string_representation(),
-                    )
-                })
-                .collect::<HashMap<i32, String>>()
-        })
-        .flatten()
-        .collect();
+    let mut rolls_map: HashMap<i32, String> = HashMap::new();
+
+    for (delegate, rolls) in cycle_meta_data.rolls_data() {
+        for roll in rolls {
+            rolls_map.insert(
+                *roll,
+                SignaturePublicKeyHash::from_tagged_bytes(delegate.to_vec())?
+                    .to_string_representation(),
+            );
+        }
+    }
 
     // iterate through the whole cycle if necessery
     if let Some(cycle) = parameters.requested_cycle() {
@@ -348,24 +340,18 @@ fn get_endorsing_rights(
     // define helper and output variables
     let mut endorsing_rights = Vec::<EndorsingRight>::new();
 
-    let rolls_map: HashMap<i32, String> = cycle_meta_data
-        .rolls_data()
-        .iter()
-        .map(|(delegate, rolls)| {
-            rolls
-                .iter()
-                .map(|roll| {
-                    (
-                        *roll,
-                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
-                            .unwrap()
-                            .to_string_representation(),
-                    )
-                })
-                .collect::<HashMap<i32, String>>()
-        })
-        .flatten()
-        .collect();
+    // build a reverse map of rols so we have access in O(1)
+    let mut rolls_map: HashMap<i32, String> = HashMap::new();
+
+    for (delegate, rolls) in cycle_meta_data.rolls_data() {
+        for roll in rolls {
+            rolls_map.insert(
+                *roll,
+                SignaturePublicKeyHash::from_tagged_bytes(delegate.to_vec())?
+                    .to_string_representation(),
+            );
+        }
+    }
 
     // when query param cycle is specified then iterate over all cycle levels, else only given level
     if let Some(cycle) = parameters.requested_cycle() {

--- a/rpc/src/services/protocol/proto_003/votes_services.rs
+++ b/rpc/src/services/protocol/proto_003/votes_services.rs
@@ -20,7 +20,7 @@ pub fn get_votes_listings(
     // filter out the listings data
     let listings_data = if let Some(val) = env
         .tezedge_context()
-        .get_key_values_by_prefix(&context_hash, context_key_owned!("data/votes/listings"))?
+        .get_key_values_by_prefix(context_hash, context_key_owned!("data/votes/listings"))?
     {
         val
     } else {

--- a/rpc/src/services/protocol/proto_004/helpers.rs
+++ b/rpc/src/services/protocol/proto_004/helpers.rs
@@ -50,14 +50,15 @@ impl RightsConstants {
     pub(crate) fn parse_rights_constants(
         context_proto_param: &ContextProtocolParam,
     ) -> Result<Self, anyhow::Error> {
-        let protocol_constants: ProtocolConstants = serde_json::from_str(&context_proto_param.constants_data)?;
+        let protocol_constants: ProtocolConstants =
+            serde_json::from_str(&context_proto_param.constants_data)?;
 
         Ok(Self {
             blocks_per_cycle: protocol_constants.blocks_per_cycle,
             preserved_cycles: protocol_constants.preserved_cycles,
             nonce_length: protocol_constants.nonce_length,
             time_between_blocks: protocol_constants.time_between_blocks,
-            endorsers_per_block: protocol_constants.endorsers_per_block ,
+            endorsers_per_block: protocol_constants.endorsers_per_block,
         })
     }
 }
@@ -68,11 +69,7 @@ pub(crate) fn get_cycle_data(
     cycle_meta_storage: &CycleMetaStorage,
 ) -> Result<CycleData, anyhow::Error> {
     // prepare cycle for which rollers are selected
-    let requested_cycle = if let Some(cycle) = *parameters.requested_cycle() {
-        cycle
-    } else {
-        block_cycle
-    };
+    let requested_cycle = parameters.requested_cycle().unwrap_or(block_cycle);
 
     if let Some(cycle_meta_data) = cycle_meta_storage.get(&requested_cycle)? {
         Ok(cycle_meta_data)
@@ -381,9 +378,6 @@ pub fn init_prng(
     let state = cycle_meta_data.seed_bytes();
     let zero_bytes: Vec<u8> = vec![0; nonce_size];
 
-    // the position of the block in its cycle; has to be i32
-    // let cycle_position: i32 = level_position(level, blocks_per_cycle)?;
-
     // take the state (initially the random seed), zero bytes, the use string and the blocks position in the cycle as bytes, merge them together and hash the result
     let rd = blake2b::digest_256(&merge_slices!(
         state,
@@ -456,7 +450,6 @@ impl RightsMetadata {
         requested_level: i32,
     ) -> Result<Self, RightsConstantError> {
         Ok(Self {
-            // (cycle_from_level(requested_level, blocks_per_cycle)?, level_position(requested_level, blocks_per_cycle)?)
             block_cycle: cycle_from_level(requested_level, blocks_per_cycle)?,
             block_cycle_position: level_position(requested_level, blocks_per_cycle)?,
         })

--- a/rpc/src/services/protocol/proto_004/helpers.rs
+++ b/rpc/src/services/protocol/proto_004/helpers.rs
@@ -23,6 +23,8 @@ use crate::services::protocol::{
     parse_block_metadata_level, ContextProtocolParam, MetadataParsingError,
 };
 
+use super::ProtocolConstants;
+
 /// Context constants used in baking and endorsing rights
 #[derive(Debug, Clone, Getters)]
 pub struct RightsConstants {
@@ -42,10 +44,6 @@ pub struct RightsConstants {
 pub enum RightsConstantError {
     #[error("The value is illegal, key: {key}")]
     WrongValue { key: &'static str },
-    #[error("Key cannot be parsed, key: {key}")]
-    Parsing { key: &'static str },
-    #[error("Key cannot be found in constants, key: {key}")]
-    KeyNotFound { key: &'static str },
 }
 
 impl RightsConstants {
@@ -58,80 +56,14 @@ impl RightsConstants {
     pub(crate) fn parse_rights_constants(
         context_proto_param: &ContextProtocolParam,
     ) -> Result<Self, anyhow::Error> {
-        if let Some(constatns_deserialized) =
-            serde_json::from_str::<serde_json::Value>(&context_proto_param.constants_data)?
-                .as_object()
-        {
-            let blocks_per_cycle = get_constant_i64(constatns_deserialized, "blocks_per_cycle")?;
-            let preserved_cycles = get_constant_i64(constatns_deserialized, "preserved_cycles")?;
-            let nonce_length = get_constant_i64(constatns_deserialized, "nonce_length")?;
-            let time_between_blocks = get_time_between_blocks(constatns_deserialized)?;
-            let endorsers_per_block =
-                get_constant_i64(constatns_deserialized, "endorsers_per_block")?;
+        let protocol_constants: ProtocolConstants = serde_json::from_str(&context_proto_param.constants_data)?;
 
-            Ok(Self {
-                blocks_per_cycle: blocks_per_cycle as i32,
-                preserved_cycles: preserved_cycles as u8,
-                nonce_length: nonce_length as u8,
-                time_between_blocks,
-                endorsers_per_block: endorsers_per_block as u16,
-            })
-        } else {
-            bail!("Constants not an object")
-        }
-    }
-}
-
-fn get_constant_i64(
-    constants: &serde_json::Map<String, serde_json::Value>,
-    key: &'static str,
-) -> Result<i64, RightsConstantError> {
-    if let Some(value) = constants.get(key) {
-        if let Some(i64_value) = value.as_i64() {
-            Ok(i64_value)
-        } else {
-            if let Some(str_num) = value.as_str() {
-                return str_num
-                    .parse()
-                    .map_err(|_| RightsConstantError::Parsing { key });
-            }
-            Err(RightsConstantError::Parsing { key })
-        }
-    } else {
-        Err(RightsConstantError::KeyNotFound { key })
-    }
-}
-
-fn get_time_between_blocks(
-    constants: &serde_json::Map<String, serde_json::Value>,
-) -> Result<Vec<i64>, RightsConstantError> {
-    let mut ret: Vec<i64> = Vec::new();
-    if let Some(value) = constants.get("time_between_blocks") {
-        if let Some(array) = value.as_array() {
-            for e in array {
-                if let Some(str_element) = e.as_str() {
-                    let parsed =
-                        str_element
-                            .parse::<i64>()
-                            .map_err(|_| RightsConstantError::Parsing {
-                                key: "time_between_blocks",
-                            })?;
-                    ret.push(parsed);
-                } else {
-                    return Err(RightsConstantError::Parsing {
-                        key: "time_between_blocks",
-                    });
-                }
-            }
-            Ok(ret)
-        } else {
-            Err(RightsConstantError::Parsing {
-                key: "time_between_blocks",
-            })
-        }
-    } else {
-        Err(RightsConstantError::KeyNotFound {
-            key: "time_between_blocks",
+        Ok(Self {
+            blocks_per_cycle: protocol_constants.blocks_per_cycle,
+            preserved_cycles: protocol_constants.preserved_cycles,
+            nonce_length: protocol_constants.nonce_length,
+            time_between_blocks: protocol_constants.time_between_blocks,
+            endorsers_per_block: protocol_constants.endorsers_per_block ,
         })
     }
 }

--- a/rpc/src/services/protocol/proto_004/mod.rs
+++ b/rpc/src/services/protocol/proto_004/mod.rs
@@ -1,6 +1,73 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
+use serde::Deserialize;
+use getset::CopyGetters;
+use num::BigInt;
+
 mod helpers;
 pub(crate) mod rights_service;
 pub(crate) mod votes_services;
+
+use super::{vec_string_to_int, string_to_int};
+
+#[derive(Debug, Deserialize, Clone, CopyGetters)]
+pub(crate) struct ProtocolConstants {
+    proof_of_work_nonce_size: u8,
+    nonce_length: u8,
+    max_revelations_per_block: u8,
+    max_operation_data_length: i32,
+    max_proposals_per_delegate: u8,
+    preserved_cycles: u8,
+
+    #[get_copy = "pub(crate)"]
+    blocks_per_cycle: i32,
+    
+    blocks_per_commitment: i32,
+    blocks_per_roll_snapshot: i32,
+    blocks_per_voting_period: i32,
+
+    #[serde(with = "vec_string_to_int")]
+    time_between_blocks: Vec<i64>,
+    
+    endorsers_per_block: u16,
+
+    #[serde(with = "string_to_int")]
+    hard_gas_limit_per_operation: BigInt,
+
+    #[serde(with = "string_to_int")]
+    hard_gas_limit_per_block: BigInt,
+
+    #[serde(with = "string_to_int")]
+    proof_of_work_threshold: BigInt,
+
+    #[serde(with = "string_to_int")]
+    tokens_per_roll: BigInt,
+    michelson_maximum_type_size: u16,
+
+    #[serde(with = "string_to_int")]
+    seed_nonce_revelation_tip: BigInt,
+
+    origination_size: i32,
+
+    #[serde(with = "string_to_int")]
+    block_security_deposit: BigInt,
+
+    #[serde(with = "string_to_int")]
+    endorsement_security_deposit: BigInt,
+
+    #[serde(with = "string_to_int")]
+    block_reward: BigInt,
+
+    #[serde(with = "string_to_int")]
+    endorsement_reward: BigInt,
+
+    #[serde(with = "string_to_int")]
+    cost_per_byte: BigInt,
+
+    #[serde(with = "string_to_int")]
+    hard_storage_limit_per_operation: BigInt,
+
+    #[serde(with = "string_to_int")]
+    test_chain_duration: i64,
+}

--- a/rpc/src/services/protocol/proto_004/mod.rs
+++ b/rpc/src/services/protocol/proto_004/mod.rs
@@ -1,15 +1,15 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use serde::Deserialize;
 use getset::CopyGetters;
 use num::BigInt;
+use serde::Deserialize;
 
 mod helpers;
 pub(crate) mod rights_service;
 pub(crate) mod votes_services;
 
-use super::{vec_string_to_int, string_to_int};
+use super::{string_to_int, vec_string_to_int};
 
 #[derive(Debug, Deserialize, Clone, CopyGetters)]
 pub(crate) struct ProtocolConstants {
@@ -22,14 +22,14 @@ pub(crate) struct ProtocolConstants {
 
     #[get_copy = "pub(crate)"]
     blocks_per_cycle: i32,
-    
+
     blocks_per_commitment: i32,
     blocks_per_roll_snapshot: i32,
     blocks_per_voting_period: i32,
 
     #[serde(with = "vec_string_to_int")]
     time_between_blocks: Vec<i64>,
-    
+
     endorsers_per_block: u16,
 
     #[serde(with = "string_to_int")]

--- a/rpc/src/services/protocol/proto_004/rights_service.rs
+++ b/rpc/src/services/protocol/proto_004/rights_service.rs
@@ -16,21 +16,29 @@ use std::convert::TryInto;
 use anyhow::format_err;
 use itertools::Itertools;
 
-use crate::services::dev_services::contract_id_to_contract_address_for_index;
+use crypto::hash::ChainId;
 use tezos_messages::base::rpc_support::{RpcJsonMap, ToRpcJsonMap};
 use tezos_messages::base::signature_public_key_hash::SignaturePublicKeyHash;
 use tezos_messages::protocol::proto_004::rights::{BakingRights, EndorsingRight};
-use tezos_wrapper::TezedgeContextClient;
 
+use storage::cycle_storage::CycleData;
+use storage::CycleMetaStorage;
+
+use crate::server::RpcServiceEnvironment;
+use crate::services::dev_services::contract_id_to_contract_address_for_index;
 use crate::services::protocol::proto_004::helpers::{
-    get_prng_number, init_prng, EndorserSlots, RightsConstants, RightsContextData, RightsParams,
+    get_cycle_data, get_prng_number, init_prng, level_position, EndorserSlots, RightsConstants,
+    RightsParams,
 };
 use crate::services::protocol::ContextProtocolParam;
+
+use super::helpers::RightsMetadata;
 
 /// Return generated baking rights.
 ///
 /// # Arguments
 ///
+/// * `block_id` - Url path parameter 'block_id', it contains string "head", block level or block hash.
 /// * `level` - Url query parameter 'level'.
 /// * `delegate` - Url query parameter 'delegate'.
 /// * `cycle` - Url query parameter 'cycle'.
@@ -41,14 +49,17 @@ use crate::services::protocol::ContextProtocolParam;
 /// * `state` - Current RPC collected state (head).
 ///
 /// Prepare all data to generate baking rights and then use Tezos PRNG to generate them.
-pub(crate) fn check_and_get_baking_rights(
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn check_and_get_baking_rights(
     context_proto_params: ContextProtocolParam,
     level: Option<&str>,
     delegate: Option<&str>,
     cycle: Option<&str>,
     max_priority: Option<&str>,
     has_all: bool,
-    context: &TezedgeContextClient,
+    cycle_meta_storage: &CycleMetaStorage,
+    chain_id: &ChainId,
+    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -61,16 +72,24 @@ pub(crate) fn check_and_get_baking_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
+        chain_id,
+        env,
         true,
-    )?;
+    )
+    .await?;
 
-    let context_data: RightsContextData = RightsContextData::prepare_context_data_for_rights(
+    let cycle_meta_data = get_cycle_data(
         params.clone(),
-        constants.clone(),
-        (&context_proto_params.block_header.header.context(), context),
+        *params.rights_metadata().block_cycle(),
+        cycle_meta_storage,
     )?;
 
-    get_baking_rights(&context_data, &params, &constants)
+    get_baking_rights(
+        &cycle_meta_data,
+        &params,
+        &constants,
+        params.rights_metadata(),
+    )
 }
 
 /// Use prepared data to generate baking rights
@@ -82,9 +101,10 @@ pub(crate) fn check_and_get_baking_rights(
 /// * `constants` - Context constants used in baking and endorsing rights [RightsConstants](RightsConstants::parse_rights_constants).
 #[inline]
 pub(crate) fn get_baking_rights(
-    context_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
     parameters: &RightsParams,
     constants: &RightsConstants,
+    rights_metadata: &RightsMetadata,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let mut baking_rights = Vec::<BakingRights>::new();
 
@@ -93,22 +113,48 @@ pub(crate) fn get_baking_rights(
 
     let timestamp = parameters.block_timestamp();
     let block_level = parameters.block_level();
+    let cycle_position = *rights_metadata.block_cycle_position();
+
+    // build a reverse map of rols so we have access in O(1)
+    // let rolls_map: HashMap<i32, String> = HashMap::new();
+    let rolls_map: HashMap<i32, String> = cycle_meta_data
+        .rolls_data()
+        .iter()
+        .map(|(delegate, rolls)| {
+            rolls
+                .iter()
+                .map(|roll| {
+                    (
+                        *roll,
+                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
+                            .unwrap()
+                            .to_string_representation(),
+                    )
+                })
+                .collect::<HashMap<i32, String>>()
+        })
+        .flatten()
+        .collect();
 
     // iterate through the whole cycle if necessery
     if let Some(cycle) = parameters.requested_cycle() {
-        let first_block_level = cycle * (blocks_per_cycle as i64) + 1;
-        let last_block_level = first_block_level + (blocks_per_cycle as i64);
+        let first_block_level: i32 = cycle * blocks_per_cycle + 1;
+        let last_block_level = first_block_level + blocks_per_cycle;
 
         for level in first_block_level..last_block_level {
-            let seconds_to_add = (level - block_level).abs() * time_between_blocks[0];
+            let block_level_diff: i64 = (level - block_level).abs().into();
+            let seconds_to_add: i64 = block_level_diff * time_between_blocks[0];
             let estimated_timestamp = timestamp + seconds_to_add;
+            let cycle_position = level_position(level, blocks_per_cycle)?;
 
             // assign rolls goes here
             baking_rights_assign_rolls(
-                &parameters,
-                &constants,
-                &context_data,
-                level.try_into()?,
+                parameters,
+                constants,
+                cycle_meta_data,
+                &rolls_map,
+                level,
+                cycle_position,
                 estimated_timestamp,
                 true,
                 &mut baking_rights,
@@ -118,14 +164,17 @@ pub(crate) fn get_baking_rights(
         }
     } else {
         let level = *parameters.requested_level();
-        let seconds_to_add = (level - block_level).abs() * time_between_blocks[0];
+        let block_level_diff: i64 = (level - block_level).abs().into();
+        let seconds_to_add: i64 = block_level_diff * time_between_blocks[0];
         let estimated_timestamp = timestamp + seconds_to_add;
         // assign rolls goes here
         baking_rights_assign_rolls(
-            &parameters,
-            &constants,
-            &context_data,
-            level.try_into()?,
+            parameters,
+            constants,
+            cycle_meta_data,
+            &rolls_map,
+            level,
+            cycle_position,
             estimated_timestamp,
             false,
             &mut baking_rights,
@@ -164,11 +213,14 @@ pub(crate) fn get_baking_rights(
 ///
 /// Baking priorities are are assigned to Roles, the default behavior is to include only the top priority for the delegate
 #[inline]
+#[allow(clippy::too_many_arguments)]
 fn baking_rights_assign_rolls(
     parameters: &RightsParams,
     constants: &RightsConstants,
-    context_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
+    rolls_map: &HashMap<i32, String>,
     level: i32,
+    cycle_position: i32,
     estimated_head_timestamp: i64,
     is_cycle: bool,
     baking_rights: &mut Vec<BakingRights>,
@@ -183,20 +235,19 @@ fn baking_rights_assign_rolls(
     let max_priority = *parameters.max_priority();
     let has_all = parameters.has_all();
     let block_level = *parameters.block_level();
-    let last_roll = *context_data.last_roll();
-    let rolls_map = context_data.rolls();
-    let display_level: i32 = (*parameters.display_level()).try_into()?;
+    let last_roll = *cycle_meta_data.last_roll();
+    let display_level: i32 = *parameters.display_level();
 
     for priority in 0..max_priority {
         // draw the rolls for the requested parameters
         let delegate_to_assign;
         // TODO: priority can overflow in the ocaml code, do a priority % i32::max_value()
         let mut state = init_prng(
-            &context_data,
-            &constants,
+            cycle_meta_data,
+            constants,
             BAKING_USE_STRING,
-            level,
-            priority.try_into()?,
+            cycle_position,
+            priority,
         )?;
 
         loop {
@@ -216,7 +267,7 @@ fn baking_rights_assign_rolls(
         }
 
         // we omit the estimated_time field if the block on the requested level is already baked
-        let priority_timestamp = if block_level < (level as i64) {
+        let priority_timestamp = if block_level < level {
             let time = if time_between_blocks.len() == 1 {
                 time_between_blocks[0]
             } else {
@@ -232,7 +283,7 @@ fn baking_rights_assign_rolls(
 
         baking_rights.push(BakingRights::new(
             rights_level,
-            SignaturePublicKeyHash::from_b58_hash(&delegate_to_assign)?,
+            SignaturePublicKeyHash::from_b58_hash(delegate_to_assign)?,
             priority as u16,
             priority_timestamp,
         ));
@@ -245,6 +296,7 @@ fn baking_rights_assign_rolls(
 ///
 /// # Arguments
 ///
+/// * `block_id` - Url path parameter 'block_id', it contains string "head", block level or block hash.
 /// * `level` - Url query parameter 'level'.
 /// * `delegate` - Url query parameter 'delegate'.
 /// * `cycle` - Url query parameter 'cycle'.
@@ -254,13 +306,16 @@ fn baking_rights_assign_rolls(
 /// * `state` - Current RPC collected state (head).
 ///
 /// Prepare all data to generate endorsing rights and then use Tezos PRNG to generate them.
-pub(crate) fn check_and_get_endorsing_rights(
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn check_and_get_endorsing_rights(
     context_proto_params: ContextProtocolParam,
     level: Option<&str>,
     delegate: Option<&str>,
     cycle: Option<&str>,
     has_all: bool,
-    context: &TezedgeContextClient,
+    cycle_meta_storage: &CycleMetaStorage,
+    chain_id: &ChainId,
+    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -273,16 +328,19 @@ pub(crate) fn check_and_get_endorsing_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
+        chain_id,
+        env,
         false,
-    )?;
+    )
+    .await?;
 
-    let context_data: RightsContextData = RightsContextData::prepare_context_data_for_rights(
+    let cycle_meta_data = get_cycle_data(
         params.clone(),
-        constants.clone(),
-        (&context_proto_params.block_header.header.context(), context),
+        *params.rights_metadata().block_cycle(),
+        cycle_meta_storage,
     )?;
 
-    get_endorsing_rights(&context_data, &params, &constants)
+    get_endorsing_rights(&cycle_meta_data, &params, &constants)
 }
 
 /// Use prepared data to generate endosring rights
@@ -293,31 +351,52 @@ pub(crate) fn check_and_get_endorsing_rights(
 /// * `parameters` - Parameters created by [RightsParams](RightsParams::parse_rights_parameters).
 /// * `constants` - Context constants used in baking and endorsing rights [RightsConstants](RightsConstants::parse_rights_constants).
 fn get_endorsing_rights(
-    context_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
     parameters: &RightsParams,
     constants: &RightsConstants,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     // define helper and output variables
     let mut endorsing_rights = Vec::<EndorsingRight>::new();
 
+    let rolls_map: HashMap<i32, String> = cycle_meta_data
+        .rolls_data()
+        .iter()
+        .map(|(delegate, rolls)| {
+            rolls
+                .iter()
+                .map(|roll| {
+                    (
+                        *roll,
+                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
+                            .unwrap()
+                            .to_string_representation(),
+                    )
+                })
+                .collect::<HashMap<i32, String>>()
+        })
+        .flatten()
+        .collect();
+
     // when query param cycle is specified then iterate over all cycle levels, else only given level
     if let Some(cycle) = parameters.requested_cycle() {
         let blocks_per_cycle = *constants.blocks_per_cycle();
-        let first_cycle_level = cycle * (blocks_per_cycle as i64) + 1;
-        let last_cycle_level = first_cycle_level + (blocks_per_cycle as i64);
+        let first_cycle_level = cycle * blocks_per_cycle + 1;
+        let last_cycle_level = first_cycle_level + blocks_per_cycle;
         for level in first_cycle_level..last_cycle_level {
             // get estimated time first because is equal for all endorsers in given level
             // the base level for estimated time computation is level of previous block
             let estimated_time: Option<i64> =
                 parameters.get_estimated_time(constants, Some(level - 1));
+            let cycle_position = level_position(level, blocks_per_cycle)?;
 
             complete_endorsing_rights_for_level(
-                context_data,
+                cycle_meta_data,
                 parameters,
                 constants,
-                level,
+                &rolls_map,
                 level,
                 estimated_time,
+                cycle_position,
                 &mut endorsing_rights,
             )?;
             // endorsing_rights = merge_slices!(&endorsing_rights, &level_endorsing_rights);
@@ -327,12 +406,13 @@ fn get_endorsing_rights(
         let estimated_time: Option<i64> = parameters.get_estimated_time(constants, None);
 
         complete_endorsing_rights_for_level(
-            context_data,
+            cycle_meta_data,
             parameters,
             constants,
-            *parameters.requested_level(),
+            &rolls_map,
             *parameters.display_level(),
             estimated_time,
+            *parameters.rights_metadata().block_cycle_position(),
             &mut endorsing_rights,
         )?;
     };
@@ -356,17 +436,20 @@ fn get_endorsing_rights(
 /// * `display_level` - Level to be displayed in output.
 /// * `estimated_time` - Estimated time of endorsement, is set to None if in past relative to block_id.
 #[inline]
+#[allow(clippy::too_many_arguments)]
 fn complete_endorsing_rights_for_level(
-    context_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
     parameters: &RightsParams,
     constants: &RightsConstants,
-    level: i64,
-    display_level: i64,
+    rolls_map: &HashMap<i32, String>,
+    display_level: i32,
     estimated_time: Option<i64>,
+    cycle_position: i32,
     endorsing_rights: &mut Vec<EndorsingRight>,
 ) -> Result<(), anyhow::Error> {
     // endorsers_slots is needed to group all slots by delegate
-    let endorsers_slots = get_endorsers_slots(constants, context_data, level)?;
+    let endorsers_slots =
+        get_endorsers_slots(constants, cycle_meta_data, rolls_map, cycle_position)?;
 
     // convert contract id to hash contract address hex byte string (needed for ordering)
     let mut endorers_slots_keys_for_order: HashMap<String, String> = HashMap::new();
@@ -397,8 +480,8 @@ fn complete_endorsing_rights_for_level(
         }
 
         endorsing_rights.push(EndorsingRight::new(
-            display_level.try_into()?,
-            SignaturePublicKeyHash::from_b58_hash(&delegate_contract_id)?,
+            display_level,
+            SignaturePublicKeyHash::from_b58_hash(delegate_contract_id)?,
             delegate_data.slots().clone(),
             estimated_time,
         ))
@@ -416,28 +499,29 @@ fn complete_endorsing_rights_for_level(
 #[inline]
 fn get_endorsers_slots(
     constants: &RightsConstants,
-    context_data: &RightsContextData,
-    level: i64,
+    cycle_meta_data: &CycleData,
+    rolls_map: &HashMap<i32, String>,
+    cycle_position: i32,
 ) -> Result<HashMap<String, EndorserSlots>, anyhow::Error> {
     // special byte string used in Tezos PRNG
     const ENDORSEMENT_USE_STRING: &[u8] = b"level endorsement:";
     // prepare helper variable
     let mut endorsers_slots: HashMap<String, EndorserSlots> = HashMap::new();
 
-    for endorser_slot in (0..*constants.endorsers_per_block() as u8).rev() {
+    for endorser_slot in (0..*constants.endorsers_per_block()).rev() {
         // generate PRNG per endorsement slot and take delegates by roll number from context_rolls
         // if roll number is not found then reroll with new state till roll nuber is found in context_rolls
         let mut state = init_prng(
-            &context_data,
-            &constants,
+            cycle_meta_data,
+            constants,
             ENDORSEMENT_USE_STRING,
-            level.try_into()?,
+            cycle_position,
             endorser_slot.try_into()?,
         )?;
         loop {
-            let (random_num, sequence) = get_prng_number(state, *context_data.last_roll())?;
+            let (random_num, sequence) = get_prng_number(state, *cycle_meta_data.last_roll())?;
 
-            if let Some(delegate) = context_data.rolls().get(&random_num) {
+            if let Some(delegate) = rolls_map.get(&random_num) {
                 // collect all slots for each delegate
                 let endorsers_slots_entry = endorsers_slots
                     .entry(delegate.clone())

--- a/rpc/src/services/protocol/proto_004/rights_service.rs
+++ b/rpc/src/services/protocol/proto_004/rights_service.rs
@@ -110,25 +110,17 @@ pub(crate) fn get_baking_rights(
     let cycle_position = *rights_metadata.block_cycle_position();
 
     // build a reverse map of rols so we have access in O(1)
-    // let rolls_map: HashMap<i32, String> = HashMap::new();
-    let rolls_map: HashMap<i32, String> = cycle_meta_data
-        .rolls_data()
-        .iter()
-        .map(|(delegate, rolls)| {
-            rolls
-                .iter()
-                .map(|roll| {
-                    (
-                        *roll,
-                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
-                            .unwrap()
-                            .to_string_representation(),
-                    )
-                })
-                .collect::<HashMap<i32, String>>()
-        })
-        .flatten()
-        .collect();
+    let mut rolls_map: HashMap<i32, String> = HashMap::new();
+
+    for (delegate, rolls) in cycle_meta_data.rolls_data() {
+        for roll in rolls {
+            rolls_map.insert(
+                *roll,
+                SignaturePublicKeyHash::from_tagged_bytes(delegate.to_vec())?
+                    .to_string_representation(),
+            );
+        }
+    }
 
     // iterate through the whole cycle if necessery
     if let Some(cycle) = parameters.requested_cycle() {
@@ -348,24 +340,18 @@ fn get_endorsing_rights(
     // define helper and output variables
     let mut endorsing_rights = Vec::<EndorsingRight>::new();
 
-    let rolls_map: HashMap<i32, String> = cycle_meta_data
-        .rolls_data()
-        .iter()
-        .map(|(delegate, rolls)| {
-            rolls
-                .iter()
-                .map(|roll| {
-                    (
-                        *roll,
-                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
-                            .unwrap()
-                            .to_string_representation(),
-                    )
-                })
-                .collect::<HashMap<i32, String>>()
-        })
-        .flatten()
-        .collect();
+    // build a reverse map of rols so we have access in O(1)
+    let mut rolls_map: HashMap<i32, String> = HashMap::new();
+
+    for (delegate, rolls) in cycle_meta_data.rolls_data() {
+        for roll in rolls {
+            rolls_map.insert(
+                *roll,
+                SignaturePublicKeyHash::from_tagged_bytes(delegate.to_vec())?
+                    .to_string_representation(),
+            );
+        }
+    }
 
     // when query param cycle is specified then iterate over all cycle levels, else only given level
     if let Some(cycle) = parameters.requested_cycle() {

--- a/rpc/src/services/protocol/proto_004/rights_service.rs
+++ b/rpc/src/services/protocol/proto_004/rights_service.rs
@@ -16,7 +16,6 @@ use std::convert::TryInto;
 use anyhow::format_err;
 use itertools::Itertools;
 
-use crypto::hash::ChainId;
 use tezos_messages::base::rpc_support::{RpcJsonMap, ToRpcJsonMap};
 use tezos_messages::base::signature_public_key_hash::SignaturePublicKeyHash;
 use tezos_messages::protocol::proto_004::rights::{BakingRights, EndorsingRight};
@@ -24,7 +23,6 @@ use tezos_messages::protocol::proto_004::rights::{BakingRights, EndorsingRight};
 use storage::cycle_storage::CycleData;
 use storage::CycleMetaStorage;
 
-use crate::server::RpcServiceEnvironment;
 use crate::services::dev_services::contract_id_to_contract_address_for_index;
 use crate::services::protocol::proto_004::helpers::{
     get_cycle_data, get_prng_number, init_prng, level_position, EndorserSlots, RightsConstants,
@@ -58,8 +56,6 @@ pub(crate) async fn check_and_get_baking_rights(
     max_priority: Option<&str>,
     has_all: bool,
     cycle_meta_storage: &CycleMetaStorage,
-    chain_id: &ChainId,
-    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -72,8 +68,6 @@ pub(crate) async fn check_and_get_baking_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
-        chain_id,
-        env,
         true,
     )
     .await?;
@@ -314,8 +308,6 @@ pub(crate) async fn check_and_get_endorsing_rights(
     cycle: Option<&str>,
     has_all: bool,
     cycle_meta_storage: &CycleMetaStorage,
-    chain_id: &ChainId,
-    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -328,8 +320,6 @@ pub(crate) async fn check_and_get_endorsing_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
-        chain_id,
-        env,
         false,
     )
     .await?;

--- a/rpc/src/services/protocol/proto_004/votes_services.rs
+++ b/rpc/src/services/protocol/proto_004/votes_services.rs
@@ -20,7 +20,7 @@ pub fn get_votes_listings(
     // filter out the listings data
     let listings_data = if let Some(val) = env
         .tezedge_context()
-        .get_key_values_by_prefix(&context_hash, context_key_owned!("data/votes/listings"))?
+        .get_key_values_by_prefix(context_hash, context_key_owned!("data/votes/listings"))?
     {
         val
     } else {

--- a/rpc/src/services/protocol/proto_005_2/helpers.rs
+++ b/rpc/src/services/protocol/proto_005_2/helpers.rs
@@ -50,14 +50,15 @@ impl RightsConstants {
     pub(crate) fn parse_rights_constants(
         context_proto_param: &ContextProtocolParam,
     ) -> Result<Self, anyhow::Error> {
-        let protocol_constants: ProtocolConstants = serde_json::from_str(&context_proto_param.constants_data)?;
+        let protocol_constants: ProtocolConstants =
+            serde_json::from_str(&context_proto_param.constants_data)?;
 
         Ok(Self {
             blocks_per_cycle: protocol_constants.blocks_per_cycle,
             preserved_cycles: protocol_constants.preserved_cycles,
             nonce_length: protocol_constants.nonce_length,
             time_between_blocks: protocol_constants.time_between_blocks,
-            endorsers_per_block: protocol_constants.endorsers_per_block ,
+            endorsers_per_block: protocol_constants.endorsers_per_block,
         })
     }
 }
@@ -68,11 +69,7 @@ pub(crate) fn get_cycle_data(
     cycle_meta_storage: &CycleMetaStorage,
 ) -> Result<CycleData, anyhow::Error> {
     // prepare cycle for which rollers are selected
-    let requested_cycle = if let Some(cycle) = *parameters.requested_cycle() {
-        cycle
-    } else {
-        block_cycle
-    };
+    let requested_cycle = parameters.requested_cycle().unwrap_or(block_cycle);
 
     if let Some(cycle_meta_data) = cycle_meta_storage.get(&requested_cycle)? {
         Ok(cycle_meta_data)
@@ -381,9 +378,6 @@ pub fn init_prng(
     let state = cycle_meta_data.seed_bytes();
     let zero_bytes: Vec<u8> = vec![0; nonce_size];
 
-    // the position of the block in its cycle; has to be i32
-    // let cycle_position: i32 = level_position(level, blocks_per_cycle)?;
-
     // take the state (initially the random seed), zero bytes, the use string and the blocks position in the cycle as bytes, merge them together and hash the result
     let rd = blake2b::digest_256(&merge_slices!(
         state,
@@ -456,7 +450,6 @@ impl RightsMetadata {
         requested_level: i32,
     ) -> Result<Self, RightsConstantError> {
         Ok(Self {
-            // (cycle_from_level(requested_level, blocks_per_cycle)?, level_position(requested_level, blocks_per_cycle)?)
             block_cycle: cycle_from_level(requested_level, blocks_per_cycle)?,
             block_cycle_position: level_position(requested_level, blocks_per_cycle)?,
         })

--- a/rpc/src/services/protocol/proto_005_2/helpers.rs
+++ b/rpc/src/services/protocol/proto_005_2/helpers.rs
@@ -23,6 +23,8 @@ use crate::services::protocol::{
     parse_block_metadata_level, ContextProtocolParam, MetadataParsingError,
 };
 
+use super::ProtocolConstants;
+
 /// Context constants used in baking and endorsing rights
 #[derive(Debug, Clone, Getters)]
 pub struct RightsConstants {
@@ -42,10 +44,6 @@ pub struct RightsConstants {
 pub enum RightsConstantError {
     #[error("The value is illegal, key: {key}")]
     WrongValue { key: &'static str },
-    #[error("Key cannot be parsed, key: {key}")]
-    Parsing { key: &'static str },
-    #[error("Key cannot be found in constants, key: {key}")]
-    KeyNotFound { key: &'static str },
 }
 
 impl RightsConstants {
@@ -58,80 +56,14 @@ impl RightsConstants {
     pub(crate) fn parse_rights_constants(
         context_proto_param: &ContextProtocolParam,
     ) -> Result<Self, anyhow::Error> {
-        if let Some(constatns_deserialized) =
-            serde_json::from_str::<serde_json::Value>(&context_proto_param.constants_data)?
-                .as_object()
-        {
-            let blocks_per_cycle = get_constant_i64(constatns_deserialized, "blocks_per_cycle")?;
-            let preserved_cycles = get_constant_i64(constatns_deserialized, "preserved_cycles")?;
-            let nonce_length = get_constant_i64(constatns_deserialized, "nonce_length")?;
-            let time_between_blocks = get_time_between_blocks(constatns_deserialized)?;
-            let endorsers_per_block =
-                get_constant_i64(constatns_deserialized, "endorsers_per_block")?;
+        let protocol_constants: ProtocolConstants = serde_json::from_str(&context_proto_param.constants_data)?;
 
-            Ok(Self {
-                blocks_per_cycle: blocks_per_cycle as i32,
-                preserved_cycles: preserved_cycles as u8,
-                nonce_length: nonce_length as u8,
-                time_between_blocks,
-                endorsers_per_block: endorsers_per_block as u16,
-            })
-        } else {
-            bail!("Constants not an object")
-        }
-    }
-}
-
-fn get_constant_i64(
-    constants: &serde_json::Map<String, serde_json::Value>,
-    key: &'static str,
-) -> Result<i64, RightsConstantError> {
-    if let Some(value) = constants.get(key) {
-        if let Some(i64_value) = value.as_i64() {
-            Ok(i64_value)
-        } else {
-            if let Some(str_num) = value.as_str() {
-                return str_num
-                    .parse()
-                    .map_err(|_| RightsConstantError::Parsing { key });
-            }
-            Err(RightsConstantError::Parsing { key })
-        }
-    } else {
-        Err(RightsConstantError::KeyNotFound { key })
-    }
-}
-
-fn get_time_between_blocks(
-    constants: &serde_json::Map<String, serde_json::Value>,
-) -> Result<Vec<i64>, RightsConstantError> {
-    let mut ret: Vec<i64> = Vec::new();
-    if let Some(value) = constants.get("time_between_blocks") {
-        if let Some(array) = value.as_array() {
-            for e in array {
-                if let Some(str_element) = e.as_str() {
-                    let parsed =
-                        str_element
-                            .parse::<i64>()
-                            .map_err(|_| RightsConstantError::Parsing {
-                                key: "time_between_blocks",
-                            })?;
-                    ret.push(parsed);
-                } else {
-                    return Err(RightsConstantError::Parsing {
-                        key: "time_between_blocks",
-                    });
-                }
-            }
-            Ok(ret)
-        } else {
-            Err(RightsConstantError::Parsing {
-                key: "time_between_blocks",
-            })
-        }
-    } else {
-        Err(RightsConstantError::KeyNotFound {
-            key: "time_between_blocks",
+        Ok(Self {
+            blocks_per_cycle: protocol_constants.blocks_per_cycle,
+            preserved_cycles: protocol_constants.preserved_cycles,
+            nonce_length: protocol_constants.nonce_length,
+            time_between_blocks: protocol_constants.time_between_blocks,
+            endorsers_per_block: protocol_constants.endorsers_per_block ,
         })
     }
 }

--- a/rpc/src/services/protocol/proto_005_2/helpers.rs
+++ b/rpc/src/services/protocol/proto_005_2/helpers.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use crypto::hash::ChainId;
 use anyhow::bail;
 use getset::Getters;
+use thiserror::Error;
 
 use crypto::{
     blake2b::{self, Blake2bError},

--- a/rpc/src/services/protocol/proto_005_2/mod.rs
+++ b/rpc/src/services/protocol/proto_005_2/mod.rs
@@ -1,6 +1,81 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
+use serde::Deserialize;
+use getset::CopyGetters;
+use num::BigInt;
+
 mod helpers;
 pub(crate) mod rights_service;
 pub(crate) mod votes_services;
+
+use super::{vec_string_to_int, string_to_int};
+
+#[derive(Debug, Deserialize, Clone, CopyGetters)]
+pub(crate) struct ProtocolConstants {
+    proof_of_work_nonce_size: u8,
+    nonce_length: u8,
+    max_revelations_per_block: u8,
+    max_operation_data_length: i32,
+    max_proposals_per_delegate: u8,
+    preserved_cycles: u8,
+
+    #[get_copy = "pub(crate)"]
+    blocks_per_cycle: i32,
+    
+    blocks_per_commitment: i32,
+    blocks_per_roll_snapshot: i32,
+    blocks_per_voting_period: i32,
+
+    #[serde(with = "vec_string_to_int")]
+    time_between_blocks: Vec<i64>,
+    
+    endorsers_per_block: u16,
+
+    #[serde(with = "string_to_int")]
+    hard_gas_limit_per_operation: BigInt,
+
+    #[serde(with = "string_to_int")]
+    hard_gas_limit_per_block: BigInt,
+
+    #[serde(with = "string_to_int")]
+    proof_of_work_threshold: BigInt,
+
+    #[serde(with = "string_to_int")]
+    tokens_per_roll: BigInt,
+    michelson_maximum_type_size: u16,
+
+    #[serde(with = "string_to_int")]
+    seed_nonce_revelation_tip: BigInt,
+
+    origination_size: i32,
+
+    #[serde(with = "string_to_int")]
+    block_security_deposit: BigInt,
+
+    #[serde(with = "string_to_int")]
+    endorsement_security_deposit: BigInt,
+
+    #[serde(with = "string_to_int")]
+    block_reward: BigInt,
+
+    #[serde(with = "string_to_int")]
+    endorsement_reward: BigInt,
+
+    #[serde(with = "string_to_int")]
+    cost_per_byte: BigInt,
+
+    #[serde(with = "string_to_int")]
+    hard_storage_limit_per_operation: BigInt,
+
+    quorum_min: i32,
+    quorum_max: i32,
+    min_proposal_quorum: i32,
+    initial_endorsers: u16,
+
+    #[serde(with = "string_to_int")]
+    delay_per_missing_endorsement: i64,
+
+    #[serde(with = "string_to_int")]
+    test_chain_duration: i64,
+}

--- a/rpc/src/services/protocol/proto_005_2/mod.rs
+++ b/rpc/src/services/protocol/proto_005_2/mod.rs
@@ -1,15 +1,15 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use serde::Deserialize;
 use getset::CopyGetters;
 use num::BigInt;
+use serde::Deserialize;
 
 mod helpers;
 pub(crate) mod rights_service;
 pub(crate) mod votes_services;
 
-use super::{vec_string_to_int, string_to_int};
+use super::{string_to_int, vec_string_to_int};
 
 #[derive(Debug, Deserialize, Clone, CopyGetters)]
 pub(crate) struct ProtocolConstants {
@@ -22,14 +22,14 @@ pub(crate) struct ProtocolConstants {
 
     #[get_copy = "pub(crate)"]
     blocks_per_cycle: i32,
-    
+
     blocks_per_commitment: i32,
     blocks_per_roll_snapshot: i32,
     blocks_per_voting_period: i32,
 
     #[serde(with = "vec_string_to_int")]
     time_between_blocks: Vec<i64>,
-    
+
     endorsers_per_block: u16,
 
     #[serde(with = "string_to_int")]

--- a/rpc/src/services/protocol/proto_005_2/rights_service.rs
+++ b/rpc/src/services/protocol/proto_005_2/rights_service.rs
@@ -16,7 +16,6 @@ use std::convert::TryInto;
 use anyhow::format_err;
 use itertools::Itertools;
 
-use crypto::hash::ChainId;
 use tezos_messages::base::rpc_support::{RpcJsonMap, ToRpcJsonMap};
 use tezos_messages::base::signature_public_key_hash::SignaturePublicKeyHash;
 use tezos_messages::protocol::proto_005_2::rights::{BakingRights, EndorsingRight};
@@ -24,7 +23,6 @@ use tezos_messages::protocol::proto_005_2::rights::{BakingRights, EndorsingRight
 use storage::cycle_storage::CycleData;
 use storage::CycleMetaStorage;
 
-use crate::server::RpcServiceEnvironment;
 use crate::services::dev_services::contract_id_to_contract_address_for_index;
 use crate::services::protocol::proto_005_2::helpers::{
     get_cycle_data, get_prng_number, init_prng, level_position, EndorserSlots, RightsConstants,
@@ -58,8 +56,6 @@ pub(crate) async fn check_and_get_baking_rights(
     max_priority: Option<&str>,
     has_all: bool,
     cycle_meta_storage: &CycleMetaStorage,
-    chain_id: &ChainId,
-    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -72,8 +68,6 @@ pub(crate) async fn check_and_get_baking_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
-        chain_id,
-        env,
         true,
     )
     .await?;
@@ -314,8 +308,6 @@ pub(crate) async fn check_and_get_endorsing_rights(
     cycle: Option<&str>,
     has_all: bool,
     cycle_meta_storage: &CycleMetaStorage,
-    chain_id: &ChainId,
-    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -328,8 +320,6 @@ pub(crate) async fn check_and_get_endorsing_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
-        chain_id,
-        env,
         false,
     )
     .await?;

--- a/rpc/src/services/protocol/proto_005_2/rights_service.rs
+++ b/rpc/src/services/protocol/proto_005_2/rights_service.rs
@@ -110,25 +110,17 @@ pub(crate) fn get_baking_rights(
     let cycle_position = *rights_metadata.block_cycle_position();
 
     // build a reverse map of rols so we have access in O(1)
-    // let rolls_map: HashMap<i32, String> = HashMap::new();
-    let rolls_map: HashMap<i32, String> = cycle_meta_data
-        .rolls_data()
-        .iter()
-        .map(|(delegate, rolls)| {
-            rolls
-                .iter()
-                .map(|roll| {
-                    (
-                        *roll,
-                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
-                            .unwrap()
-                            .to_string_representation(),
-                    )
-                })
-                .collect::<HashMap<i32, String>>()
-        })
-        .flatten()
-        .collect();
+    let mut rolls_map: HashMap<i32, String> = HashMap::new();
+
+    for (delegate, rolls) in cycle_meta_data.rolls_data() {
+        for roll in rolls {
+            rolls_map.insert(
+                *roll,
+                SignaturePublicKeyHash::from_tagged_bytes(delegate.to_vec())?
+                    .to_string_representation(),
+            );
+        }
+    }
 
     // iterate through the whole cycle if necessery
     if let Some(cycle) = parameters.requested_cycle() {
@@ -348,24 +340,18 @@ fn get_endorsing_rights(
     // define helper and output variables
     let mut endorsing_rights = Vec::<EndorsingRight>::new();
 
-    let rolls_map: HashMap<i32, String> = cycle_meta_data
-        .rolls_data()
-        .iter()
-        .map(|(delegate, rolls)| {
-            rolls
-                .iter()
-                .map(|roll| {
-                    (
-                        *roll,
-                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
-                            .unwrap()
-                            .to_string_representation(),
-                    )
-                })
-                .collect::<HashMap<i32, String>>()
-        })
-        .flatten()
-        .collect();
+    // build a reverse map of rols so we have access in O(1)
+    let mut rolls_map: HashMap<i32, String> = HashMap::new();
+
+    for (delegate, rolls) in cycle_meta_data.rolls_data() {
+        for roll in rolls {
+            rolls_map.insert(
+                *roll,
+                SignaturePublicKeyHash::from_tagged_bytes(delegate.to_vec())?
+                    .to_string_representation(),
+            );
+        }
+    }
 
     // when query param cycle is specified then iterate over all cycle levels, else only given level
     if let Some(cycle) = parameters.requested_cycle() {

--- a/rpc/src/services/protocol/proto_005_2/rights_service.rs
+++ b/rpc/src/services/protocol/proto_005_2/rights_service.rs
@@ -16,21 +16,29 @@ use std::convert::TryInto;
 use anyhow::format_err;
 use itertools::Itertools;
 
-use crate::services::dev_services::contract_id_to_contract_address_for_index;
+use crypto::hash::ChainId;
 use tezos_messages::base::rpc_support::{RpcJsonMap, ToRpcJsonMap};
 use tezos_messages::base::signature_public_key_hash::SignaturePublicKeyHash;
 use tezos_messages::protocol::proto_005_2::rights::{BakingRights, EndorsingRight};
-use tezos_wrapper::TezedgeContextClient;
 
+use storage::cycle_storage::CycleData;
+use storage::CycleMetaStorage;
+
+use crate::server::RpcServiceEnvironment;
+use crate::services::dev_services::contract_id_to_contract_address_for_index;
 use crate::services::protocol::proto_005_2::helpers::{
-    get_prng_number, init_prng, EndorserSlots, RightsConstants, RightsContextData, RightsParams,
+    get_cycle_data, get_prng_number, init_prng, level_position, EndorserSlots, RightsConstants,
+    RightsParams,
 };
 use crate::services::protocol::ContextProtocolParam;
+
+use super::helpers::RightsMetadata;
 
 /// Return generated baking rights.
 ///
 /// # Arguments
 ///
+/// * `block_id` - Url path parameter 'block_id', it contains string "head", block level or block hash.
 /// * `level` - Url query parameter 'level'.
 /// * `delegate` - Url query parameter 'delegate'.
 /// * `cycle` - Url query parameter 'cycle'.
@@ -41,14 +49,17 @@ use crate::services::protocol::ContextProtocolParam;
 /// * `state` - Current RPC collected state (head).
 ///
 /// Prepare all data to generate baking rights and then use Tezos PRNG to generate them.
-pub(crate) fn check_and_get_baking_rights(
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn check_and_get_baking_rights(
     context_proto_params: ContextProtocolParam,
     level: Option<&str>,
     delegate: Option<&str>,
     cycle: Option<&str>,
     max_priority: Option<&str>,
     has_all: bool,
-    context: &TezedgeContextClient,
+    cycle_meta_storage: &CycleMetaStorage,
+    chain_id: &ChainId,
+    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -61,16 +72,24 @@ pub(crate) fn check_and_get_baking_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
+        chain_id,
+        env,
         true,
-    )?;
+    )
+    .await?;
 
-    let context_data: RightsContextData = RightsContextData::prepare_context_data_for_rights(
+    let cycle_meta_data = get_cycle_data(
         params.clone(),
-        constants.clone(),
-        (&context_proto_params.block_header.header.context(), context),
+        *params.rights_metadata().block_cycle(),
+        cycle_meta_storage,
     )?;
 
-    get_baking_rights(&context_data, &params, &constants)
+    get_baking_rights(
+        &cycle_meta_data,
+        &params,
+        &constants,
+        params.rights_metadata(),
+    )
 }
 
 /// Use prepared data to generate baking rights
@@ -82,9 +101,10 @@ pub(crate) fn check_and_get_baking_rights(
 /// * `constants` - Context constants used in baking and endorsing rights [RightsConstants](RightsConstants::parse_rights_constants).
 #[inline]
 pub(crate) fn get_baking_rights(
-    context_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
     parameters: &RightsParams,
     constants: &RightsConstants,
+    rights_metadata: &RightsMetadata,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let mut baking_rights = Vec::<BakingRights>::new();
 
@@ -93,22 +113,48 @@ pub(crate) fn get_baking_rights(
 
     let timestamp = parameters.block_timestamp();
     let block_level = parameters.block_level();
+    let cycle_position = *rights_metadata.block_cycle_position();
+
+    // build a reverse map of rols so we have access in O(1)
+    // let rolls_map: HashMap<i32, String> = HashMap::new();
+    let rolls_map: HashMap<i32, String> = cycle_meta_data
+        .rolls_data()
+        .iter()
+        .map(|(delegate, rolls)| {
+            rolls
+                .iter()
+                .map(|roll| {
+                    (
+                        *roll,
+                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
+                            .unwrap()
+                            .to_string_representation(),
+                    )
+                })
+                .collect::<HashMap<i32, String>>()
+        })
+        .flatten()
+        .collect();
 
     // iterate through the whole cycle if necessery
     if let Some(cycle) = parameters.requested_cycle() {
-        let first_block_level = cycle * (blocks_per_cycle as i64) + 1;
-        let last_block_level = first_block_level + (blocks_per_cycle as i64);
+        let first_block_level: i32 = cycle * blocks_per_cycle + 1;
+        let last_block_level = first_block_level + blocks_per_cycle;
 
         for level in first_block_level..last_block_level {
-            let seconds_to_add = (level - block_level).abs() * time_between_blocks[0];
+            let block_level_diff: i64 = (level - block_level).abs().into();
+            let seconds_to_add: i64 = block_level_diff * time_between_blocks[0];
             let estimated_timestamp = timestamp + seconds_to_add;
+            let cycle_position = level_position(level, blocks_per_cycle)?;
 
             // assign rolls goes here
             baking_rights_assign_rolls(
-                &parameters,
-                &constants,
-                &context_data,
-                level.try_into()?,
+                parameters,
+                constants,
+                cycle_meta_data,
+                &rolls_map,
+                level,
+                cycle_position,
                 estimated_timestamp,
                 true,
                 &mut baking_rights,
@@ -118,14 +164,17 @@ pub(crate) fn get_baking_rights(
         }
     } else {
         let level = *parameters.requested_level();
-        let seconds_to_add = (level - block_level).abs() * time_between_blocks[0];
+        let block_level_diff: i64 = (level - block_level).abs().into();
+        let seconds_to_add: i64 = block_level_diff * time_between_blocks[0];
         let estimated_timestamp = timestamp + seconds_to_add;
         // assign rolls goes here
         baking_rights_assign_rolls(
-            &parameters,
-            &constants,
-            &context_data,
-            level.try_into()?,
+            parameters,
+            constants,
+            cycle_meta_data,
+            &rolls_map,
+            level,
+            cycle_position,
             estimated_timestamp,
             false,
             &mut baking_rights,
@@ -164,11 +213,14 @@ pub(crate) fn get_baking_rights(
 ///
 /// Baking priorities are are assigned to Roles, the default behavior is to include only the top priority for the delegate
 #[inline]
+#[allow(clippy::too_many_arguments)]
 fn baking_rights_assign_rolls(
     parameters: &RightsParams,
     constants: &RightsConstants,
-    context_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
+    rolls_map: &HashMap<i32, String>,
     level: i32,
+    cycle_position: i32,
     estimated_head_timestamp: i64,
     is_cycle: bool,
     baking_rights: &mut Vec<BakingRights>,
@@ -183,20 +235,19 @@ fn baking_rights_assign_rolls(
     let max_priority = *parameters.max_priority();
     let has_all = parameters.has_all();
     let block_level = *parameters.block_level();
-    let last_roll = *context_data.last_roll();
-    let rolls_map = context_data.rolls();
-    let display_level: i32 = (*parameters.display_level()).try_into()?;
+    let last_roll = *cycle_meta_data.last_roll();
+    let display_level: i32 = *parameters.display_level();
 
     for priority in 0..max_priority {
         // draw the rolls for the requested parameters
         let delegate_to_assign;
         // TODO: priority can overflow in the ocaml code, do a priority % i32::max_value()
         let mut state = init_prng(
-            &context_data,
-            &constants,
+            cycle_meta_data,
+            constants,
             BAKING_USE_STRING,
-            level,
-            priority.try_into()?,
+            cycle_position,
+            priority,
         )?;
 
         loop {
@@ -216,7 +267,7 @@ fn baking_rights_assign_rolls(
         }
 
         // we omit the estimated_time field if the block on the requested level is already baked
-        let priority_timestamp = if block_level < (level as i64) {
+        let priority_timestamp = if block_level < level {
             let time = if time_between_blocks.len() == 1 {
                 time_between_blocks[0]
             } else {
@@ -232,7 +283,7 @@ fn baking_rights_assign_rolls(
 
         baking_rights.push(BakingRights::new(
             rights_level,
-            SignaturePublicKeyHash::from_b58_hash(&delegate_to_assign)?,
+            SignaturePublicKeyHash::from_b58_hash(delegate_to_assign)?,
             priority as u16,
             priority_timestamp,
         ));
@@ -245,6 +296,7 @@ fn baking_rights_assign_rolls(
 ///
 /// # Arguments
 ///
+/// * `block_id` - Url path parameter 'block_id', it contains string "head", block level or block hash.
 /// * `level` - Url query parameter 'level'.
 /// * `delegate` - Url query parameter 'delegate'.
 /// * `cycle` - Url query parameter 'cycle'.
@@ -254,13 +306,16 @@ fn baking_rights_assign_rolls(
 /// * `state` - Current RPC collected state (head).
 ///
 /// Prepare all data to generate endorsing rights and then use Tezos PRNG to generate them.
-pub(crate) fn check_and_get_endorsing_rights(
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn check_and_get_endorsing_rights(
     context_proto_params: ContextProtocolParam,
     level: Option<&str>,
     delegate: Option<&str>,
     cycle: Option<&str>,
     has_all: bool,
-    context: &TezedgeContextClient,
+    cycle_meta_storage: &CycleMetaStorage,
+    chain_id: &ChainId,
+    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -273,16 +328,19 @@ pub(crate) fn check_and_get_endorsing_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
+        chain_id,
+        env,
         false,
-    )?;
+    )
+    .await?;
 
-    let context_data: RightsContextData = RightsContextData::prepare_context_data_for_rights(
+    let cycle_meta_data = get_cycle_data(
         params.clone(),
-        constants.clone(),
-        (&context_proto_params.block_header.header.context(), context),
+        *params.rights_metadata().block_cycle(),
+        cycle_meta_storage,
     )?;
 
-    get_endorsing_rights(&context_data, &params, &constants)
+    get_endorsing_rights(&cycle_meta_data, &params, &constants)
 }
 
 /// Use prepared data to generate endosring rights
@@ -293,31 +351,52 @@ pub(crate) fn check_and_get_endorsing_rights(
 /// * `parameters` - Parameters created by [RightsParams](RightsParams::parse_rights_parameters).
 /// * `constants` - Context constants used in baking and endorsing rights [RightsConstants](RightsConstants::parse_rights_constants).
 fn get_endorsing_rights(
-    context_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
     parameters: &RightsParams,
     constants: &RightsConstants,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     // define helper and output variables
     let mut endorsing_rights = Vec::<EndorsingRight>::new();
 
+    let rolls_map: HashMap<i32, String> = cycle_meta_data
+        .rolls_data()
+        .iter()
+        .map(|(delegate, rolls)| {
+            rolls
+                .iter()
+                .map(|roll| {
+                    (
+                        *roll,
+                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
+                            .unwrap()
+                            .to_string_representation(),
+                    )
+                })
+                .collect::<HashMap<i32, String>>()
+        })
+        .flatten()
+        .collect();
+
     // when query param cycle is specified then iterate over all cycle levels, else only given level
     if let Some(cycle) = parameters.requested_cycle() {
         let blocks_per_cycle = *constants.blocks_per_cycle();
-        let first_cycle_level = cycle * (blocks_per_cycle as i64) + 1;
-        let last_cycle_level = first_cycle_level + (blocks_per_cycle as i64);
+        let first_cycle_level = cycle * blocks_per_cycle + 1;
+        let last_cycle_level = first_cycle_level + blocks_per_cycle;
         for level in first_cycle_level..last_cycle_level {
             // get estimated time first because is equal for all endorsers in given level
             // the base level for estimated time computation is level of previous block
             let estimated_time: Option<i64> =
                 parameters.get_estimated_time(constants, Some(level - 1));
+            let cycle_position = level_position(level, blocks_per_cycle)?;
 
             complete_endorsing_rights_for_level(
-                context_data,
+                cycle_meta_data,
                 parameters,
                 constants,
-                level,
+                &rolls_map,
                 level,
                 estimated_time,
+                cycle_position,
                 &mut endorsing_rights,
             )?;
             // endorsing_rights = merge_slices!(&endorsing_rights, &level_endorsing_rights);
@@ -327,12 +406,13 @@ fn get_endorsing_rights(
         let estimated_time: Option<i64> = parameters.get_estimated_time(constants, None);
 
         complete_endorsing_rights_for_level(
-            context_data,
+            cycle_meta_data,
             parameters,
             constants,
-            *parameters.requested_level(),
+            &rolls_map,
             *parameters.display_level(),
             estimated_time,
+            *parameters.rights_metadata().block_cycle_position(),
             &mut endorsing_rights,
         )?;
     };
@@ -356,17 +436,20 @@ fn get_endorsing_rights(
 /// * `display_level` - Level to be displayed in output.
 /// * `estimated_time` - Estimated time of endorsement, is set to None if in past relative to block_id.
 #[inline]
+#[allow(clippy::too_many_arguments)]
 fn complete_endorsing_rights_for_level(
-    context_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
     parameters: &RightsParams,
     constants: &RightsConstants,
-    level: i64,
-    display_level: i64,
+    rolls_map: &HashMap<i32, String>,
+    display_level: i32,
     estimated_time: Option<i64>,
+    cycle_position: i32,
     endorsing_rights: &mut Vec<EndorsingRight>,
 ) -> Result<(), anyhow::Error> {
     // endorsers_slots is needed to group all slots by delegate
-    let endorsers_slots = get_endorsers_slots(constants, context_data, level)?;
+    let endorsers_slots =
+        get_endorsers_slots(constants, cycle_meta_data, rolls_map, cycle_position)?;
 
     // convert contract id to hash contract address hex byte string (needed for ordering)
     let mut endorers_slots_keys_for_order: HashMap<String, String> = HashMap::new();
@@ -397,8 +480,8 @@ fn complete_endorsing_rights_for_level(
         }
 
         endorsing_rights.push(EndorsingRight::new(
-            display_level.try_into()?,
-            SignaturePublicKeyHash::from_b58_hash(&delegate_contract_id)?,
+            display_level,
+            SignaturePublicKeyHash::from_b58_hash(delegate_contract_id)?,
             delegate_data.slots().clone(),
             estimated_time,
         ))
@@ -416,28 +499,29 @@ fn complete_endorsing_rights_for_level(
 #[inline]
 fn get_endorsers_slots(
     constants: &RightsConstants,
-    context_data: &RightsContextData,
-    level: i64,
+    cycle_meta_data: &CycleData,
+    rolls_map: &HashMap<i32, String>,
+    cycle_position: i32,
 ) -> Result<HashMap<String, EndorserSlots>, anyhow::Error> {
     // special byte string used in Tezos PRNG
     const ENDORSEMENT_USE_STRING: &[u8] = b"level endorsement:";
     // prepare helper variable
     let mut endorsers_slots: HashMap<String, EndorserSlots> = HashMap::new();
 
-    for endorser_slot in (0..*constants.endorsers_per_block() as u8).rev() {
+    for endorser_slot in (0..*constants.endorsers_per_block()).rev() {
         // generate PRNG per endorsement slot and take delegates by roll number from context_rolls
         // if roll number is not found then reroll with new state till roll nuber is found in context_rolls
         let mut state = init_prng(
-            &context_data,
-            &constants,
+            cycle_meta_data,
+            constants,
             ENDORSEMENT_USE_STRING,
-            level.try_into()?,
+            cycle_position,
             endorser_slot.try_into()?,
         )?;
         loop {
-            let (random_num, sequence) = get_prng_number(state, *context_data.last_roll())?;
+            let (random_num, sequence) = get_prng_number(state, *cycle_meta_data.last_roll())?;
 
-            if let Some(delegate) = context_data.rolls().get(&random_num) {
+            if let Some(delegate) = rolls_map.get(&random_num) {
                 // collect all slots for each delegate
                 let endorsers_slots_entry = endorsers_slots
                     .entry(delegate.clone())

--- a/rpc/src/services/protocol/proto_005_2/votes_services.rs
+++ b/rpc/src/services/protocol/proto_005_2/votes_services.rs
@@ -20,7 +20,7 @@ pub fn get_votes_listings(
     // filter out the listings data
     let listings_data = if let Some(val) = env
         .tezedge_context()
-        .get_key_values_by_prefix(&context_hash, context_key_owned!("data/votes/listings"))?
+        .get_key_values_by_prefix(context_hash, context_key_owned!("data/votes/listings"))?
     {
         val
     } else {

--- a/rpc/src/services/protocol/proto_006/helpers.rs
+++ b/rpc/src/services/protocol/proto_006/helpers.rs
@@ -50,14 +50,15 @@ impl RightsConstants {
     pub(crate) fn parse_rights_constants(
         context_proto_param: &ContextProtocolParam,
     ) -> Result<Self, anyhow::Error> {
-        let protocol_constants: ProtocolConstants = serde_json::from_str(&context_proto_param.constants_data)?;
+        let protocol_constants: ProtocolConstants =
+            serde_json::from_str(&context_proto_param.constants_data)?;
 
         Ok(Self {
             blocks_per_cycle: protocol_constants.blocks_per_cycle,
             preserved_cycles: protocol_constants.preserved_cycles,
             nonce_length: protocol_constants.nonce_length,
             time_between_blocks: protocol_constants.time_between_blocks,
-            endorsers_per_block: protocol_constants.endorsers_per_block ,
+            endorsers_per_block: protocol_constants.endorsers_per_block,
         })
     }
 }
@@ -68,11 +69,7 @@ pub(crate) fn get_cycle_data(
     cycle_meta_storage: &CycleMetaStorage,
 ) -> Result<CycleData, anyhow::Error> {
     // prepare cycle for which rollers are selected
-    let requested_cycle = if let Some(cycle) = *parameters.requested_cycle() {
-        cycle
-    } else {
-        block_cycle
-    };
+    let requested_cycle = parameters.requested_cycle().unwrap_or(block_cycle);
 
     if let Some(cycle_meta_data) = cycle_meta_storage.get(&requested_cycle)? {
         Ok(cycle_meta_data)
@@ -381,9 +378,6 @@ pub fn init_prng(
     let state = cycle_meta_data.seed_bytes();
     let zero_bytes: Vec<u8> = vec![0; nonce_size];
 
-    // the position of the block in its cycle; has to be i32
-    // let cycle_position: i32 = level_position(level, blocks_per_cycle)?;
-
     // take the state (initially the random seed), zero bytes, the use string and the blocks position in the cycle as bytes, merge them together and hash the result
     let rd = blake2b::digest_256(&merge_slices!(
         state,
@@ -456,7 +450,6 @@ impl RightsMetadata {
         requested_level: i32,
     ) -> Result<Self, RightsConstantError> {
         Ok(Self {
-            // (cycle_from_level(requested_level, blocks_per_cycle)?, level_position(requested_level, blocks_per_cycle)?)
             block_cycle: cycle_from_level(requested_level, blocks_per_cycle)?,
             block_cycle_position: level_position(requested_level, blocks_per_cycle)?,
         })

--- a/rpc/src/services/protocol/proto_006/helpers.rs
+++ b/rpc/src/services/protocol/proto_006/helpers.rs
@@ -23,6 +23,8 @@ use crate::services::protocol::{
     parse_block_metadata_level, ContextProtocolParam, MetadataParsingError,
 };
 
+use super::ProtocolConstants;
+
 /// Context constants used in baking and endorsing rights
 #[derive(Debug, Clone, Getters)]
 pub struct RightsConstants {
@@ -42,10 +44,6 @@ pub struct RightsConstants {
 pub enum RightsConstantError {
     #[error("The value is illegal, key: {key}")]
     WrongValue { key: &'static str },
-    #[error("Key cannot be parsed, key: {key}")]
-    Parsing { key: &'static str },
-    #[error("Key cannot be found in constants, key: {key}")]
-    KeyNotFound { key: &'static str },
 }
 
 impl RightsConstants {
@@ -58,80 +56,14 @@ impl RightsConstants {
     pub(crate) fn parse_rights_constants(
         context_proto_param: &ContextProtocolParam,
     ) -> Result<Self, anyhow::Error> {
-        if let Some(constatns_deserialized) =
-            serde_json::from_str::<serde_json::Value>(&context_proto_param.constants_data)?
-                .as_object()
-        {
-            let blocks_per_cycle = get_constant_i64(constatns_deserialized, "blocks_per_cycle")?;
-            let preserved_cycles = get_constant_i64(constatns_deserialized, "preserved_cycles")?;
-            let nonce_length = get_constant_i64(constatns_deserialized, "nonce_length")?;
-            let time_between_blocks = get_time_between_blocks(constatns_deserialized)?;
-            let endorsers_per_block =
-                get_constant_i64(constatns_deserialized, "endorsers_per_block")?;
+        let protocol_constants: ProtocolConstants = serde_json::from_str(&context_proto_param.constants_data)?;
 
-            Ok(Self {
-                blocks_per_cycle: blocks_per_cycle as i32,
-                preserved_cycles: preserved_cycles as u8,
-                nonce_length: nonce_length as u8,
-                time_between_blocks,
-                endorsers_per_block: endorsers_per_block as u16,
-            })
-        } else {
-            bail!("Constants not an object")
-        }
-    }
-}
-
-fn get_constant_i64(
-    constants: &serde_json::Map<String, serde_json::Value>,
-    key: &'static str,
-) -> Result<i64, RightsConstantError> {
-    if let Some(value) = constants.get(key) {
-        if let Some(i64_value) = value.as_i64() {
-            Ok(i64_value)
-        } else {
-            if let Some(str_num) = value.as_str() {
-                return str_num
-                    .parse()
-                    .map_err(|_| RightsConstantError::Parsing { key });
-            }
-            Err(RightsConstantError::Parsing { key })
-        }
-    } else {
-        Err(RightsConstantError::KeyNotFound { key })
-    }
-}
-
-fn get_time_between_blocks(
-    constants: &serde_json::Map<String, serde_json::Value>,
-) -> Result<Vec<i64>, RightsConstantError> {
-    let mut ret: Vec<i64> = Vec::new();
-    if let Some(value) = constants.get("time_between_blocks") {
-        if let Some(array) = value.as_array() {
-            for e in array {
-                if let Some(str_element) = e.as_str() {
-                    let parsed =
-                        str_element
-                            .parse::<i64>()
-                            .map_err(|_| RightsConstantError::Parsing {
-                                key: "time_between_blocks",
-                            })?;
-                    ret.push(parsed);
-                } else {
-                    return Err(RightsConstantError::Parsing {
-                        key: "time_between_blocks",
-                    });
-                }
-            }
-            Ok(ret)
-        } else {
-            Err(RightsConstantError::Parsing {
-                key: "time_between_blocks",
-            })
-        }
-    } else {
-        Err(RightsConstantError::KeyNotFound {
-            key: "time_between_blocks",
+        Ok(Self {
+            blocks_per_cycle: protocol_constants.blocks_per_cycle,
+            preserved_cycles: protocol_constants.preserved_cycles,
+            nonce_length: protocol_constants.nonce_length,
+            time_between_blocks: protocol_constants.time_between_blocks,
+            endorsers_per_block: protocol_constants.endorsers_per_block ,
         })
     }
 }

--- a/rpc/src/services/protocol/proto_006/helpers.rs
+++ b/rpc/src/services/protocol/proto_006/helpers.rs
@@ -1,26 +1,27 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::sync::Arc;
 
-use anyhow::{bail, format_err};
+use crypto::hash::ChainId;
+use anyhow::bail;
 use getset::Getters;
-use tezos_context::context_key_owned;
 use thiserror::Error;
 
-use crypto::hash::ContextHash;
 use crypto::{
     blake2b::{self, Blake2bError},
     crypto_box::PublicKeyError,
 };
-use storage::{num_from_slice, BlockHeaderWithHash};
-use tezos_messages::base::signature_public_key_hash::SignaturePublicKeyHash;
-use tezos_messages::p2p::binary_message::BinaryRead;
-use tezos_wrapper::TezedgeContextClient;
+use storage::cycle_storage::CycleData;
+use storage::{num_from_slice, BlockHeaderWithHash, CycleMetaStorage};
 
+use crate::helpers::{parse_block_hash, BlockMetadata};
 use crate::merge_slices;
-use crate::services::protocol::ContextProtocolParam;
+use crate::server::RpcServiceEnvironment;
+use crate::services::protocol::{
+    parse_block_metadata_level, ContextProtocolParam, MetadataParsingError,
+};
 
 /// Context constants used in baking and endorsing rights
 #[derive(Debug, Clone, Getters)]
@@ -34,31 +35,20 @@ pub struct RightsConstants {
     #[get = "pub(crate)"]
     time_between_blocks: Vec<i64>,
     #[get = "pub(crate)"]
-    blocks_per_roll_snapshot: i32,
-    #[get = "pub(crate)"]
     endorsers_per_block: u16,
 }
 
-impl RightsConstants {
-    /// simple constructor to create RightsConstants
-    pub fn new(
-        blocks_per_cycle: i32,
-        preserved_cycles: u8,
-        nonce_length: u8,
-        time_between_blocks: Vec<i64>,
-        blocks_per_roll_snapshot: i32,
-        endorsers_per_block: u16,
-    ) -> Self {
-        Self {
-            blocks_per_cycle,
-            preserved_cycles,
-            nonce_length,
-            time_between_blocks,
-            blocks_per_roll_snapshot,
-            endorsers_per_block,
-        }
-    }
+#[derive(Debug, Error)]
+pub enum RightsConstantError {
+    #[error("The value is illegal, key: {key}")]
+    WrongValue { key: &'static str },
+    #[error("Key cannot be parsed, key: {key}")]
+    Parsing { key: &'static str },
+    #[error("Key cannot be found in constants, key: {key}")]
+    KeyNotFound { key: &'static str },
+}
 
+impl RightsConstants {
     /// Get all context constants which are used in endorsing and baking rights generation
     ///
     /// # Arguments
@@ -68,165 +58,103 @@ impl RightsConstants {
     pub(crate) fn parse_rights_constants(
         context_proto_param: &ContextProtocolParam,
     ) -> Result<Self, anyhow::Error> {
-        let dynamic =
-            tezos_messages::protocol::proto_006::constants::ParametricConstants::from_bytes(
-                &context_proto_param.constants_data,
-            )?;
-        let fixed = tezos_messages::protocol::proto_006::constants::FIXED;
-
-        Ok(RightsConstants::new(
-            dynamic.blocks_per_cycle(),
-            dynamic.preserved_cycles(),
-            fixed.nonce_length(),
-            dynamic.time_between_blocks().clone(),
-            dynamic.blocks_per_roll_snapshot(),
-            dynamic.endorsers_per_block(),
-        ))
-    }
-}
-
-/// Data from context DB for completing baking and endorsing rights
-#[derive(Debug, Clone, Getters)]
-pub struct RightsContextData {
-    /// Random seed for Tezos PRNG
-    #[get = "pub(crate)"]
-    random_seed: Vec<u8>,
-
-    /// Number of last roll so Tezos PRNG will not overflow
-    #[get = "pub(crate)"]
-    last_roll: i32,
-
-    /// List of rolls mapped to rollers contract id
-    #[get = "pub(crate)"]
-    rolls: HashMap<i32, String>,
-}
-
-impl RightsContextData {
-    /// Simple constructor to create RightsContextData
-    pub fn new(random_seed: Vec<u8>, last_roll: i32, rolls: HashMap<i32, String>) -> Self {
-        Self {
-            random_seed,
-            last_roll,
-            rolls,
-        }
-    }
-
-    /// Get context data roll_snapshot, random_seed, last_roll and rolls from context list
-    ///
-    /// # Arguments
-    ///
-    /// * `parameters` - Parameters created by [RightsParams](RightsParams::parse_rights_parameters).
-    /// * `constants` - Context constants used in baking and endorsing rights.
-    /// * `list` - Context list handler.
-    ///
-    /// Return RightsContextData.
-    pub(crate) fn prepare_context_data_for_rights(
-        parameters: RightsParams,
-        constants: RightsConstants,
-        (ctx_hash, context): (&ContextHash, &TezedgeContextClient),
-    ) -> Result<Self, anyhow::Error> {
-        // prepare constants that are used
-        let blocks_per_cycle = *constants.blocks_per_cycle();
-
-        // prepare parameters that are used
-        let requested_level = *parameters.requested_level();
-
-        // prepare cycle for which rollers are selected
-        let requested_cycle = if let Some(cycle) = *parameters.requested_cycle() {
-            cycle
-        } else {
-            cycle_from_level(requested_level, blocks_per_cycle)?
-        };
-
-        // get index of roll snapshot
-        let roll_snapshot: i16 = {
-            if let Some(data) = context.get_key_from_history(
-                &ctx_hash,
-                context_key_owned!("data/cycle/{}/roll_snapshot", requested_cycle),
-            )? {
-                num_from_slice!(data, 0, i16)
-            } else {
-                // key not found - prepare error for later processing
-                return Err(format_err!("roll_snapshot"));
-            }
-        };
-
-        let random_seed = {
-            if let Some(data) = context.get_key_from_history(
-                &ctx_hash,
-                context_key_owned!("data/cycle/{}/random_seed", requested_cycle),
-            )? {
-                data
-            } else {
-                // key not found - prepare error for later processing
-                return Err(format_err!("random_seed"));
-            }
-        };
-
-        // Snapshots of last_roll are listed from 0 same as roll_snapshot.
-        let last_roll = {
-            if let Some(data) = context.get_key_from_history(
-                &ctx_hash,
-                context_key_owned!("data/cycle/{}/last_roll/{}", requested_cycle, roll_snapshot),
-            )? {
-                num_from_slice!(data, 0, i32)
-            } else {
-                // key not found - prepare error for later processing
-                return Err(format_err!("last_roll"));
-            }
-        };
-
-        // get list of rolls from context list
-        let context_rolls = if let Some(rolls) =
-            Self::get_context_rolls((&ctx_hash, &context), requested_cycle, roll_snapshot)?
+        if let Some(constatns_deserialized) =
+            serde_json::from_str::<serde_json::Value>(&context_proto_param.constants_data)?
+                .as_object()
         {
-            rolls
-        } else {
-            return Err(format_err!("rolls"));
-        };
+            let blocks_per_cycle = get_constant_i64(constatns_deserialized, "blocks_per_cycle")?;
+            let preserved_cycles = get_constant_i64(constatns_deserialized, "preserved_cycles")?;
+            let nonce_length = get_constant_i64(constatns_deserialized, "nonce_length")?;
+            let time_between_blocks = get_time_between_blocks(constatns_deserialized)?;
+            let endorsers_per_block =
+                get_constant_i64(constatns_deserialized, "endorsers_per_block")?;
 
-        Ok(Self::new(random_seed.to_vec(), last_roll, context_rolls))
+            Ok(Self {
+                blocks_per_cycle: blocks_per_cycle as i32,
+                preserved_cycles: preserved_cycles as u8,
+                nonce_length: nonce_length as u8,
+                time_between_blocks,
+                endorsers_per_block: endorsers_per_block as u16,
+            })
+        } else {
+            bail!("Constants not an object")
+        }
     }
+}
 
-    /// get list of rollers from context list selected by snapshot level
-    ///
-    /// # Arguments
-    ///
-    /// * `context` - context list HashMap from [get_context_as_hashmap](RightsContextData::get_context_as_hashmap)
-    ///
-    /// Return rollers for [RightsContextData.rolls](RightsContextData.rolls)
-    fn get_context_rolls(
-        (ctx_hash, context): (&ContextHash, &TezedgeContextClient),
-        cycle: i64,
-        snapshot: i16,
-    ) -> Result<Option<HashMap<i32, String>>, anyhow::Error> {
-        let rolls = if let Some(val) = context.get_key_values_by_prefix(
-            &ctx_hash,
-            context_key_owned!("data/rolls/owner/snapshot/{}/{}", cycle, snapshot),
-        )? {
-            val
+fn get_constant_i64(
+    constants: &serde_json::Map<String, serde_json::Value>,
+    key: &'static str,
+) -> Result<i64, RightsConstantError> {
+    if let Some(value) = constants.get(key) {
+        if let Some(i64_value) = value.as_i64() {
+            Ok(i64_value)
         } else {
-            bail!("No rolls found in context")
-        };
-
-        let mut roll_owners: HashMap<i32, String> = HashMap::new();
-
-        // iterate through all the owners,the roll_num is the last component of the key, decode the value (it is a public key) to get the public key hash address (tz1...)
-        for (key, value) in rolls.into_iter() {
-            if key.last().is_none() {
-                continue;
+            if let Some(str_num) = value.as_str() {
+                return str_num
+                    .parse()
+                    .map_err(|_| RightsConstantError::Parsing { key });
             }
-            let roll_num = key.last().unwrap();
+            Err(RightsConstantError::Parsing { key })
+        }
+    } else {
+        Err(RightsConstantError::KeyNotFound { key })
+    }
+}
 
-            // the values are public keys
-            let delegate = SignaturePublicKeyHash::from_tagged_bytes(value.clone())?
-                .to_string_representation();
-            roll_owners.insert(roll_num.parse()?, delegate);
+fn get_time_between_blocks(
+    constants: &serde_json::Map<String, serde_json::Value>,
+) -> Result<Vec<i64>, RightsConstantError> {
+    let mut ret: Vec<i64> = Vec::new();
+    if let Some(value) = constants.get("time_between_blocks") {
+        if let Some(array) = value.as_array() {
+            for e in array {
+                if let Some(str_element) = e.as_str() {
+                    let parsed =
+                        str_element
+                            .parse::<i64>()
+                            .map_err(|_| RightsConstantError::Parsing {
+                                key: "time_between_blocks",
+                            })?;
+                    ret.push(parsed);
+                } else {
+                    return Err(RightsConstantError::Parsing {
+                        key: "time_between_blocks",
+                    });
+                }
+            }
+            Ok(ret)
+        } else {
+            Err(RightsConstantError::Parsing {
+                key: "time_between_blocks",
+            })
         }
-        if roll_owners.is_empty() {
-            bail!("No rolls assigned, all rolls happened to be DELETED")
-        }
-        Ok(Some(roll_owners))
+    } else {
+        Err(RightsConstantError::KeyNotFound {
+            key: "time_between_blocks",
+        })
+    }
+}
+
+pub(crate) fn get_cycle_data(
+    parameters: RightsParams,
+    block_cycle: i32,
+    cycle_meta_storage: &CycleMetaStorage,
+) -> Result<CycleData, anyhow::Error> {
+    // prepare cycle for which rollers are selected
+    let requested_cycle = if let Some(cycle) = *parameters.requested_cycle() {
+        cycle
+    } else {
+        block_cycle
+    };
+
+    if let Some(cycle_meta_data) = cycle_meta_storage.get(&requested_cycle)? {
+        Ok(cycle_meta_data)
+    } else {
+        bail!(
+            "No cycle data found for requested_cycle: {}",
+            requested_cycle
+        )
     }
 }
 
@@ -235,7 +163,7 @@ impl RightsContextData {
 pub struct RightsParams {
     /// Level (height) of block. Parsed from url path parameter 'block_id'.
     #[get = "pub(crate)"]
-    block_level: i64,
+    block_level: i32,
 
     /// Header timestamp of block. Parsed from url path parameter 'block_id'.
     #[get = "pub(crate)"]
@@ -247,41 +175,46 @@ pub struct RightsParams {
 
     /// Cycle for whitch all rights will be listed. Url query parameter 'cycle'.
     #[get = "pub(crate)"]
-    requested_cycle: Option<i64>,
+    requested_cycle: Option<i32>,
 
     /// Level (height) of block for whitch all rights will be listed. Url query parameter 'level'.
     #[get = "pub(crate)"]
-    requested_level: i64,
+    requested_level: i32,
 
     /// Level to be displayed in output.
     #[get = "pub(crate)"]
-    display_level: i64,
+    display_level: i32,
 
     /// Level for estimated_time computation. Endorsing rights only.
     #[get = "pub(crate)"]
-    timestamp_level: i64,
+    timestamp_level: i32,
 
     /// Max priority to which baking rights are listed. Url query parameter 'max_priority'.
     #[get = "pub(crate)"]
-    max_priority: i64,
+    max_priority: i32,
 
     /// Indicate that baking rights for maximum priority should be listed. Url query parameter 'all'.
     #[get = "pub(crate)"]
     has_all: bool,
+
+    #[get = "pub(crate)"]
+    rights_metadata: RightsMetadata,
 }
 
 impl RightsParams {
     /// Simple constructor to create RightsParams
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
-        block_level: i64,
+        block_level: i32,
         block_timestamp: i64,
         requested_delegate: Option<String>,
-        requested_cycle: Option<i64>,
-        requested_level: i64,
-        display_level: i64,
-        timestamp_level: i64,
-        max_priority: i64,
+        requested_cycle: Option<i32>,
+        requested_level: i32,
+        display_level: i32,
+        timestamp_level: i32,
+        max_priority: i32,
         has_all: bool,
+        rights_metadata: RightsMetadata,
     ) -> Self {
         Self {
             block_level,
@@ -293,6 +226,7 @@ impl RightsParams {
             timestamp_level,
             max_priority,
             has_all,
+            rights_metadata,
         }
     }
 
@@ -312,7 +246,8 @@ impl RightsParams {
     /// * `is_baking_rights` - flag to identify if are parsed baking or endorsing rights
     ///
     /// Return RightsParams
-    pub(crate) fn parse_rights_parameters(
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn parse_rights_parameters(
         param_level: Option<&str>,
         param_delegate: Option<&str>,
         param_cycle: Option<&str>,
@@ -320,30 +255,25 @@ impl RightsParams {
         param_has_all: bool,
         rights_constants: &RightsConstants,
         block_header: &BlockHeaderWithHash,
+        chain_id: &ChainId,
+        env: &RpcServiceEnvironment,
         is_baking_rights: bool,
     ) -> Result<Self, anyhow::Error> {
-        let block_level: i64 = block_header.header.level().into();
+        let block_level = block_header.header.level();
         let preserved_cycles = *rights_constants.preserved_cycles();
         let blocks_per_cycle = *rights_constants.blocks_per_cycle();
 
         // this is the cycle of block_id level
-        let current_cycle = cycle_from_level(block_level, blocks_per_cycle)?;
 
         // display_level is here because of corner case where all levels < 1 are computed as level 1 but oputputed as they are
-        let mut display_level: i64 = block_level;
+        let mut display_level: i32 = block_level;
         // endorsing rights only: timestamp_level is the base level for timestamp computation is taken from last known block (block_id) timestamp + time_between_blocks[0]
-        let mut timestamp_level: i64 = block_level;
+        let mut timestamp_level: i32 = block_level;
         // Check the param_level, if there is a level specified validate it, if no set it to the block_level
         // requested_level is used to get data from context list
-        let requested_level: i64 = match param_level {
+        let requested_level: i32 = match param_level {
             Some(level) => {
                 let level = level.parse()?;
-                // check the bounds for the requested level (if it is in the previous/next preserved cycles)
-                Self::validate_cycle(
-                    cycle_from_level(level, blocks_per_cycle)?,
-                    current_cycle,
-                    preserved_cycles,
-                )?;
                 // display level is always same as level requested
                 display_level = level;
                 // endorsing rights: to compute timestamp for level parameter there need to be taken timestamp of previous block
@@ -368,11 +298,37 @@ impl RightsParams {
             }
         };
 
+        let block_metadata = match crate::services::base_services::get_block_metadata(
+            chain_id,
+            &parse_block_hash(chain_id, &requested_level.to_string(), env)?,
+            env,
+        )
+        .await
+        {
+            Ok(metadata) => Some(metadata),
+            Err(_) => None,
+        };
+
+        let rights_metadata = if let Some(metadata) = block_metadata {
+            RightsMetadata::extract_from_block_metadata(metadata)?
+        } else if param_level.is_some() {
+            RightsMetadata::calculate(blocks_per_cycle, requested_level)?
+        } else {
+            // this should never happen. When block_metadata is not available it means we requested a future level (thus level is always Some())
+            bail!("No level parameter in url")
+        };
+
+        Self::validate_cycle(
+            cycle_from_level(requested_level, blocks_per_cycle)?,
+            rights_metadata.block_cycle,
+            preserved_cycles,
+        )?;
+
         // validate requested cycle
         let requested_cycle = match param_cycle {
             Some(val) => Some(Self::validate_cycle(
                 val.parse()?,
-                current_cycle,
+                rights_metadata.block_cycle,
                 preserved_cycles,
             )?),
             None => None,
@@ -394,6 +350,7 @@ impl RightsParams {
             timestamp_level, // endorsing rights only
             max_priority,
             param_has_all,
+            rights_metadata,
         ))
     }
 
@@ -409,7 +366,7 @@ impl RightsParams {
     pub fn get_estimated_time(
         &self,
         constants: &RightsConstants,
-        level: Option<i64>,
+        level: Option<i32>,
     ) -> Option<i64> {
         // if is cycle then level is provided as parameter else use prepared timestamp_level
         let timestamp_level = level.unwrap_or(self.timestamp_level);
@@ -428,13 +385,17 @@ impl RightsParams {
     /// Validate if cycle requested as url query parameter (cycle or level) is available in context list by checking preserved_cycles constant
     #[inline]
     fn validate_cycle(
-        requested_cycle: i64,
-        current_cycle: i64,
+        requested_cycle: i32,
+        current_cycle: i32,
         preserved_cycles: u8,
-    ) -> Result<i64, anyhow::Error> {
-        if (requested_cycle - current_cycle).abs() <= (preserved_cycles as i64) {
+    ) -> Result<i32, anyhow::Error> {
+        if (requested_cycle - current_cycle).abs() <= preserved_cycles.into() {
             Ok(requested_cycle)
         } else {
+            // TODO: proper json response is needed for this
+            // Octez is:
+            //    [{ "kind": "permanent", "id": "proto.008-PtEdo2Zk.seed.unknown_seed",
+            //        "oldest": 330, "requested": 200, "latest": 340 }]
             bail!("Requested cycle out of bounds") //TODO: prepare cycle error
         }
     }
@@ -461,47 +422,6 @@ impl EndorserSlots {
     /// Push endorsing slot to slots
     pub fn push_to_slot(&mut self, slot: u16) {
         self.slots.push(slot);
-    }
-}
-
-/// Return cycle in which is given level
-///
-/// # Arguments
-///
-/// * `level` - level to specify cycle for
-/// * `blocks_per_cycle` - context constant
-///
-/// Level 0 (genesis block) is not part of any cycle (cycle 0 starts at level 1),
-/// hence the blocks_per_cycle - 1 for last cycle block.
-pub fn cycle_from_level(level: i64, blocks_per_cycle: i32) -> Result<i64, anyhow::Error> {
-    // check if blocks_per_cycle is not 0 to prevent panic
-    if blocks_per_cycle > 0 {
-        Ok((level - 1) / (blocks_per_cycle as i64))
-    } else {
-        bail!("wrong value blocks_per_cycle={}", blocks_per_cycle)
-    }
-}
-
-/// Return the position of the block in its cycle
-///
-/// # Arguments
-///
-/// * `level` - level to specify cycle for
-/// * `blocks_per_cycle` - context constant
-///
-/// Level 0 (genesis block) is not part of any cycle (cycle 0 starts at level 1),
-/// hence the blocks_per_cycle - 1 for last cycle block.
-pub fn level_position(level: i32, blocks_per_cycle: i32) -> Result<i32, anyhow::Error> {
-    // check if blocks_per_cycle is not 0 to prevent panic
-    if blocks_per_cycle <= 0 {
-        bail!("wrong value blocks_per_cycle={}", blocks_per_cycle);
-    }
-    let cycle_position = (level % blocks_per_cycle) - 1;
-    if cycle_position < 0 {
-        //for last block
-        Ok(blocks_per_cycle - 1)
-    } else {
-        Ok(cycle_position)
     }
 }
 
@@ -543,24 +463,23 @@ pub type TezosPRNGResult = Result<(i32, RandomSeedState), TezosPRNGError>;
 /// Return first random sequence state to use in [get_prng_number](`get_prng_number`)
 #[inline]
 pub fn init_prng(
-    cycle_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
     constants: &RightsConstants,
     use_string_bytes: &[u8],
-    level: i32,
+    cycle_position: i32,
     offset: i32,
 ) -> Result<RandomSeedState, anyhow::Error> {
     // a safe way to convert betwwen types is to use try_from
     let nonce_size = usize::try_from(*constants.nonce_length())?;
-    let blocks_per_cycle = *constants.blocks_per_cycle();
-    let state = cycle_data.random_seed();
+    let state = cycle_meta_data.seed_bytes();
     let zero_bytes: Vec<u8> = vec![0; nonce_size];
 
     // the position of the block in its cycle; has to be i32
-    let cycle_position: i32 = level_position(level, blocks_per_cycle)?;
+    // let cycle_position: i32 = level_position(level, blocks_per_cycle)?;
 
     // take the state (initially the random seed), zero bytes, the use string and the blocks position in the cycle as bytes, merge them together and hash the result
     let rd = blake2b::digest_256(&merge_slices!(
-        &state,
+        state,
         &zero_bytes,
         use_string_bytes,
         &cycle_position.to_be_bytes()
@@ -613,4 +532,89 @@ pub fn get_prng_number(state: RandomSeedState, bound: i32) -> TezosPRNGResult {
         };
     }
     Ok((v, sequence))
+}
+
+#[derive(Debug, Clone, Getters)]
+pub struct RightsMetadata {
+    #[get = "pub(crate)"]
+    block_cycle: i32,
+
+    #[get = "pub(crate)"]
+    block_cycle_position: i32,
+}
+
+impl RightsMetadata {
+    pub fn extract_from_block_metadata(
+        block_metadata: Arc<BlockMetadata>,
+    ) -> Result<Self, MetadataParsingError> {
+        let (block_cycle, block_cycle_position) =
+            match parse_block_metadata_level(&block_metadata, "level_info") {
+                Ok(cycle_data) => cycle_data,
+                Err(MetadataParsingError::KeyNotFoundError { key: _ }) => {
+                    // No level info found, trying the older scheme
+                    parse_block_metadata_level(&block_metadata, "level")?
+                }
+                Err(e) => return Err(e),
+            };
+        Ok(Self {
+            block_cycle,
+            block_cycle_position,
+        })
+    }
+
+    pub fn calculate(
+        blocks_per_cycle: i32,
+        requested_level: i32,
+    ) -> Result<Self, RightsConstantError> {
+        Ok(Self {
+            // (cycle_from_level(requested_level, blocks_per_cycle)?, level_position(requested_level, blocks_per_cycle)?)
+            block_cycle: cycle_from_level(requested_level, blocks_per_cycle)?,
+            block_cycle_position: level_position(requested_level, blocks_per_cycle)?,
+        })
+    }
+}
+
+/// Return cycle in which is given level
+///
+/// # Arguments
+///
+/// * `level` - level to specify cycle for
+/// * `blocks_per_cycle` - context constant
+///
+/// Level 0 (genesis block) is not part of any cycle (cycle 0 starts at level 1),
+/// hence the blocks_per_cycle - 1 for last cycle block.
+pub fn cycle_from_level(level: i32, blocks_per_cycle: i32) -> Result<i32, RightsConstantError> {
+    // check if blocks_per_cycle is not 0 to prevent panic
+    if blocks_per_cycle > 0 {
+        Ok((level - 1) / blocks_per_cycle)
+    } else {
+        Err(RightsConstantError::WrongValue {
+            key: "blocks_per_cycle",
+        })
+    }
+}
+
+/// Return the position of the block in its cycle
+///
+/// # Arguments
+///
+/// * `level` - level to specify cycle for
+/// * `blocks_per_cycle` - context constant
+///
+/// Level 0 (genesis block) is not part of any cycle (cycle 0 starts at level 1),
+/// hence the blocks_per_cycle - 1 for last cycle block.
+pub fn level_position(level: i32, blocks_per_cycle: i32) -> Result<i32, RightsConstantError> {
+    // check if blocks_per_cycle is not 0 to prevent panic
+    if blocks_per_cycle <= 0 {
+        return Err(RightsConstantError::WrongValue {
+            key: "blocks_per_cycle",
+        });
+    }
+    let cycle_position = (level % blocks_per_cycle) - 1;
+    if cycle_position < 0 {
+        //for last block
+        Ok(blocks_per_cycle - 1)
+    } else {
+        Ok(cycle_position)
+    }
 }

--- a/rpc/src/services/protocol/proto_006/mod.rs
+++ b/rpc/src/services/protocol/proto_006/mod.rs
@@ -1,6 +1,81 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
+use serde::Deserialize;
+use getset::CopyGetters;
+use num::BigInt;
+
 mod helpers;
 pub(crate) mod rights_service;
 pub(crate) mod votes_services;
+
+use super::{vec_string_to_int, string_to_int};
+
+#[derive(Debug, Deserialize, Clone, CopyGetters)]
+pub(crate) struct ProtocolConstants {
+    proof_of_work_nonce_size: u8,
+    nonce_length: u8,
+    max_revelations_per_block: u8,
+    max_operation_data_length: i32,
+    max_proposals_per_delegate: u8,
+    preserved_cycles: u8,
+    
+    #[get_copy = "pub(crate)"]
+    blocks_per_cycle: i32,
+    
+    blocks_per_commitment: i32,
+    blocks_per_roll_snapshot: i32,
+    blocks_per_voting_period: i32,
+
+    #[serde(with = "vec_string_to_int")]
+    time_between_blocks: Vec<i64>,
+    
+    endorsers_per_block: u16,
+
+    #[serde(with = "string_to_int")]
+    hard_gas_limit_per_operation: BigInt,
+
+    #[serde(with = "string_to_int")]
+    hard_gas_limit_per_block: BigInt,
+
+    #[serde(with = "string_to_int")]
+    proof_of_work_threshold: BigInt,
+
+    #[serde(with = "string_to_int")]
+    tokens_per_roll: BigInt,
+    michelson_maximum_type_size: u16,
+
+    #[serde(with = "string_to_int")]
+    seed_nonce_revelation_tip: BigInt,
+
+    origination_size: i32,
+
+    #[serde(with = "string_to_int")]
+    block_security_deposit: BigInt,
+
+    #[serde(with = "string_to_int")]
+    endorsement_security_deposit: BigInt,
+
+    #[serde(with = "vec_string_to_int")]
+    baking_reward_per_endorsement: Vec<BigInt>,
+
+    #[serde(with = "vec_string_to_int")]
+    endorsement_reward: Vec<BigInt>,
+
+    #[serde(with = "string_to_int")]
+    cost_per_byte: BigInt,
+
+    #[serde(with = "string_to_int")]
+    hard_storage_limit_per_operation: BigInt,
+
+    quorum_min: i32,
+    quorum_max: i32,
+    min_proposal_quorum: i32,
+    initial_endorsers: u16,
+
+    #[serde(with = "string_to_int")]
+    delay_per_missing_endorsement: i64,
+
+    #[serde(with = "string_to_int")]
+    test_chain_duration: i64,
+}

--- a/rpc/src/services/protocol/proto_006/mod.rs
+++ b/rpc/src/services/protocol/proto_006/mod.rs
@@ -1,15 +1,15 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use serde::Deserialize;
 use getset::CopyGetters;
 use num::BigInt;
+use serde::Deserialize;
 
 mod helpers;
 pub(crate) mod rights_service;
 pub(crate) mod votes_services;
 
-use super::{vec_string_to_int, string_to_int};
+use super::{string_to_int, vec_string_to_int};
 
 #[derive(Debug, Deserialize, Clone, CopyGetters)]
 pub(crate) struct ProtocolConstants {
@@ -19,17 +19,17 @@ pub(crate) struct ProtocolConstants {
     max_operation_data_length: i32,
     max_proposals_per_delegate: u8,
     preserved_cycles: u8,
-    
+
     #[get_copy = "pub(crate)"]
     blocks_per_cycle: i32,
-    
+
     blocks_per_commitment: i32,
     blocks_per_roll_snapshot: i32,
     blocks_per_voting_period: i32,
 
     #[serde(with = "vec_string_to_int")]
     time_between_blocks: Vec<i64>,
-    
+
     endorsers_per_block: u16,
 
     #[serde(with = "string_to_int")]

--- a/rpc/src/services/protocol/proto_006/rights_service.rs
+++ b/rpc/src/services/protocol/proto_006/rights_service.rs
@@ -1,27 +1,44 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
+// TODO: (anagy) - check TODO's
+// TODO: refactor errors so this will be removed
+// Enum defining possible response structures for RPC calls
+// there is reason to have this structure because of format of error responses from ocaml node:
+// [{"kind":"permanent","id":"proto.005-PsBabyM1.context.storage_error","missing_key":["cycle","4","random_seed"],"function":"get"}]
+// [{"kind":"permanent","id":"proto.005-PsBabyM1.seed.unknown_seed","oldest":9,"requested":20,"latest":15}]
+// if there have to be same response format then RpcErrorMsg is covering it
+// this enum can be removed if errors are generated from error context directly in result_to_json_response function
+
 use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;
 
 use anyhow::format_err;
 use itertools::Itertools;
 
-use crate::services::dev_services::contract_id_to_contract_address_for_index;
+use crypto::hash::ChainId;
 use tezos_messages::base::rpc_support::{RpcJsonMap, ToRpcJsonMap};
 use tezos_messages::base::signature_public_key_hash::SignaturePublicKeyHash;
 use tezos_messages::protocol::proto_006::rights::{BakingRights, EndorsingRight};
-use tezos_wrapper::TezedgeContextClient;
 
+use storage::cycle_storage::CycleData;
+use storage::CycleMetaStorage;
+
+use crate::server::RpcServiceEnvironment;
+use crate::services::dev_services::contract_id_to_contract_address_for_index;
 use crate::services::protocol::proto_006::helpers::{
-    get_prng_number, init_prng, EndorserSlots, RightsConstants, RightsContextData, RightsParams,
+    get_cycle_data, get_prng_number, init_prng, level_position, EndorserSlots, RightsConstants,
+    RightsParams,
 };
 use crate::services::protocol::ContextProtocolParam;
+
+use super::helpers::RightsMetadata;
 
 /// Return generated baking rights.
 ///
 /// # Arguments
 ///
+/// * `block_id` - Url path parameter 'block_id', it contains string "head", block level or block hash.
 /// * `level` - Url query parameter 'level'.
 /// * `delegate` - Url query parameter 'delegate'.
 /// * `cycle` - Url query parameter 'cycle'.
@@ -32,14 +49,17 @@ use crate::services::protocol::ContextProtocolParam;
 /// * `state` - Current RPC collected state (head).
 ///
 /// Prepare all data to generate baking rights and then use Tezos PRNG to generate them.
-pub(crate) fn check_and_get_baking_rights(
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn check_and_get_baking_rights(
     context_proto_params: ContextProtocolParam,
     level: Option<&str>,
     delegate: Option<&str>,
     cycle: Option<&str>,
     max_priority: Option<&str>,
     has_all: bool,
-    context: &TezedgeContextClient,
+    cycle_meta_storage: &CycleMetaStorage,
+    chain_id: &ChainId,
+    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -52,16 +72,24 @@ pub(crate) fn check_and_get_baking_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
+        chain_id,
+        env,
         true,
-    )?;
+    )
+    .await?;
 
-    let context_data: RightsContextData = RightsContextData::prepare_context_data_for_rights(
+    let cycle_meta_data = get_cycle_data(
         params.clone(),
-        constants.clone(),
-        (&context_proto_params.block_header.header.context(), context),
+        *params.rights_metadata().block_cycle(),
+        cycle_meta_storage,
     )?;
 
-    get_baking_rights(&context_data, &params, &constants)
+    get_baking_rights(
+        &cycle_meta_data,
+        &params,
+        &constants,
+        params.rights_metadata(),
+    )
 }
 
 /// Use prepared data to generate baking rights
@@ -73,9 +101,10 @@ pub(crate) fn check_and_get_baking_rights(
 /// * `constants` - Context constants used in baking and endorsing rights [RightsConstants](RightsConstants::parse_rights_constants).
 #[inline]
 pub(crate) fn get_baking_rights(
-    context_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
     parameters: &RightsParams,
     constants: &RightsConstants,
+    rights_metadata: &RightsMetadata,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let mut baking_rights = Vec::<BakingRights>::new();
 
@@ -84,22 +113,48 @@ pub(crate) fn get_baking_rights(
 
     let timestamp = parameters.block_timestamp();
     let block_level = parameters.block_level();
+    let cycle_position = *rights_metadata.block_cycle_position();
+
+    // build a reverse map of rols so we have access in O(1)
+    // let rolls_map: HashMap<i32, String> = HashMap::new();
+    let rolls_map: HashMap<i32, String> = cycle_meta_data
+        .rolls_data()
+        .iter()
+        .map(|(delegate, rolls)| {
+            rolls
+                .iter()
+                .map(|roll| {
+                    (
+                        *roll,
+                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
+                            .unwrap()
+                            .to_string_representation(),
+                    )
+                })
+                .collect::<HashMap<i32, String>>()
+        })
+        .flatten()
+        .collect();
 
     // iterate through the whole cycle if necessery
     if let Some(cycle) = parameters.requested_cycle() {
-        let first_block_level = cycle * (blocks_per_cycle as i64) + 1;
-        let last_block_level = first_block_level + (blocks_per_cycle as i64);
+        let first_block_level: i32 = cycle * blocks_per_cycle + 1;
+        let last_block_level = first_block_level + blocks_per_cycle;
 
         for level in first_block_level..last_block_level {
-            let seconds_to_add = (level - block_level).abs() * time_between_blocks[0];
+            let block_level_diff: i64 = (level - block_level).abs().into();
+            let seconds_to_add: i64 = block_level_diff * time_between_blocks[0];
             let estimated_timestamp = timestamp + seconds_to_add;
+            let cycle_position = level_position(level, blocks_per_cycle)?;
 
             // assign rolls goes here
             baking_rights_assign_rolls(
-                &parameters,
-                &constants,
-                &context_data,
-                level.try_into()?,
+                parameters,
+                constants,
+                cycle_meta_data,
+                &rolls_map,
+                level,
+                cycle_position,
                 estimated_timestamp,
                 true,
                 &mut baking_rights,
@@ -109,14 +164,17 @@ pub(crate) fn get_baking_rights(
         }
     } else {
         let level = *parameters.requested_level();
-        let seconds_to_add = (level - block_level).abs() * time_between_blocks[0];
+        let block_level_diff: i64 = (level - block_level).abs().into();
+        let seconds_to_add: i64 = block_level_diff * time_between_blocks[0];
         let estimated_timestamp = timestamp + seconds_to_add;
         // assign rolls goes here
         baking_rights_assign_rolls(
-            &parameters,
-            &constants,
-            &context_data,
-            level.try_into()?,
+            parameters,
+            constants,
+            cycle_meta_data,
+            &rolls_map,
+            level,
+            cycle_position,
             estimated_timestamp,
             false,
             &mut baking_rights,
@@ -155,11 +213,14 @@ pub(crate) fn get_baking_rights(
 ///
 /// Baking priorities are are assigned to Roles, the default behavior is to include only the top priority for the delegate
 #[inline]
+#[allow(clippy::too_many_arguments)]
 fn baking_rights_assign_rolls(
     parameters: &RightsParams,
     constants: &RightsConstants,
-    context_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
+    rolls_map: &HashMap<i32, String>,
     level: i32,
+    cycle_position: i32,
     estimated_head_timestamp: i64,
     is_cycle: bool,
     baking_rights: &mut Vec<BakingRights>,
@@ -174,20 +235,19 @@ fn baking_rights_assign_rolls(
     let max_priority = *parameters.max_priority();
     let has_all = parameters.has_all();
     let block_level = *parameters.block_level();
-    let last_roll = *context_data.last_roll();
-    let rolls_map = context_data.rolls();
-    let display_level: i32 = (*parameters.display_level()).try_into()?;
+    let last_roll = *cycle_meta_data.last_roll();
+    let display_level: i32 = *parameters.display_level();
 
     for priority in 0..max_priority + 1 {
         // draw the rolls for the requested parameters
         let delegate_to_assign;
         // TODO: priority can overflow in the ocaml code, do a priority % i32::max_value()
         let mut state = init_prng(
-            &context_data,
-            &constants,
+            cycle_meta_data,
+            constants,
             BAKING_USE_STRING,
-            level,
-            priority.try_into()?,
+            cycle_position,
+            priority,
         )?;
 
         loop {
@@ -207,7 +267,7 @@ fn baking_rights_assign_rolls(
         }
 
         // we omit the estimated_time field if the block on the requested level is already baked
-        let priority_timestamp = if block_level < (level as i64) {
+        let priority_timestamp = if block_level < level {
             let time = if time_between_blocks.len() == 1 {
                 time_between_blocks[0]
             } else {
@@ -223,7 +283,7 @@ fn baking_rights_assign_rolls(
 
         baking_rights.push(BakingRights::new(
             rights_level,
-            SignaturePublicKeyHash::from_b58_hash(&delegate_to_assign)?,
+            SignaturePublicKeyHash::from_b58_hash(delegate_to_assign)?,
             priority as u16,
             priority_timestamp,
         ));
@@ -236,6 +296,7 @@ fn baking_rights_assign_rolls(
 ///
 /// # Arguments
 ///
+/// * `block_id` - Url path parameter 'block_id', it contains string "head", block level or block hash.
 /// * `level` - Url query parameter 'level'.
 /// * `delegate` - Url query parameter 'delegate'.
 /// * `cycle` - Url query parameter 'cycle'.
@@ -245,13 +306,16 @@ fn baking_rights_assign_rolls(
 /// * `state` - Current RPC collected state (head).
 ///
 /// Prepare all data to generate endorsing rights and then use Tezos PRNG to generate them.
-pub(crate) fn check_and_get_endorsing_rights(
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn check_and_get_endorsing_rights(
     context_proto_params: ContextProtocolParam,
     level: Option<&str>,
     delegate: Option<&str>,
     cycle: Option<&str>,
     has_all: bool,
-    context: &TezedgeContextClient,
+    cycle_meta_storage: &CycleMetaStorage,
+    chain_id: &ChainId,
+    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -264,16 +328,19 @@ pub(crate) fn check_and_get_endorsing_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
+        chain_id,
+        env,
         false,
-    )?;
+    )
+    .await?;
 
-    let context_data: RightsContextData = RightsContextData::prepare_context_data_for_rights(
+    let cycle_meta_data = get_cycle_data(
         params.clone(),
-        constants.clone(),
-        (&context_proto_params.block_header.header.context(), context),
+        *params.rights_metadata().block_cycle(),
+        cycle_meta_storage,
     )?;
 
-    get_endorsing_rights(&context_data, &params, &constants)
+    get_endorsing_rights(&cycle_meta_data, &params, &constants)
 }
 
 /// Use prepared data to generate endosring rights
@@ -284,31 +351,52 @@ pub(crate) fn check_and_get_endorsing_rights(
 /// * `parameters` - Parameters created by [RightsParams](RightsParams::parse_rights_parameters).
 /// * `constants` - Context constants used in baking and endorsing rights [RightsConstants](RightsConstants::parse_rights_constants).
 fn get_endorsing_rights(
-    context_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
     parameters: &RightsParams,
     constants: &RightsConstants,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     // define helper and output variables
     let mut endorsing_rights = Vec::<EndorsingRight>::new();
 
+    let rolls_map: HashMap<i32, String> = cycle_meta_data
+        .rolls_data()
+        .iter()
+        .map(|(delegate, rolls)| {
+            rolls
+                .iter()
+                .map(|roll| {
+                    (
+                        *roll,
+                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
+                            .unwrap()
+                            .to_string_representation(),
+                    )
+                })
+                .collect::<HashMap<i32, String>>()
+        })
+        .flatten()
+        .collect();
+
     // when query param cycle is specified then iterate over all cycle levels, else only given level
     if let Some(cycle) = parameters.requested_cycle() {
         let blocks_per_cycle = *constants.blocks_per_cycle();
-        let first_cycle_level = cycle * (blocks_per_cycle as i64) + 1;
-        let last_cycle_level = first_cycle_level + (blocks_per_cycle as i64);
+        let first_cycle_level = cycle * blocks_per_cycle + 1;
+        let last_cycle_level = first_cycle_level + blocks_per_cycle;
         for level in first_cycle_level..last_cycle_level {
             // get estimated time first because is equal for all endorsers in given level
             // the base level for estimated time computation is level of previous block
             let estimated_time: Option<i64> =
                 parameters.get_estimated_time(constants, Some(level - 1));
+            let cycle_position = level_position(level, blocks_per_cycle)?;
 
             complete_endorsing_rights_for_level(
-                context_data,
+                cycle_meta_data,
                 parameters,
                 constants,
-                level,
+                &rolls_map,
                 level,
                 estimated_time,
+                cycle_position,
                 &mut endorsing_rights,
             )?;
             // endorsing_rights = merge_slices!(&endorsing_rights, &level_endorsing_rights);
@@ -318,12 +406,13 @@ fn get_endorsing_rights(
         let estimated_time: Option<i64> = parameters.get_estimated_time(constants, None);
 
         complete_endorsing_rights_for_level(
-            context_data,
+            cycle_meta_data,
             parameters,
             constants,
-            *parameters.requested_level(),
+            &rolls_map,
             *parameters.display_level(),
             estimated_time,
+            *parameters.rights_metadata().block_cycle_position(),
             &mut endorsing_rights,
         )?;
     };
@@ -347,17 +436,20 @@ fn get_endorsing_rights(
 /// * `display_level` - Level to be displayed in output.
 /// * `estimated_time` - Estimated time of endorsement, is set to None if in past relative to block_id.
 #[inline]
+#[allow(clippy::too_many_arguments)]
 fn complete_endorsing_rights_for_level(
-    context_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
     parameters: &RightsParams,
     constants: &RightsConstants,
-    level: i64,
-    display_level: i64,
+    rolls_map: &HashMap<i32, String>,
+    display_level: i32,
     estimated_time: Option<i64>,
+    cycle_position: i32,
     endorsing_rights: &mut Vec<EndorsingRight>,
 ) -> Result<(), anyhow::Error> {
     // endorsers_slots is needed to group all slots by delegate
-    let endorsers_slots = get_endorsers_slots(constants, context_data, level)?;
+    let endorsers_slots =
+        get_endorsers_slots(constants, cycle_meta_data, rolls_map, cycle_position)?;
 
     // convert contract id to hash contract address hex byte string (needed for ordering)
     let mut endorers_slots_keys_for_order: HashMap<String, String> = HashMap::new();
@@ -388,8 +480,8 @@ fn complete_endorsing_rights_for_level(
         }
 
         endorsing_rights.push(EndorsingRight::new(
-            display_level.try_into()?,
-            SignaturePublicKeyHash::from_b58_hash(&delegate_contract_id)?,
+            display_level,
+            SignaturePublicKeyHash::from_b58_hash(delegate_contract_id)?,
             delegate_data.slots().clone(),
             estimated_time,
         ))
@@ -407,28 +499,29 @@ fn complete_endorsing_rights_for_level(
 #[inline]
 fn get_endorsers_slots(
     constants: &RightsConstants,
-    context_data: &RightsContextData,
-    level: i64,
+    cycle_meta_data: &CycleData,
+    rolls_map: &HashMap<i32, String>,
+    cycle_position: i32,
 ) -> Result<HashMap<String, EndorserSlots>, anyhow::Error> {
     // special byte string used in Tezos PRNG
     const ENDORSEMENT_USE_STRING: &[u8] = b"level endorsement:";
     // prepare helper variable
     let mut endorsers_slots: HashMap<String, EndorserSlots> = HashMap::new();
 
-    for endorser_slot in (0..*constants.endorsers_per_block() as u8).rev() {
+    for endorser_slot in (0..*constants.endorsers_per_block()).rev() {
         // generate PRNG per endorsement slot and take delegates by roll number from context_rolls
         // if roll number is not found then reroll with new state till roll nuber is found in context_rolls
         let mut state = init_prng(
-            &context_data,
-            &constants,
+            cycle_meta_data,
+            constants,
             ENDORSEMENT_USE_STRING,
-            level.try_into()?,
+            cycle_position,
             endorser_slot.try_into()?,
         )?;
         loop {
-            let (random_num, sequence) = get_prng_number(state, *context_data.last_roll())?;
+            let (random_num, sequence) = get_prng_number(state, *cycle_meta_data.last_roll())?;
 
-            if let Some(delegate) = context_data.rolls().get(&random_num) {
+            if let Some(delegate) = rolls_map.get(&random_num) {
                 // collect all slots for each delegate
                 let endorsers_slots_entry = endorsers_slots
                     .entry(delegate.clone())

--- a/rpc/src/services/protocol/proto_006/rights_service.rs
+++ b/rpc/src/services/protocol/proto_006/rights_service.rs
@@ -16,7 +16,6 @@ use std::convert::TryInto;
 use anyhow::format_err;
 use itertools::Itertools;
 
-use crypto::hash::ChainId;
 use tezos_messages::base::rpc_support::{RpcJsonMap, ToRpcJsonMap};
 use tezos_messages::base::signature_public_key_hash::SignaturePublicKeyHash;
 use tezos_messages::protocol::proto_006::rights::{BakingRights, EndorsingRight};
@@ -24,7 +23,6 @@ use tezos_messages::protocol::proto_006::rights::{BakingRights, EndorsingRight};
 use storage::cycle_storage::CycleData;
 use storage::CycleMetaStorage;
 
-use crate::server::RpcServiceEnvironment;
 use crate::services::dev_services::contract_id_to_contract_address_for_index;
 use crate::services::protocol::proto_006::helpers::{
     get_cycle_data, get_prng_number, init_prng, level_position, EndorserSlots, RightsConstants,
@@ -58,8 +56,6 @@ pub(crate) async fn check_and_get_baking_rights(
     max_priority: Option<&str>,
     has_all: bool,
     cycle_meta_storage: &CycleMetaStorage,
-    chain_id: &ChainId,
-    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -72,8 +68,6 @@ pub(crate) async fn check_and_get_baking_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
-        chain_id,
-        env,
         true,
     )
     .await?;
@@ -314,8 +308,6 @@ pub(crate) async fn check_and_get_endorsing_rights(
     cycle: Option<&str>,
     has_all: bool,
     cycle_meta_storage: &CycleMetaStorage,
-    chain_id: &ChainId,
-    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -328,8 +320,6 @@ pub(crate) async fn check_and_get_endorsing_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
-        chain_id,
-        env,
         false,
     )
     .await?;

--- a/rpc/src/services/protocol/proto_006/rights_service.rs
+++ b/rpc/src/services/protocol/proto_006/rights_service.rs
@@ -110,25 +110,17 @@ pub(crate) fn get_baking_rights(
     let cycle_position = *rights_metadata.block_cycle_position();
 
     // build a reverse map of rols so we have access in O(1)
-    // let rolls_map: HashMap<i32, String> = HashMap::new();
-    let rolls_map: HashMap<i32, String> = cycle_meta_data
-        .rolls_data()
-        .iter()
-        .map(|(delegate, rolls)| {
-            rolls
-                .iter()
-                .map(|roll| {
-                    (
-                        *roll,
-                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
-                            .unwrap()
-                            .to_string_representation(),
-                    )
-                })
-                .collect::<HashMap<i32, String>>()
-        })
-        .flatten()
-        .collect();
+    let mut rolls_map: HashMap<i32, String> = HashMap::new();
+
+    for (delegate, rolls) in cycle_meta_data.rolls_data() {
+        for roll in rolls {
+            rolls_map.insert(
+                *roll,
+                SignaturePublicKeyHash::from_tagged_bytes(delegate.to_vec())?
+                    .to_string_representation(),
+            );
+        }
+    }
 
     // iterate through the whole cycle if necessery
     if let Some(cycle) = parameters.requested_cycle() {
@@ -348,24 +340,18 @@ fn get_endorsing_rights(
     // define helper and output variables
     let mut endorsing_rights = Vec::<EndorsingRight>::new();
 
-    let rolls_map: HashMap<i32, String> = cycle_meta_data
-        .rolls_data()
-        .iter()
-        .map(|(delegate, rolls)| {
-            rolls
-                .iter()
-                .map(|roll| {
-                    (
-                        *roll,
-                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
-                            .unwrap()
-                            .to_string_representation(),
-                    )
-                })
-                .collect::<HashMap<i32, String>>()
-        })
-        .flatten()
-        .collect();
+    // build a reverse map of rols so we have access in O(1)
+    let mut rolls_map: HashMap<i32, String> = HashMap::new();
+
+    for (delegate, rolls) in cycle_meta_data.rolls_data() {
+        for roll in rolls {
+            rolls_map.insert(
+                *roll,
+                SignaturePublicKeyHash::from_tagged_bytes(delegate.to_vec())?
+                    .to_string_representation(),
+            );
+        }
+    }
 
     // when query param cycle is specified then iterate over all cycle levels, else only given level
     if let Some(cycle) = parameters.requested_cycle() {

--- a/rpc/src/services/protocol/proto_007/helpers.rs
+++ b/rpc/src/services/protocol/proto_007/helpers.rs
@@ -50,14 +50,15 @@ impl RightsConstants {
     pub(crate) fn parse_rights_constants(
         context_proto_param: &ContextProtocolParam,
     ) -> Result<Self, anyhow::Error> {
-        let protocol_constants: ProtocolConstants = serde_json::from_str(&context_proto_param.constants_data)?;
+        let protocol_constants: ProtocolConstants =
+            serde_json::from_str(&context_proto_param.constants_data)?;
 
         Ok(Self {
             blocks_per_cycle: protocol_constants.blocks_per_cycle,
             preserved_cycles: protocol_constants.preserved_cycles,
             nonce_length: protocol_constants.nonce_length,
             time_between_blocks: protocol_constants.time_between_blocks,
-            endorsers_per_block: protocol_constants.endorsers_per_block ,
+            endorsers_per_block: protocol_constants.endorsers_per_block,
         })
     }
 }
@@ -68,11 +69,7 @@ pub(crate) fn get_cycle_data(
     cycle_meta_storage: &CycleMetaStorage,
 ) -> Result<CycleData, anyhow::Error> {
     // prepare cycle for which rollers are selected
-    let requested_cycle = if let Some(cycle) = *parameters.requested_cycle() {
-        cycle
-    } else {
-        block_cycle
-    };
+    let requested_cycle = parameters.requested_cycle().unwrap_or(block_cycle);
 
     if let Some(cycle_meta_data) = cycle_meta_storage.get(&requested_cycle)? {
         Ok(cycle_meta_data)
@@ -381,9 +378,6 @@ pub fn init_prng(
     let state = cycle_meta_data.seed_bytes();
     let zero_bytes: Vec<u8> = vec![0; nonce_size];
 
-    // the position of the block in its cycle; has to be i32
-    // let cycle_position: i32 = level_position(level, blocks_per_cycle)?;
-
     // take the state (initially the random seed), zero bytes, the use string and the blocks position in the cycle as bytes, merge them together and hash the result
     let rd = blake2b::digest_256(&merge_slices!(
         state,
@@ -456,7 +450,6 @@ impl RightsMetadata {
         requested_level: i32,
     ) -> Result<Self, RightsConstantError> {
         Ok(Self {
-            // (cycle_from_level(requested_level, blocks_per_cycle)?, level_position(requested_level, blocks_per_cycle)?)
             block_cycle: cycle_from_level(requested_level, blocks_per_cycle)?,
             block_cycle_position: level_position(requested_level, blocks_per_cycle)?,
         })

--- a/rpc/src/services/protocol/proto_007/helpers.rs
+++ b/rpc/src/services/protocol/proto_007/helpers.rs
@@ -1,26 +1,27 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::sync::Arc;
 
-use anyhow::{bail, format_err};
+use crypto::hash::ChainId;
+use anyhow::bail;
 use getset::Getters;
-use tezos_context::context_key_owned;
 use thiserror::Error;
 
-use crypto::hash::ContextHash;
 use crypto::{
     blake2b::{self, Blake2bError},
     crypto_box::PublicKeyError,
 };
-use storage::{num_from_slice, BlockHeaderWithHash};
-use tezos_messages::base::signature_public_key_hash::SignaturePublicKeyHash;
-use tezos_messages::p2p::binary_message::BinaryRead;
-use tezos_wrapper::TezedgeContextClient;
+use storage::cycle_storage::CycleData;
+use storage::{num_from_slice, BlockHeaderWithHash, CycleMetaStorage};
 
+use crate::helpers::{parse_block_hash, BlockMetadata};
 use crate::merge_slices;
-use crate::services::protocol::ContextProtocolParam;
+use crate::server::RpcServiceEnvironment;
+use crate::services::protocol::{
+    parse_block_metadata_level, ContextProtocolParam, MetadataParsingError,
+};
 
 /// Context constants used in baking and endorsing rights
 #[derive(Debug, Clone, Getters)]
@@ -34,31 +35,20 @@ pub struct RightsConstants {
     #[get = "pub(crate)"]
     time_between_blocks: Vec<i64>,
     #[get = "pub(crate)"]
-    blocks_per_roll_snapshot: i32,
-    #[get = "pub(crate)"]
     endorsers_per_block: u16,
 }
 
-impl RightsConstants {
-    /// simple constructor to create RightsConstants
-    pub fn new(
-        blocks_per_cycle: i32,
-        preserved_cycles: u8,
-        nonce_length: u8,
-        time_between_blocks: Vec<i64>,
-        blocks_per_roll_snapshot: i32,
-        endorsers_per_block: u16,
-    ) -> Self {
-        Self {
-            blocks_per_cycle,
-            preserved_cycles,
-            nonce_length,
-            time_between_blocks,
-            blocks_per_roll_snapshot,
-            endorsers_per_block,
-        }
-    }
+#[derive(Debug, Error)]
+pub enum RightsConstantError {
+    #[error("The value is illegal, key: {key}")]
+    WrongValue { key: &'static str },
+    #[error("Key cannot be parsed, key: {key}")]
+    Parsing { key: &'static str },
+    #[error("Key cannot be found in constants, key: {key}")]
+    KeyNotFound { key: &'static str },
+}
 
+impl RightsConstants {
     /// Get all context constants which are used in endorsing and baking rights generation
     ///
     /// # Arguments
@@ -68,165 +58,103 @@ impl RightsConstants {
     pub(crate) fn parse_rights_constants(
         context_proto_param: &ContextProtocolParam,
     ) -> Result<Self, anyhow::Error> {
-        let dynamic =
-            tezos_messages::protocol::proto_007::constants::ParametricConstants::from_bytes(
-                &context_proto_param.constants_data,
-            )?;
-        let fixed = tezos_messages::protocol::proto_007::constants::FIXED;
-
-        Ok(RightsConstants::new(
-            dynamic.blocks_per_cycle(),
-            dynamic.preserved_cycles(),
-            fixed.nonce_length(),
-            dynamic.time_between_blocks().clone(),
-            dynamic.blocks_per_roll_snapshot(),
-            dynamic.endorsers_per_block(),
-        ))
-    }
-}
-
-/// Data from context DB for completing baking and endorsing rights
-#[derive(Debug, Clone, Getters)]
-pub struct RightsContextData {
-    /// Random seed for Tezos PRNG
-    #[get = "pub(crate)"]
-    random_seed: Vec<u8>,
-
-    /// Number of last roll so Tezos PRNG will not overflow
-    #[get = "pub(crate)"]
-    last_roll: i32,
-
-    /// List of rolls mapped to rollers contract id
-    #[get = "pub(crate)"]
-    rolls: HashMap<i32, String>,
-}
-
-impl RightsContextData {
-    /// Simple constructor to create RightsContextData
-    pub fn new(random_seed: Vec<u8>, last_roll: i32, rolls: HashMap<i32, String>) -> Self {
-        Self {
-            random_seed,
-            last_roll,
-            rolls,
-        }
-    }
-
-    /// Get context data roll_snapshot, random_seed, last_roll and rolls from context list
-    ///
-    /// # Arguments
-    ///
-    /// * `parameters` - Parameters created by [RightsParams](RightsParams::parse_rights_parameters).
-    /// * `constants` - Context constants used in baking and endorsing rights.
-    /// * `list` - Context list handler.
-    ///
-    /// Return RightsContextData.
-    pub(crate) fn prepare_context_data_for_rights(
-        parameters: RightsParams,
-        constants: RightsConstants,
-        (ctx_hash, context): (&ContextHash, &TezedgeContextClient),
-    ) -> Result<Self, anyhow::Error> {
-        // prepare constants that are used
-        let blocks_per_cycle = *constants.blocks_per_cycle();
-
-        // prepare parameters that are used
-        let requested_level = *parameters.requested_level();
-
-        // prepare cycle for which rollers are selected
-        let requested_cycle = if let Some(cycle) = *parameters.requested_cycle() {
-            cycle
-        } else {
-            cycle_from_level(requested_level, blocks_per_cycle)?
-        };
-
-        // get index of roll snapshot
-        let roll_snapshot: i16 = {
-            if let Some(data) = context.get_key_from_history(
-                &ctx_hash,
-                context_key_owned!("data/cycle/{}/roll_snapshot", requested_cycle),
-            )? {
-                num_from_slice!(data, 0, i16)
-            } else {
-                // key not found - prepare error for later processing
-                return Err(format_err!("roll_snapshot"));
-            }
-        };
-
-        let random_seed = {
-            if let Some(data) = context.get_key_from_history(
-                &ctx_hash,
-                context_key_owned!("data/cycle/{}/random_seed", requested_cycle),
-            )? {
-                data
-            } else {
-                // key not found - prepare error for later processing
-                return Err(format_err!("random_seed"));
-            }
-        };
-
-        // Snapshots of last_roll are listed from 0 same as roll_snapshot.
-        let last_roll = {
-            if let Some(data) = context.get_key_from_history(
-                &ctx_hash,
-                context_key_owned!("data/cycle/{}/last_roll/{}", requested_cycle, roll_snapshot),
-            )? {
-                num_from_slice!(data, 0, i32)
-            } else {
-                // key not found - prepare error for later processing
-                return Err(format_err!("last_roll"));
-            }
-        };
-
-        // get list of rolls from context list
-        let context_rolls = if let Some(rolls) =
-            Self::get_context_rolls((&ctx_hash, &context), requested_cycle, roll_snapshot)?
+        if let Some(constatns_deserialized) =
+            serde_json::from_str::<serde_json::Value>(&context_proto_param.constants_data)?
+                .as_object()
         {
-            rolls
-        } else {
-            return Err(format_err!("rolls"));
-        };
+            let blocks_per_cycle = get_constant_i64(constatns_deserialized, "blocks_per_cycle")?;
+            let preserved_cycles = get_constant_i64(constatns_deserialized, "preserved_cycles")?;
+            let nonce_length = get_constant_i64(constatns_deserialized, "nonce_length")?;
+            let time_between_blocks = get_time_between_blocks(constatns_deserialized)?;
+            let endorsers_per_block =
+                get_constant_i64(constatns_deserialized, "endorsers_per_block")?;
 
-        Ok(Self::new(random_seed.to_vec(), last_roll, context_rolls))
+            Ok(Self {
+                blocks_per_cycle: blocks_per_cycle as i32,
+                preserved_cycles: preserved_cycles as u8,
+                nonce_length: nonce_length as u8,
+                time_between_blocks,
+                endorsers_per_block: endorsers_per_block as u16,
+            })
+        } else {
+            bail!("Constants not an object")
+        }
     }
+}
 
-    /// get list of rollers from context list selected by snapshot level
-    ///
-    /// # Arguments
-    ///
-    /// * `context` - context list HashMap from [get_context_as_hashmap](RightsContextData::get_context_as_hashmap)
-    ///
-    /// Return rollers for [RightsContextData.rolls](RightsContextData.rolls)
-    fn get_context_rolls(
-        (ctx_hash, context): (&ContextHash, &TezedgeContextClient),
-        cycle: i64,
-        snapshot: i16,
-    ) -> Result<Option<HashMap<i32, String>>, anyhow::Error> {
-        let rolls = if let Some(val) = context.get_key_values_by_prefix(
-            &ctx_hash,
-            context_key_owned!("data/rolls/owner/snapshot/{}/{}", cycle, snapshot),
-        )? {
-            val
+fn get_constant_i64(
+    constants: &serde_json::Map<String, serde_json::Value>,
+    key: &'static str,
+) -> Result<i64, RightsConstantError> {
+    if let Some(value) = constants.get(key) {
+        if let Some(i64_value) = value.as_i64() {
+            Ok(i64_value)
         } else {
-            bail!("No rolls found in context")
-        };
-
-        let mut roll_owners: HashMap<i32, String> = HashMap::new();
-
-        // iterate through all the owners,the roll_num is the last component of the key, decode the value (it is a public key) to get the public key hash address (tz1...)
-        for (key, value) in rolls.into_iter() {
-            if key.last().is_none() {
-                continue;
+            if let Some(str_num) = value.as_str() {
+                return str_num
+                    .parse()
+                    .map_err(|_| RightsConstantError::Parsing { key });
             }
-            let roll_num = key.last().unwrap();
+            Err(RightsConstantError::Parsing { key })
+        }
+    } else {
+        Err(RightsConstantError::KeyNotFound { key })
+    }
+}
 
-            // the values are public keys
-            let delegate = SignaturePublicKeyHash::from_tagged_bytes(value.clone())?
-                .to_string_representation();
-            roll_owners.insert(roll_num.parse()?, delegate);
+fn get_time_between_blocks(
+    constants: &serde_json::Map<String, serde_json::Value>,
+) -> Result<Vec<i64>, RightsConstantError> {
+    let mut ret: Vec<i64> = Vec::new();
+    if let Some(value) = constants.get("time_between_blocks") {
+        if let Some(array) = value.as_array() {
+            for e in array {
+                if let Some(str_element) = e.as_str() {
+                    let parsed =
+                        str_element
+                            .parse::<i64>()
+                            .map_err(|_| RightsConstantError::Parsing {
+                                key: "time_between_blocks",
+                            })?;
+                    ret.push(parsed);
+                } else {
+                    return Err(RightsConstantError::Parsing {
+                        key: "time_between_blocks",
+                    });
+                }
+            }
+            Ok(ret)
+        } else {
+            Err(RightsConstantError::Parsing {
+                key: "time_between_blocks",
+            })
         }
-        if roll_owners.is_empty() {
-            bail!("No rolls assigned, all rolls happened to be DELETED")
-        }
-        Ok(Some(roll_owners))
+    } else {
+        Err(RightsConstantError::KeyNotFound {
+            key: "time_between_blocks",
+        })
+    }
+}
+
+pub(crate) fn get_cycle_data(
+    parameters: RightsParams,
+    block_cycle: i32,
+    cycle_meta_storage: &CycleMetaStorage,
+) -> Result<CycleData, anyhow::Error> {
+    // prepare cycle for which rollers are selected
+    let requested_cycle = if let Some(cycle) = *parameters.requested_cycle() {
+        cycle
+    } else {
+        block_cycle
+    };
+
+    if let Some(cycle_meta_data) = cycle_meta_storage.get(&requested_cycle)? {
+        Ok(cycle_meta_data)
+    } else {
+        bail!(
+            "No cycle data found for requested_cycle: {}",
+            requested_cycle
+        )
     }
 }
 
@@ -235,7 +163,7 @@ impl RightsContextData {
 pub struct RightsParams {
     /// Level (height) of block. Parsed from url path parameter 'block_id'.
     #[get = "pub(crate)"]
-    block_level: i64,
+    block_level: i32,
 
     /// Header timestamp of block. Parsed from url path parameter 'block_id'.
     #[get = "pub(crate)"]
@@ -247,41 +175,46 @@ pub struct RightsParams {
 
     /// Cycle for whitch all rights will be listed. Url query parameter 'cycle'.
     #[get = "pub(crate)"]
-    requested_cycle: Option<i64>,
+    requested_cycle: Option<i32>,
 
     /// Level (height) of block for whitch all rights will be listed. Url query parameter 'level'.
     #[get = "pub(crate)"]
-    requested_level: i64,
+    requested_level: i32,
 
     /// Level to be displayed in output.
     #[get = "pub(crate)"]
-    display_level: i64,
+    display_level: i32,
 
     /// Level for estimated_time computation. Endorsing rights only.
     #[get = "pub(crate)"]
-    timestamp_level: i64,
+    timestamp_level: i32,
 
     /// Max priority to which baking rights are listed. Url query parameter 'max_priority'.
     #[get = "pub(crate)"]
-    max_priority: i64,
+    max_priority: i32,
 
     /// Indicate that baking rights for maximum priority should be listed. Url query parameter 'all'.
     #[get = "pub(crate)"]
     has_all: bool,
+
+    #[get = "pub(crate)"]
+    rights_metadata: RightsMetadata,
 }
 
 impl RightsParams {
     /// Simple constructor to create RightsParams
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
-        block_level: i64,
+        block_level: i32,
         block_timestamp: i64,
         requested_delegate: Option<String>,
-        requested_cycle: Option<i64>,
-        requested_level: i64,
-        display_level: i64,
-        timestamp_level: i64,
-        max_priority: i64,
+        requested_cycle: Option<i32>,
+        requested_level: i32,
+        display_level: i32,
+        timestamp_level: i32,
+        max_priority: i32,
         has_all: bool,
+        rights_metadata: RightsMetadata,
     ) -> Self {
         Self {
             block_level,
@@ -293,6 +226,7 @@ impl RightsParams {
             timestamp_level,
             max_priority,
             has_all,
+            rights_metadata,
         }
     }
 
@@ -312,7 +246,8 @@ impl RightsParams {
     /// * `is_baking_rights` - flag to identify if are parsed baking or endorsing rights
     ///
     /// Return RightsParams
-    pub(crate) fn parse_rights_parameters(
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn parse_rights_parameters(
         param_level: Option<&str>,
         param_delegate: Option<&str>,
         param_cycle: Option<&str>,
@@ -320,30 +255,25 @@ impl RightsParams {
         param_has_all: bool,
         rights_constants: &RightsConstants,
         block_header: &BlockHeaderWithHash,
+        chain_id: &ChainId,
+        env: &RpcServiceEnvironment,
         is_baking_rights: bool,
     ) -> Result<Self, anyhow::Error> {
-        let block_level: i64 = block_header.header.level().into();
+        let block_level = block_header.header.level();
         let preserved_cycles = *rights_constants.preserved_cycles();
         let blocks_per_cycle = *rights_constants.blocks_per_cycle();
 
         // this is the cycle of block_id level
-        let current_cycle = cycle_from_level(block_level, blocks_per_cycle)?;
 
         // display_level is here because of corner case where all levels < 1 are computed as level 1 but oputputed as they are
-        let mut display_level: i64 = block_level;
+        let mut display_level: i32 = block_level;
         // endorsing rights only: timestamp_level is the base level for timestamp computation is taken from last known block (block_id) timestamp + time_between_blocks[0]
-        let mut timestamp_level: i64 = block_level;
+        let mut timestamp_level: i32 = block_level;
         // Check the param_level, if there is a level specified validate it, if no set it to the block_level
         // requested_level is used to get data from context list
-        let requested_level: i64 = match param_level {
+        let requested_level: i32 = match param_level {
             Some(level) => {
                 let level = level.parse()?;
-                // check the bounds for the requested level (if it is in the previous/next preserved cycles)
-                Self::validate_cycle(
-                    cycle_from_level(level, blocks_per_cycle)?,
-                    current_cycle,
-                    preserved_cycles,
-                )?;
                 // display level is always same as level requested
                 display_level = level;
                 // endorsing rights: to compute timestamp for level parameter there need to be taken timestamp of previous block
@@ -368,11 +298,37 @@ impl RightsParams {
             }
         };
 
+        let block_metadata = match crate::services::base_services::get_block_metadata(
+            chain_id,
+            &parse_block_hash(chain_id, &requested_level.to_string(), env)?,
+            env,
+        )
+        .await
+        {
+            Ok(metadata) => Some(metadata),
+            Err(_) => None,
+        };
+
+        let rights_metadata = if let Some(metadata) = block_metadata {
+            RightsMetadata::extract_from_block_metadata(metadata)?
+        } else if param_level.is_some() {
+            RightsMetadata::calculate(blocks_per_cycle, requested_level)?
+        } else {
+            // this should never happen. When block_metadata is not available it means we requested a future level (thus level is always Some())
+            bail!("No level parameter in url")
+        };
+
+        Self::validate_cycle(
+            cycle_from_level(requested_level, blocks_per_cycle)?,
+            rights_metadata.block_cycle,
+            preserved_cycles,
+        )?;
+
         // validate requested cycle
         let requested_cycle = match param_cycle {
             Some(val) => Some(Self::validate_cycle(
                 val.parse()?,
-                current_cycle,
+                rights_metadata.block_cycle,
                 preserved_cycles,
             )?),
             None => None,
@@ -394,6 +350,7 @@ impl RightsParams {
             timestamp_level, // endorsing rights only
             max_priority,
             param_has_all,
+            rights_metadata,
         ))
     }
 
@@ -409,7 +366,7 @@ impl RightsParams {
     pub fn get_estimated_time(
         &self,
         constants: &RightsConstants,
-        level: Option<i64>,
+        level: Option<i32>,
     ) -> Option<i64> {
         // if is cycle then level is provided as parameter else use prepared timestamp_level
         let timestamp_level = level.unwrap_or(self.timestamp_level);
@@ -428,13 +385,17 @@ impl RightsParams {
     /// Validate if cycle requested as url query parameter (cycle or level) is available in context list by checking preserved_cycles constant
     #[inline]
     fn validate_cycle(
-        requested_cycle: i64,
-        current_cycle: i64,
+        requested_cycle: i32,
+        current_cycle: i32,
         preserved_cycles: u8,
-    ) -> Result<i64, anyhow::Error> {
-        if (requested_cycle - current_cycle).abs() <= (preserved_cycles as i64) {
+    ) -> Result<i32, anyhow::Error> {
+        if (requested_cycle - current_cycle).abs() <= preserved_cycles.into() {
             Ok(requested_cycle)
         } else {
+            // TODO: proper json response is needed for this
+            // Octez is:
+            //    [{ "kind": "permanent", "id": "proto.008-PtEdo2Zk.seed.unknown_seed",
+            //        "oldest": 330, "requested": 200, "latest": 340 }]
             bail!("Requested cycle out of bounds") //TODO: prepare cycle error
         }
     }
@@ -461,47 +422,6 @@ impl EndorserSlots {
     /// Push endorsing slot to slots
     pub fn push_to_slot(&mut self, slot: u16) {
         self.slots.push(slot);
-    }
-}
-
-/// Return cycle in which is given level
-///
-/// # Arguments
-///
-/// * `level` - level to specify cycle for
-/// * `blocks_per_cycle` - context constant
-///
-/// Level 0 (genesis block) is not part of any cycle (cycle 0 starts at level 1),
-/// hence the blocks_per_cycle - 1 for last cycle block.
-pub fn cycle_from_level(level: i64, blocks_per_cycle: i32) -> Result<i64, anyhow::Error> {
-    // check if blocks_per_cycle is not 0 to prevent panic
-    if blocks_per_cycle > 0 {
-        Ok((level - 1) / (blocks_per_cycle as i64))
-    } else {
-        bail!("wrong value blocks_per_cycle={}", blocks_per_cycle)
-    }
-}
-
-/// Return the position of the block in its cycle
-///
-/// # Arguments
-///
-/// * `level` - level to specify cycle for
-/// * `blocks_per_cycle` - context constant
-///
-/// Level 0 (genesis block) is not part of any cycle (cycle 0 starts at level 1),
-/// hence the blocks_per_cycle - 1 for last cycle block.
-pub fn level_position(level: i32, blocks_per_cycle: i32) -> Result<i32, anyhow::Error> {
-    // check if blocks_per_cycle is not 0 to prevent panic
-    if blocks_per_cycle <= 0 {
-        bail!("wrong value blocks_per_cycle={}", blocks_per_cycle);
-    }
-    let cycle_position = (level % blocks_per_cycle) - 1;
-    if cycle_position < 0 {
-        //for last block
-        Ok(blocks_per_cycle - 1)
-    } else {
-        Ok(cycle_position)
     }
 }
 
@@ -543,24 +463,23 @@ pub type TezosPRNGResult = Result<(i32, RandomSeedState), TezosPRNGError>;
 /// Return first random sequence state to use in [get_prng_number](`get_prng_number`)
 #[inline]
 pub fn init_prng(
-    cycle_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
     constants: &RightsConstants,
     use_string_bytes: &[u8],
-    level: i32,
+    cycle_position: i32,
     offset: i32,
 ) -> Result<RandomSeedState, anyhow::Error> {
     // a safe way to convert betwwen types is to use try_from
     let nonce_size = usize::try_from(*constants.nonce_length())?;
-    let blocks_per_cycle = *constants.blocks_per_cycle();
-    let state = cycle_data.random_seed();
+    let state = cycle_meta_data.seed_bytes();
     let zero_bytes: Vec<u8> = vec![0; nonce_size];
 
     // the position of the block in its cycle; has to be i32
-    let cycle_position: i32 = level_position(level, blocks_per_cycle)?;
+    // let cycle_position: i32 = level_position(level, blocks_per_cycle)?;
 
     // take the state (initially the random seed), zero bytes, the use string and the blocks position in the cycle as bytes, merge them together and hash the result
     let rd = blake2b::digest_256(&merge_slices!(
-        &state,
+        state,
         &zero_bytes,
         use_string_bytes,
         &cycle_position.to_be_bytes()
@@ -613,4 +532,89 @@ pub fn get_prng_number(state: RandomSeedState, bound: i32) -> TezosPRNGResult {
         };
     }
     Ok((v, sequence))
+}
+
+#[derive(Debug, Clone, Getters)]
+pub struct RightsMetadata {
+    #[get = "pub(crate)"]
+    block_cycle: i32,
+
+    #[get = "pub(crate)"]
+    block_cycle_position: i32,
+}
+
+impl RightsMetadata {
+    pub fn extract_from_block_metadata(
+        block_metadata: Arc<BlockMetadata>,
+    ) -> Result<Self, MetadataParsingError> {
+        let (block_cycle, block_cycle_position) =
+            match parse_block_metadata_level(&block_metadata, "level_info") {
+                Ok(cycle_data) => cycle_data,
+                Err(MetadataParsingError::KeyNotFoundError { key: _ }) => {
+                    // No level info found, trying the older scheme
+                    parse_block_metadata_level(&block_metadata, "level")?
+                }
+                Err(e) => return Err(e),
+            };
+        Ok(Self {
+            block_cycle,
+            block_cycle_position,
+        })
+    }
+
+    pub fn calculate(
+        blocks_per_cycle: i32,
+        requested_level: i32,
+    ) -> Result<Self, RightsConstantError> {
+        Ok(Self {
+            // (cycle_from_level(requested_level, blocks_per_cycle)?, level_position(requested_level, blocks_per_cycle)?)
+            block_cycle: cycle_from_level(requested_level, blocks_per_cycle)?,
+            block_cycle_position: level_position(requested_level, blocks_per_cycle)?,
+        })
+    }
+}
+
+/// Return cycle in which is given level
+///
+/// # Arguments
+///
+/// * `level` - level to specify cycle for
+/// * `blocks_per_cycle` - context constant
+///
+/// Level 0 (genesis block) is not part of any cycle (cycle 0 starts at level 1),
+/// hence the blocks_per_cycle - 1 for last cycle block.
+pub fn cycle_from_level(level: i32, blocks_per_cycle: i32) -> Result<i32, RightsConstantError> {
+    // check if blocks_per_cycle is not 0 to prevent panic
+    if blocks_per_cycle > 0 {
+        Ok((level - 1) / blocks_per_cycle)
+    } else {
+        Err(RightsConstantError::WrongValue {
+            key: "blocks_per_cycle",
+        })
+    }
+}
+
+/// Return the position of the block in its cycle
+///
+/// # Arguments
+///
+/// * `level` - level to specify cycle for
+/// * `blocks_per_cycle` - context constant
+///
+/// Level 0 (genesis block) is not part of any cycle (cycle 0 starts at level 1),
+/// hence the blocks_per_cycle - 1 for last cycle block.
+pub fn level_position(level: i32, blocks_per_cycle: i32) -> Result<i32, RightsConstantError> {
+    // check if blocks_per_cycle is not 0 to prevent panic
+    if blocks_per_cycle <= 0 {
+        return Err(RightsConstantError::WrongValue {
+            key: "blocks_per_cycle",
+        });
+    }
+    let cycle_position = (level % blocks_per_cycle) - 1;
+    if cycle_position < 0 {
+        //for last block
+        Ok(blocks_per_cycle - 1)
+    } else {
+        Ok(cycle_position)
+    }
 }

--- a/rpc/src/services/protocol/proto_007/helpers.rs
+++ b/rpc/src/services/protocol/proto_007/helpers.rs
@@ -23,6 +23,8 @@ use crate::services::protocol::{
     parse_block_metadata_level, ContextProtocolParam, MetadataParsingError,
 };
 
+use super::ProtocolConstants;
+
 /// Context constants used in baking and endorsing rights
 #[derive(Debug, Clone, Getters)]
 pub struct RightsConstants {
@@ -42,10 +44,6 @@ pub struct RightsConstants {
 pub enum RightsConstantError {
     #[error("The value is illegal, key: {key}")]
     WrongValue { key: &'static str },
-    #[error("Key cannot be parsed, key: {key}")]
-    Parsing { key: &'static str },
-    #[error("Key cannot be found in constants, key: {key}")]
-    KeyNotFound { key: &'static str },
 }
 
 impl RightsConstants {
@@ -58,80 +56,14 @@ impl RightsConstants {
     pub(crate) fn parse_rights_constants(
         context_proto_param: &ContextProtocolParam,
     ) -> Result<Self, anyhow::Error> {
-        if let Some(constatns_deserialized) =
-            serde_json::from_str::<serde_json::Value>(&context_proto_param.constants_data)?
-                .as_object()
-        {
-            let blocks_per_cycle = get_constant_i64(constatns_deserialized, "blocks_per_cycle")?;
-            let preserved_cycles = get_constant_i64(constatns_deserialized, "preserved_cycles")?;
-            let nonce_length = get_constant_i64(constatns_deserialized, "nonce_length")?;
-            let time_between_blocks = get_time_between_blocks(constatns_deserialized)?;
-            let endorsers_per_block =
-                get_constant_i64(constatns_deserialized, "endorsers_per_block")?;
+        let protocol_constants: ProtocolConstants = serde_json::from_str(&context_proto_param.constants_data)?;
 
-            Ok(Self {
-                blocks_per_cycle: blocks_per_cycle as i32,
-                preserved_cycles: preserved_cycles as u8,
-                nonce_length: nonce_length as u8,
-                time_between_blocks,
-                endorsers_per_block: endorsers_per_block as u16,
-            })
-        } else {
-            bail!("Constants not an object")
-        }
-    }
-}
-
-fn get_constant_i64(
-    constants: &serde_json::Map<String, serde_json::Value>,
-    key: &'static str,
-) -> Result<i64, RightsConstantError> {
-    if let Some(value) = constants.get(key) {
-        if let Some(i64_value) = value.as_i64() {
-            Ok(i64_value)
-        } else {
-            if let Some(str_num) = value.as_str() {
-                return str_num
-                    .parse()
-                    .map_err(|_| RightsConstantError::Parsing { key });
-            }
-            Err(RightsConstantError::Parsing { key })
-        }
-    } else {
-        Err(RightsConstantError::KeyNotFound { key })
-    }
-}
-
-fn get_time_between_blocks(
-    constants: &serde_json::Map<String, serde_json::Value>,
-) -> Result<Vec<i64>, RightsConstantError> {
-    let mut ret: Vec<i64> = Vec::new();
-    if let Some(value) = constants.get("time_between_blocks") {
-        if let Some(array) = value.as_array() {
-            for e in array {
-                if let Some(str_element) = e.as_str() {
-                    let parsed =
-                        str_element
-                            .parse::<i64>()
-                            .map_err(|_| RightsConstantError::Parsing {
-                                key: "time_between_blocks",
-                            })?;
-                    ret.push(parsed);
-                } else {
-                    return Err(RightsConstantError::Parsing {
-                        key: "time_between_blocks",
-                    });
-                }
-            }
-            Ok(ret)
-        } else {
-            Err(RightsConstantError::Parsing {
-                key: "time_between_blocks",
-            })
-        }
-    } else {
-        Err(RightsConstantError::KeyNotFound {
-            key: "time_between_blocks",
+        Ok(Self {
+            blocks_per_cycle: protocol_constants.blocks_per_cycle,
+            preserved_cycles: protocol_constants.preserved_cycles,
+            nonce_length: protocol_constants.nonce_length,
+            time_between_blocks: protocol_constants.time_between_blocks,
+            endorsers_per_block: protocol_constants.endorsers_per_block ,
         })
     }
 }

--- a/rpc/src/services/protocol/proto_007/mod.rs
+++ b/rpc/src/services/protocol/proto_007/mod.rs
@@ -1,15 +1,15 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use serde::Deserialize;
 use getset::CopyGetters;
 use num::BigInt;
+use serde::Deserialize;
 
 mod helpers;
 pub(crate) mod rights_service;
 pub(crate) mod votes_services;
 
-use super::{vec_string_to_int, string_to_int};
+use super::{string_to_int, vec_string_to_int};
 
 #[derive(Debug, Deserialize, Clone, CopyGetters)]
 pub(crate) struct ProtocolConstants {
@@ -22,14 +22,14 @@ pub(crate) struct ProtocolConstants {
 
     #[get_copy = "pub(crate)"]
     blocks_per_cycle: i32,
-    
+
     blocks_per_commitment: i32,
     blocks_per_roll_snapshot: i32,
     blocks_per_voting_period: i32,
 
     #[serde(with = "vec_string_to_int")]
     time_between_blocks: Vec<i64>,
-    
+
     endorsers_per_block: u16,
 
     #[serde(with = "string_to_int")]

--- a/rpc/src/services/protocol/proto_007/mod.rs
+++ b/rpc/src/services/protocol/proto_007/mod.rs
@@ -1,6 +1,81 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
+use serde::Deserialize;
+use getset::CopyGetters;
+use num::BigInt;
+
 mod helpers;
 pub(crate) mod rights_service;
 pub(crate) mod votes_services;
+
+use super::{vec_string_to_int, string_to_int};
+
+#[derive(Debug, Deserialize, Clone, CopyGetters)]
+pub(crate) struct ProtocolConstants {
+    proof_of_work_nonce_size: u8,
+    nonce_length: u8,
+    max_anon_ops_per_block: u8,
+    max_operation_data_length: i32,
+    max_proposals_per_delegate: u8,
+    preserved_cycles: u8,
+
+    #[get_copy = "pub(crate)"]
+    blocks_per_cycle: i32,
+    
+    blocks_per_commitment: i32,
+    blocks_per_roll_snapshot: i32,
+    blocks_per_voting_period: i32,
+
+    #[serde(with = "vec_string_to_int")]
+    time_between_blocks: Vec<i64>,
+    
+    endorsers_per_block: u16,
+
+    #[serde(with = "string_to_int")]
+    hard_gas_limit_per_operation: BigInt,
+
+    #[serde(with = "string_to_int")]
+    hard_gas_limit_per_block: BigInt,
+
+    #[serde(with = "string_to_int")]
+    proof_of_work_threshold: BigInt,
+
+    #[serde(with = "string_to_int")]
+    tokens_per_roll: BigInt,
+    michelson_maximum_type_size: u16,
+
+    #[serde(with = "string_to_int")]
+    seed_nonce_revelation_tip: BigInt,
+
+    origination_size: i32,
+
+    #[serde(with = "string_to_int")]
+    block_security_deposit: BigInt,
+
+    #[serde(with = "string_to_int")]
+    endorsement_security_deposit: BigInt,
+
+    #[serde(with = "vec_string_to_int")]
+    baking_reward_per_endorsement: Vec<BigInt>,
+
+    #[serde(with = "vec_string_to_int")]
+    endorsement_reward: Vec<BigInt>,
+
+    #[serde(with = "string_to_int")]
+    cost_per_byte: BigInt,
+
+    #[serde(with = "string_to_int")]
+    hard_storage_limit_per_operation: BigInt,
+
+    quorum_min: i32,
+    quorum_max: i32,
+    min_proposal_quorum: i32,
+    initial_endorsers: u16,
+
+    #[serde(with = "string_to_int")]
+    delay_per_missing_endorsement: i64,
+
+    #[serde(with = "string_to_int")]
+    test_chain_duration: i64,
+}

--- a/rpc/src/services/protocol/proto_007/rights_service.rs
+++ b/rpc/src/services/protocol/proto_007/rights_service.rs
@@ -110,25 +110,17 @@ pub(crate) fn get_baking_rights(
     let cycle_position = *rights_metadata.block_cycle_position();
 
     // build a reverse map of rols so we have access in O(1)
-    // let rolls_map: HashMap<i32, String> = HashMap::new();
-    let rolls_map: HashMap<i32, String> = cycle_meta_data
-        .rolls_data()
-        .iter()
-        .map(|(delegate, rolls)| {
-            rolls
-                .iter()
-                .map(|roll| {
-                    (
-                        *roll,
-                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
-                            .unwrap()
-                            .to_string_representation(),
-                    )
-                })
-                .collect::<HashMap<i32, String>>()
-        })
-        .flatten()
-        .collect();
+    let mut rolls_map: HashMap<i32, String> = HashMap::new();
+
+    for (delegate, rolls) in cycle_meta_data.rolls_data() {
+        for roll in rolls {
+            rolls_map.insert(
+                *roll,
+                SignaturePublicKeyHash::from_tagged_bytes(delegate.to_vec())?
+                    .to_string_representation(),
+            );
+        }
+    }
 
     // iterate through the whole cycle if necessery
     if let Some(cycle) = parameters.requested_cycle() {
@@ -348,24 +340,18 @@ fn get_endorsing_rights(
     // define helper and output variables
     let mut endorsing_rights = Vec::<EndorsingRight>::new();
 
-    let rolls_map: HashMap<i32, String> = cycle_meta_data
-        .rolls_data()
-        .iter()
-        .map(|(delegate, rolls)| {
-            rolls
-                .iter()
-                .map(|roll| {
-                    (
-                        *roll,
-                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
-                            .unwrap()
-                            .to_string_representation(),
-                    )
-                })
-                .collect::<HashMap<i32, String>>()
-        })
-        .flatten()
-        .collect();
+    // build a reverse map of rols so we have access in O(1)
+    let mut rolls_map: HashMap<i32, String> = HashMap::new();
+
+    for (delegate, rolls) in cycle_meta_data.rolls_data() {
+        for roll in rolls {
+            rolls_map.insert(
+                *roll,
+                SignaturePublicKeyHash::from_tagged_bytes(delegate.to_vec())?
+                    .to_string_representation(),
+            );
+        }
+    }
 
     // when query param cycle is specified then iterate over all cycle levels, else only given level
     if let Some(cycle) = parameters.requested_cycle() {

--- a/rpc/src/services/protocol/proto_007/rights_service.rs
+++ b/rpc/src/services/protocol/proto_007/rights_service.rs
@@ -16,7 +16,6 @@ use std::convert::TryInto;
 use anyhow::format_err;
 use itertools::Itertools;
 
-use crypto::hash::ChainId;
 use tezos_messages::base::rpc_support::{RpcJsonMap, ToRpcJsonMap};
 use tezos_messages::base::signature_public_key_hash::SignaturePublicKeyHash;
 use tezos_messages::protocol::proto_007::rights::{BakingRights, EndorsingRight};
@@ -24,7 +23,6 @@ use tezos_messages::protocol::proto_007::rights::{BakingRights, EndorsingRight};
 use storage::cycle_storage::CycleData;
 use storage::CycleMetaStorage;
 
-use crate::server::RpcServiceEnvironment;
 use crate::services::dev_services::contract_id_to_contract_address_for_index;
 use crate::services::protocol::proto_007::helpers::{
     get_cycle_data, get_prng_number, init_prng, level_position, EndorserSlots, RightsConstants,
@@ -58,8 +56,6 @@ pub(crate) async fn check_and_get_baking_rights(
     max_priority: Option<&str>,
     has_all: bool,
     cycle_meta_storage: &CycleMetaStorage,
-    chain_id: &ChainId,
-    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -72,8 +68,6 @@ pub(crate) async fn check_and_get_baking_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
-        chain_id,
-        env,
         true,
     )
     .await?;
@@ -314,8 +308,6 @@ pub(crate) async fn check_and_get_endorsing_rights(
     cycle: Option<&str>,
     has_all: bool,
     cycle_meta_storage: &CycleMetaStorage,
-    chain_id: &ChainId,
-    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -328,8 +320,6 @@ pub(crate) async fn check_and_get_endorsing_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
-        chain_id,
-        env,
         false,
     )
     .await?;

--- a/rpc/src/services/protocol/proto_007/votes_services.rs
+++ b/rpc/src/services/protocol/proto_007/votes_services.rs
@@ -20,7 +20,7 @@ pub fn get_votes_listings(
     // filter out the listings data
     let listings_data = if let Some(val) = env
         .tezedge_context()
-        .get_key_values_by_prefix(&context_hash, context_key_owned!("data/votes/listings"))?
+        .get_key_values_by_prefix(context_hash, context_key_owned!("data/votes/listings"))?
     {
         val
     } else {

--- a/rpc/src/services/protocol/proto_008/helpers.rs
+++ b/rpc/src/services/protocol/proto_008/helpers.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 use std::convert::TryFrom;
-use std::sync::Arc;
 
-use crypto::hash::ChainId;
 use anyhow::bail;
 use getset::Getters;
 use thiserror::Error;
@@ -16,12 +14,8 @@ use crypto::{
 use storage::cycle_storage::CycleData;
 use storage::{num_from_slice, BlockHeaderWithHash, CycleMetaStorage};
 
-use crate::helpers::{parse_block_hash, BlockMetadata};
 use crate::merge_slices;
-use crate::server::RpcServiceEnvironment;
-use crate::services::protocol::{
-    parse_block_metadata_level, ContextProtocolParam, MetadataParsingError,
-};
+use crate::services::protocol::ContextProtocolParam;
 
 use super::ProtocolConstants;
 
@@ -187,8 +181,6 @@ impl RightsParams {
         param_has_all: bool,
         rights_constants: &RightsConstants,
         block_header: &BlockHeaderWithHash,
-        chain_id: &ChainId,
-        env: &RpcServiceEnvironment,
         is_baking_rights: bool,
     ) -> Result<Self, anyhow::Error> {
         let block_level = block_header.header.level();
@@ -196,6 +188,7 @@ impl RightsParams {
         let blocks_per_cycle = *rights_constants.blocks_per_cycle();
 
         // this is the cycle of block_id level
+        let current_cycle = cycle_from_level(block_level, blocks_per_cycle)?;
 
         // display_level is here because of corner case where all levels < 1 are computed as level 1 but oputputed as they are
         let mut display_level: i32 = block_level;
@@ -230,29 +223,11 @@ impl RightsParams {
             }
         };
 
-        let block_metadata = match crate::services::base_services::get_block_metadata(
-            chain_id,
-            &parse_block_hash(chain_id, &requested_level.to_string(), env)?,
-            env,
-        )
-        .await
-        {
-            Ok(metadata) => Some(metadata),
-            Err(_) => None,
-        };
-
-        let rights_metadata = if let Some(metadata) = block_metadata {
-            RightsMetadata::extract_from_block_metadata(metadata)?
-        } else if param_level.is_some() {
-            RightsMetadata::calculate(blocks_per_cycle, requested_level)?
-        } else {
-            // this should never happen. When block_metadata is not available it means we requested a future level (thus level is always Some())
-            bail!("No level parameter in url")
-        };
+        let rights_metadata = RightsMetadata::calculate(blocks_per_cycle, requested_level)?;
 
         Self::validate_cycle(
             cycle_from_level(requested_level, blocks_per_cycle)?,
-            rights_metadata.block_cycle,
+            current_cycle,
             preserved_cycles,
         )?;
 
@@ -260,7 +235,7 @@ impl RightsParams {
         let requested_cycle = match param_cycle {
             Some(val) => Some(Self::validate_cycle(
                 val.parse()?,
-                rights_metadata.block_cycle,
+                current_cycle,
                 preserved_cycles,
             )?),
             None => None,
@@ -482,24 +457,6 @@ pub struct RightsMetadata {
 }
 
 impl RightsMetadata {
-    pub fn extract_from_block_metadata(
-        block_metadata: Arc<BlockMetadata>,
-    ) -> Result<Self, MetadataParsingError> {
-        let (block_cycle, block_cycle_position) =
-            match parse_block_metadata_level(&block_metadata, "level_info") {
-                Ok(cycle_data) => cycle_data,
-                Err(MetadataParsingError::KeyNotFoundError { key: _ }) => {
-                    // No level info found, trying the older scheme
-                    parse_block_metadata_level(&block_metadata, "level")?
-                }
-                Err(e) => return Err(e),
-            };
-        Ok(Self {
-            block_cycle,
-            block_cycle_position,
-        })
-    }
-
     pub fn calculate(
         blocks_per_cycle: i32,
         requested_level: i32,

--- a/rpc/src/services/protocol/proto_008/helpers.rs
+++ b/rpc/src/services/protocol/proto_008/helpers.rs
@@ -50,14 +50,15 @@ impl RightsConstants {
     pub(crate) fn parse_rights_constants(
         context_proto_param: &ContextProtocolParam,
     ) -> Result<Self, anyhow::Error> {
-        let protocol_constants: ProtocolConstants = serde_json::from_str(&context_proto_param.constants_data)?;
+        let protocol_constants: ProtocolConstants =
+            serde_json::from_str(&context_proto_param.constants_data)?;
 
         Ok(Self {
             blocks_per_cycle: protocol_constants.blocks_per_cycle,
             preserved_cycles: protocol_constants.preserved_cycles,
             nonce_length: protocol_constants.nonce_length,
             time_between_blocks: protocol_constants.time_between_blocks,
-            endorsers_per_block: protocol_constants.endorsers_per_block ,
+            endorsers_per_block: protocol_constants.endorsers_per_block,
         })
     }
 }
@@ -68,11 +69,7 @@ pub(crate) fn get_cycle_data(
     cycle_meta_storage: &CycleMetaStorage,
 ) -> Result<CycleData, anyhow::Error> {
     // prepare cycle for which rollers are selected
-    let requested_cycle = if let Some(cycle) = *parameters.requested_cycle() {
-        cycle
-    } else {
-        block_cycle
-    };
+    let requested_cycle = parameters.requested_cycle().unwrap_or(block_cycle);
 
     if let Some(cycle_meta_data) = cycle_meta_storage.get(&requested_cycle)? {
         Ok(cycle_meta_data)
@@ -387,9 +384,6 @@ pub fn init_prng(
     let state = cycle_meta_data.seed_bytes();
     let zero_bytes: Vec<u8> = vec![0; nonce_size];
 
-    // the position of the block in its cycle; has to be i32
-    // let cycle_position: i32 = level_position(level, blocks_per_cycle)?;
-
     // take the state (initially the random seed), zero bytes, the use string and the blocks position in the cycle as bytes, merge them together and hash the result
     let rd = blake2b::digest_256(&merge_slices!(
         state,
@@ -462,7 +456,6 @@ impl RightsMetadata {
         requested_level: i32,
     ) -> Result<Self, RightsConstantError> {
         Ok(Self {
-            // (cycle_from_level(requested_level, blocks_per_cycle)?, level_position(requested_level, blocks_per_cycle)?)
             block_cycle: cycle_from_level(requested_level, blocks_per_cycle)?,
             block_cycle_position: level_position(requested_level, blocks_per_cycle)?,
         })

--- a/rpc/src/services/protocol/proto_008/helpers.rs
+++ b/rpc/src/services/protocol/proto_008/helpers.rs
@@ -1,26 +1,26 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::sync::Arc;
 
-use anyhow::{bail, format_err};
+use crypto::hash::ChainId;
+use anyhow::bail;
 use getset::Getters;
-use tezos_context::context_key_owned;
-use thiserror::Error;
 
-use crypto::hash::ContextHash;
 use crypto::{
     blake2b::{self, Blake2bError},
     crypto_box::PublicKeyError,
 };
-use storage::{num_from_slice, BlockHeaderWithHash};
-use tezos_messages::base::signature_public_key_hash::SignaturePublicKeyHash;
-use tezos_messages::p2p::binary_message::BinaryRead;
-use tezos_wrapper::TezedgeContextClient;
+use storage::cycle_storage::CycleData;
+use storage::{num_from_slice, BlockHeaderWithHash, CycleMetaStorage};
 
+use crate::helpers::{parse_block_hash, BlockMetadata};
 use crate::merge_slices;
-use crate::services::protocol::ContextProtocolParam;
+use crate::server::RpcServiceEnvironment;
+use crate::services::protocol::{
+    parse_block_metadata_level, ContextProtocolParam, MetadataParsingError,
+};
 
 /// Context constants used in baking and endorsing rights
 #[derive(Debug, Clone, Getters)]
@@ -34,31 +34,20 @@ pub struct RightsConstants {
     #[get = "pub(crate)"]
     time_between_blocks: Vec<i64>,
     #[get = "pub(crate)"]
-    blocks_per_roll_snapshot: i32,
-    #[get = "pub(crate)"]
     endorsers_per_block: u16,
 }
 
-impl RightsConstants {
-    /// simple constructor to create RightsConstants
-    pub fn new(
-        blocks_per_cycle: i32,
-        preserved_cycles: u8,
-        nonce_length: u8,
-        time_between_blocks: Vec<i64>,
-        blocks_per_roll_snapshot: i32,
-        endorsers_per_block: u16,
-    ) -> Self {
-        Self {
-            blocks_per_cycle,
-            preserved_cycles,
-            nonce_length,
-            time_between_blocks,
-            blocks_per_roll_snapshot,
-            endorsers_per_block,
-        }
-    }
+#[derive(Debug, Error)]
+pub enum RightsConstantError {
+    #[error("The value is illegal, key: {key}")]
+    WrongValue { key: &'static str },
+    #[error("Key cannot be parsed, key: {key}")]
+    Parsing { key: &'static str },
+    #[error("Key cannot be found in constants, key: {key}")]
+    KeyNotFound { key: &'static str },
+}
 
+impl RightsConstants {
     /// Get all context constants which are used in endorsing and baking rights generation
     ///
     /// # Arguments
@@ -68,165 +57,103 @@ impl RightsConstants {
     pub(crate) fn parse_rights_constants(
         context_proto_param: &ContextProtocolParam,
     ) -> Result<Self, anyhow::Error> {
-        let dynamic =
-            tezos_messages::protocol::proto_008::constants::ParametricConstants::from_bytes(
-                &context_proto_param.constants_data,
-            )?;
-        let fixed = tezos_messages::protocol::proto_008::constants::FIXED;
-
-        Ok(RightsConstants::new(
-            dynamic.blocks_per_cycle(),
-            dynamic.preserved_cycles(),
-            fixed.nonce_length(),
-            dynamic.time_between_blocks().clone(),
-            dynamic.blocks_per_roll_snapshot(),
-            dynamic.endorsers_per_block(),
-        ))
-    }
-}
-
-/// Data from context DB for completing baking and endorsing rights
-#[derive(Debug, Clone, Getters)]
-pub struct RightsContextData {
-    /// Random seed for Tezos PRNG
-    #[get = "pub(crate)"]
-    random_seed: Vec<u8>,
-
-    /// Number of last roll so Tezos PRNG will not overflow
-    #[get = "pub(crate)"]
-    last_roll: i32,
-
-    /// List of rolls mapped to rollers contract id
-    #[get = "pub(crate)"]
-    rolls: HashMap<i32, String>,
-}
-
-impl RightsContextData {
-    /// Simple constructor to create RightsContextData
-    pub fn new(random_seed: Vec<u8>, last_roll: i32, rolls: HashMap<i32, String>) -> Self {
-        Self {
-            random_seed,
-            last_roll,
-            rolls,
-        }
-    }
-
-    /// Get context data roll_snapshot, random_seed, last_roll and rolls from context list
-    ///
-    /// # Arguments
-    ///
-    /// * `parameters` - Parameters created by [RightsParams](RightsParams::parse_rights_parameters).
-    /// * `constants` - Context constants used in baking and endorsing rights.
-    /// * `list` - Context list handler.
-    ///
-    /// Return RightsContextData.
-    pub(crate) fn prepare_context_data_for_rights(
-        parameters: RightsParams,
-        constants: RightsConstants,
-        (ctx_hash, context): (&ContextHash, &TezedgeContextClient),
-    ) -> Result<Self, anyhow::Error> {
-        // prepare constants that are used
-        let blocks_per_cycle = *constants.blocks_per_cycle();
-
-        // prepare parameters that are used
-        let requested_level = *parameters.requested_level();
-
-        // prepare cycle for which rollers are selected
-        let requested_cycle = if let Some(cycle) = *parameters.requested_cycle() {
-            cycle
-        } else {
-            cycle_from_level(requested_level, blocks_per_cycle)?
-        };
-
-        // get index of roll snapshot
-        let roll_snapshot: i16 = {
-            if let Some(data) = context.get_key_from_history(
-                &ctx_hash,
-                context_key_owned!("data/cycle/{}/roll_snapshot", requested_cycle),
-            )? {
-                num_from_slice!(data, 0, i16)
-            } else {
-                // key not found - prepare error for later processing
-                return Err(format_err!("roll_snapshot"));
-            }
-        };
-
-        let random_seed = {
-            if let Some(data) = context.get_key_from_history(
-                &ctx_hash,
-                context_key_owned!("data/cycle/{}/random_seed", requested_cycle),
-            )? {
-                data
-            } else {
-                // key not found - prepare error for later processing
-                return Err(format_err!("random_seed"));
-            }
-        };
-
-        // Snapshots of last_roll are listed from 0 same as roll_snapshot.
-        let last_roll = {
-            if let Some(data) = context.get_key_from_history(
-                &ctx_hash,
-                context_key_owned!("data/cycle/{}/last_roll/{}", requested_cycle, roll_snapshot),
-            )? {
-                num_from_slice!(data, 0, i32)
-            } else {
-                // key not found - prepare error for later processing
-                return Err(format_err!("last_roll"));
-            }
-        };
-
-        // get list of rolls from context list
-        let context_rolls = if let Some(rolls) =
-            Self::get_context_rolls((&ctx_hash, &context), requested_cycle, roll_snapshot)?
+        if let Some(constatns_deserialized) =
+            serde_json::from_str::<serde_json::Value>(&context_proto_param.constants_data)?
+                .as_object()
         {
-            rolls
-        } else {
-            return Err(format_err!("rolls"));
-        };
+            let blocks_per_cycle = get_constant_i64(constatns_deserialized, "blocks_per_cycle")?;
+            let preserved_cycles = get_constant_i64(constatns_deserialized, "preserved_cycles")?;
+            let nonce_length = get_constant_i64(constatns_deserialized, "nonce_length")?;
+            let time_between_blocks = get_time_between_blocks(constatns_deserialized)?;
+            let endorsers_per_block =
+                get_constant_i64(constatns_deserialized, "endorsers_per_block")?;
 
-        Ok(Self::new(random_seed.to_vec(), last_roll, context_rolls))
+            Ok(Self {
+                blocks_per_cycle: blocks_per_cycle as i32,
+                preserved_cycles: preserved_cycles as u8,
+                nonce_length: nonce_length as u8,
+                time_between_blocks,
+                endorsers_per_block: endorsers_per_block as u16,
+            })
+        } else {
+            bail!("Constants not an object")
+        }
     }
+}
 
-    /// get list of rollers from context list selected by snapshot level
-    ///
-    /// # Arguments
-    ///
-    /// * `context` - context list HashMap from [get_context_as_hashmap](RightsContextData::get_context_as_hashmap)
-    ///
-    /// Return rollers for [RightsContextData.rolls](RightsContextData.rolls)
-    fn get_context_rolls(
-        (ctx_hash, context): (&ContextHash, &TezedgeContextClient),
-        cycle: i64,
-        snapshot: i16,
-    ) -> Result<Option<HashMap<i32, String>>, anyhow::Error> {
-        let rolls = if let Some(val) = context.get_key_values_by_prefix(
-            &ctx_hash,
-            context_key_owned!("data/rolls/owner/snapshot/{}/{}", cycle, snapshot),
-        )? {
-            val
+fn get_constant_i64(
+    constants: &serde_json::Map<String, serde_json::Value>,
+    key: &'static str,
+) -> Result<i64, RightsConstantError> {
+    if let Some(value) = constants.get(key) {
+        if let Some(i64_value) = value.as_i64() {
+            Ok(i64_value)
         } else {
-            bail!("No rolls found in context")
-        };
-
-        let mut roll_owners: HashMap<i32, String> = HashMap::new();
-
-        // iterate through all the owners,the roll_num is the last component of the key, decode the value (it is a public key) to get the public key hash address (tz1...)
-        for (key, value) in rolls.into_iter() {
-            if key.last().is_none() {
-                continue;
+            if let Some(str_num) = value.as_str() {
+                return str_num
+                    .parse()
+                    .map_err(|_| RightsConstantError::Parsing { key });
             }
-            let roll_num = key.last().unwrap();
+            Err(RightsConstantError::Parsing { key })
+        }
+    } else {
+        Err(RightsConstantError::KeyNotFound { key })
+    }
+}
 
-            // the values are public keys
-            let delegate = SignaturePublicKeyHash::from_tagged_bytes(value.clone())?
-                .to_string_representation();
-            roll_owners.insert(roll_num.parse()?, delegate);
+fn get_time_between_blocks(
+    constants: &serde_json::Map<String, serde_json::Value>,
+) -> Result<Vec<i64>, RightsConstantError> {
+    let mut ret: Vec<i64> = Vec::new();
+    if let Some(value) = constants.get("time_between_blocks") {
+        if let Some(array) = value.as_array() {
+            for e in array {
+                if let Some(str_element) = e.as_str() {
+                    let parsed =
+                        str_element
+                            .parse::<i64>()
+                            .map_err(|_| RightsConstantError::Parsing {
+                                key: "time_between_blocks",
+                            })?;
+                    ret.push(parsed);
+                } else {
+                    return Err(RightsConstantError::Parsing {
+                        key: "time_between_blocks",
+                    });
+                }
+            }
+            Ok(ret)
+        } else {
+            Err(RightsConstantError::Parsing {
+                key: "time_between_blocks",
+            })
         }
-        if roll_owners.is_empty() {
-            bail!("No rolls assigned, all rolls happened to be DELETED")
-        }
-        Ok(Some(roll_owners))
+    } else {
+        Err(RightsConstantError::KeyNotFound {
+            key: "time_between_blocks",
+        })
+    }
+}
+
+pub(crate) fn get_cycle_data(
+    parameters: RightsParams,
+    block_cycle: i32,
+    cycle_meta_storage: &CycleMetaStorage,
+) -> Result<CycleData, anyhow::Error> {
+    // prepare cycle for which rollers are selected
+    let requested_cycle = if let Some(cycle) = *parameters.requested_cycle() {
+        cycle
+    } else {
+        block_cycle
+    };
+
+    if let Some(cycle_meta_data) = cycle_meta_storage.get(&requested_cycle)? {
+        Ok(cycle_meta_data)
+    } else {
+        bail!(
+            "No cycle data found for requested_cycle: {}",
+            requested_cycle
+        )
     }
 }
 
@@ -235,7 +162,7 @@ impl RightsContextData {
 pub struct RightsParams {
     /// Level (height) of block. Parsed from url path parameter 'block_id'.
     #[get = "pub(crate)"]
-    block_level: i64,
+    block_level: i32,
 
     /// Header timestamp of block. Parsed from url path parameter 'block_id'.
     #[get = "pub(crate)"]
@@ -247,41 +174,46 @@ pub struct RightsParams {
 
     /// Cycle for whitch all rights will be listed. Url query parameter 'cycle'.
     #[get = "pub(crate)"]
-    requested_cycle: Option<i64>,
+    requested_cycle: Option<i32>,
 
     /// Level (height) of block for whitch all rights will be listed. Url query parameter 'level'.
     #[get = "pub(crate)"]
-    requested_level: i64,
+    requested_level: i32,
 
     /// Level to be displayed in output.
     #[get = "pub(crate)"]
-    display_level: i64,
+    display_level: i32,
 
     /// Level for estimated_time computation. Endorsing rights only.
     #[get = "pub(crate)"]
-    timestamp_level: i64,
+    timestamp_level: i32,
 
     /// Max priority to which baking rights are listed. Url query parameter 'max_priority'.
     #[get = "pub(crate)"]
-    max_priority: i64,
+    max_priority: i32,
 
     /// Indicate that baking rights for maximum priority should be listed. Url query parameter 'all'.
     #[get = "pub(crate)"]
     has_all: bool,
+
+    #[get = "pub(crate)"]
+    rights_metadata: RightsMetadata,
 }
 
 impl RightsParams {
     /// Simple constructor to create RightsParams
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
-        block_level: i64,
+        block_level: i32,
         block_timestamp: i64,
         requested_delegate: Option<String>,
-        requested_cycle: Option<i64>,
-        requested_level: i64,
-        display_level: i64,
-        timestamp_level: i64,
-        max_priority: i64,
+        requested_cycle: Option<i32>,
+        requested_level: i32,
+        display_level: i32,
+        timestamp_level: i32,
+        max_priority: i32,
         has_all: bool,
+        rights_metadata: RightsMetadata,
     ) -> Self {
         Self {
             block_level,
@@ -293,6 +225,7 @@ impl RightsParams {
             timestamp_level,
             max_priority,
             has_all,
+            rights_metadata,
         }
     }
 
@@ -312,7 +245,8 @@ impl RightsParams {
     /// * `is_baking_rights` - flag to identify if are parsed baking or endorsing rights
     ///
     /// Return RightsParams
-    pub(crate) fn parse_rights_parameters(
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn parse_rights_parameters(
         param_level: Option<&str>,
         param_delegate: Option<&str>,
         param_cycle: Option<&str>,
@@ -320,30 +254,25 @@ impl RightsParams {
         param_has_all: bool,
         rights_constants: &RightsConstants,
         block_header: &BlockHeaderWithHash,
+        chain_id: &ChainId,
+        env: &RpcServiceEnvironment,
         is_baking_rights: bool,
     ) -> Result<Self, anyhow::Error> {
-        let block_level: i64 = block_header.header.level().into();
+        let block_level = block_header.header.level();
         let preserved_cycles = *rights_constants.preserved_cycles();
         let blocks_per_cycle = *rights_constants.blocks_per_cycle();
 
         // this is the cycle of block_id level
-        let current_cycle = cycle_from_level(block_level, blocks_per_cycle)?;
 
         // display_level is here because of corner case where all levels < 1 are computed as level 1 but oputputed as they are
-        let mut display_level: i64 = block_level;
+        let mut display_level: i32 = block_level;
         // endorsing rights only: timestamp_level is the base level for timestamp computation is taken from last known block (block_id) timestamp + time_between_blocks[0]
-        let mut timestamp_level: i64 = block_level;
+        let mut timestamp_level: i32 = block_level;
         // Check the param_level, if there is a level specified validate it, if no set it to the block_level
         // requested_level is used to get data from context list
-        let requested_level: i64 = match param_level {
+        let requested_level: i32 = match param_level {
             Some(level) => {
                 let level = level.parse()?;
-                // check the bounds for the requested level (if it is in the previous/next preserved cycles)
-                Self::validate_cycle(
-                    cycle_from_level(level, blocks_per_cycle)?,
-                    current_cycle,
-                    preserved_cycles,
-                )?;
                 // display level is always same as level requested
                 display_level = level;
                 // endorsing rights: to compute timestamp for level parameter there need to be taken timestamp of previous block
@@ -368,11 +297,37 @@ impl RightsParams {
             }
         };
 
+        let block_metadata = match crate::services::base_services::get_block_metadata(
+            chain_id,
+            &parse_block_hash(chain_id, &requested_level.to_string(), env)?,
+            env,
+        )
+        .await
+        {
+            Ok(metadata) => Some(metadata),
+            Err(_) => None,
+        };
+
+        let rights_metadata = if let Some(metadata) = block_metadata {
+            RightsMetadata::extract_from_block_metadata(metadata)?
+        } else if param_level.is_some() {
+            RightsMetadata::calculate(blocks_per_cycle, requested_level)?
+        } else {
+            // this should never happen. When block_metadata is not available it means we requested a future level (thus level is always Some())
+            bail!("No level parameter in url")
+        };
+
+        Self::validate_cycle(
+            cycle_from_level(requested_level, blocks_per_cycle)?,
+            rights_metadata.block_cycle,
+            preserved_cycles,
+        )?;
+
         // validate requested cycle
         let requested_cycle = match param_cycle {
             Some(val) => Some(Self::validate_cycle(
                 val.parse()?,
-                current_cycle,
+                rights_metadata.block_cycle,
                 preserved_cycles,
             )?),
             None => None,
@@ -400,6 +355,7 @@ impl RightsParams {
             timestamp_level, // endorsing rights only
             max_priority,
             param_has_all,
+            rights_metadata,
         ))
     }
 
@@ -415,7 +371,7 @@ impl RightsParams {
     pub fn get_estimated_time(
         &self,
         constants: &RightsConstants,
-        level: Option<i64>,
+        level: Option<i32>,
     ) -> Option<i64> {
         // if is cycle then level is provided as parameter else use prepared timestamp_level
         let timestamp_level = level.unwrap_or(self.timestamp_level);
@@ -434,13 +390,17 @@ impl RightsParams {
     /// Validate if cycle requested as url query parameter (cycle or level) is available in context list by checking preserved_cycles constant
     #[inline]
     fn validate_cycle(
-        requested_cycle: i64,
-        current_cycle: i64,
+        requested_cycle: i32,
+        current_cycle: i32,
         preserved_cycles: u8,
-    ) -> Result<i64, anyhow::Error> {
-        if (requested_cycle - current_cycle).abs() <= (preserved_cycles as i64) {
+    ) -> Result<i32, anyhow::Error> {
+        if (requested_cycle - current_cycle).abs() <= preserved_cycles.into() {
             Ok(requested_cycle)
         } else {
+            // TODO: proper json response is needed for this
+            // Octez is:
+            //    [{ "kind": "permanent", "id": "proto.008-PtEdo2Zk.seed.unknown_seed",
+            //        "oldest": 330, "requested": 200, "latest": 340 }]
             bail!("Requested cycle out of bounds") //TODO: prepare cycle error
         }
     }
@@ -467,47 +427,6 @@ impl EndorserSlots {
     /// Push endorsing slot to slots
     pub fn push_to_slot(&mut self, slot: u16) {
         self.slots.push(slot);
-    }
-}
-
-/// Return cycle in which is given level
-///
-/// # Arguments
-///
-/// * `level` - level to specify cycle for
-/// * `blocks_per_cycle` - context constant
-///
-/// Level 0 (genesis block) is not part of any cycle (cycle 0 starts at level 1),
-/// hence the blocks_per_cycle - 1 for last cycle block.
-pub fn cycle_from_level(level: i64, blocks_per_cycle: i32) -> Result<i64, anyhow::Error> {
-    // check if blocks_per_cycle is not 0 to prevent panic
-    if blocks_per_cycle > 0 {
-        Ok((level - 1) / (blocks_per_cycle as i64))
-    } else {
-        bail!("wrong value blocks_per_cycle={}", blocks_per_cycle)
-    }
-}
-
-/// Return the position of the block in its cycle
-///
-/// # Arguments
-///
-/// * `level` - level to specify cycle for
-/// * `blocks_per_cycle` - context constant
-///
-/// Level 0 (genesis block) is not part of any cycle (cycle 0 starts at level 1),
-/// hence the blocks_per_cycle - 1 for last cycle block.
-pub fn level_position(level: i32, blocks_per_cycle: i32) -> Result<i32, anyhow::Error> {
-    // check if blocks_per_cycle is not 0 to prevent panic
-    if blocks_per_cycle <= 0 {
-        bail!("wrong value blocks_per_cycle={}", blocks_per_cycle);
-    }
-    let cycle_position = (level % blocks_per_cycle) - 1;
-    if cycle_position < 0 {
-        //for last block
-        Ok(blocks_per_cycle - 1)
-    } else {
-        Ok(cycle_position)
     }
 }
 
@@ -549,24 +468,23 @@ pub type TezosPRNGResult = Result<(i32, RandomSeedState), TezosPRNGError>;
 /// Return first random sequence state to use in [get_prng_number](`get_prng_number`)
 #[inline]
 pub fn init_prng(
-    cycle_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
     constants: &RightsConstants,
     use_string_bytes: &[u8],
-    level: i32,
+    cycle_position: i32,
     offset: i32,
 ) -> Result<RandomSeedState, anyhow::Error> {
     // a safe way to convert betwwen types is to use try_from
     let nonce_size = usize::try_from(*constants.nonce_length())?;
-    let blocks_per_cycle = *constants.blocks_per_cycle();
-    let state = cycle_data.random_seed();
+    let state = cycle_meta_data.seed_bytes();
     let zero_bytes: Vec<u8> = vec![0; nonce_size];
 
     // the position of the block in its cycle; has to be i32
-    let cycle_position: i32 = level_position(level, blocks_per_cycle)?;
+    // let cycle_position: i32 = level_position(level, blocks_per_cycle)?;
 
     // take the state (initially the random seed), zero bytes, the use string and the blocks position in the cycle as bytes, merge them together and hash the result
     let rd = blake2b::digest_256(&merge_slices!(
-        &state,
+        state,
         &zero_bytes,
         use_string_bytes,
         &cycle_position.to_be_bytes()
@@ -619,4 +537,89 @@ pub fn get_prng_number(state: RandomSeedState, bound: i32) -> TezosPRNGResult {
         };
     }
     Ok((v, sequence))
+}
+
+#[derive(Debug, Clone, Getters)]
+pub struct RightsMetadata {
+    #[get = "pub(crate)"]
+    block_cycle: i32,
+
+    #[get = "pub(crate)"]
+    block_cycle_position: i32,
+}
+
+impl RightsMetadata {
+    pub fn extract_from_block_metadata(
+        block_metadata: Arc<BlockMetadata>,
+    ) -> Result<Self, MetadataParsingError> {
+        let (block_cycle, block_cycle_position) =
+            match parse_block_metadata_level(&block_metadata, "level_info") {
+                Ok(cycle_data) => cycle_data,
+                Err(MetadataParsingError::KeyNotFoundError { key: _ }) => {
+                    // No level info found, trying the older scheme
+                    parse_block_metadata_level(&block_metadata, "level")?
+                }
+                Err(e) => return Err(e),
+            };
+        Ok(Self {
+            block_cycle,
+            block_cycle_position,
+        })
+    }
+
+    pub fn calculate(
+        blocks_per_cycle: i32,
+        requested_level: i32,
+    ) -> Result<Self, RightsConstantError> {
+        Ok(Self {
+            // (cycle_from_level(requested_level, blocks_per_cycle)?, level_position(requested_level, blocks_per_cycle)?)
+            block_cycle: cycle_from_level(requested_level, blocks_per_cycle)?,
+            block_cycle_position: level_position(requested_level, blocks_per_cycle)?,
+        })
+    }
+}
+
+/// Return cycle in which is given level
+///
+/// # Arguments
+///
+/// * `level` - level to specify cycle for
+/// * `blocks_per_cycle` - context constant
+///
+/// Level 0 (genesis block) is not part of any cycle (cycle 0 starts at level 1),
+/// hence the blocks_per_cycle - 1 for last cycle block.
+pub fn cycle_from_level(level: i32, blocks_per_cycle: i32) -> Result<i32, RightsConstantError> {
+    // check if blocks_per_cycle is not 0 to prevent panic
+    if blocks_per_cycle > 0 {
+        Ok((level - 1) / blocks_per_cycle)
+    } else {
+        Err(RightsConstantError::WrongValue {
+            key: "blocks_per_cycle",
+        })
+    }
+}
+
+/// Return the position of the block in its cycle
+///
+/// # Arguments
+///
+/// * `level` - level to specify cycle for
+/// * `blocks_per_cycle` - context constant
+///
+/// Level 0 (genesis block) is not part of any cycle (cycle 0 starts at level 1),
+/// hence the blocks_per_cycle - 1 for last cycle block.
+pub fn level_position(level: i32, blocks_per_cycle: i32) -> Result<i32, RightsConstantError> {
+    // check if blocks_per_cycle is not 0 to prevent panic
+    if blocks_per_cycle <= 0 {
+        return Err(RightsConstantError::WrongValue {
+            key: "blocks_per_cycle",
+        });
+    }
+    let cycle_position = (level % blocks_per_cycle) - 1;
+    if cycle_position < 0 {
+        //for last block
+        Ok(blocks_per_cycle - 1)
+    } else {
+        Ok(cycle_position)
+    }
 }

--- a/rpc/src/services/protocol/proto_008/helpers.rs
+++ b/rpc/src/services/protocol/proto_008/helpers.rs
@@ -23,6 +23,8 @@ use crate::services::protocol::{
     parse_block_metadata_level, ContextProtocolParam, MetadataParsingError,
 };
 
+use super::ProtocolConstants;
+
 /// Context constants used in baking and endorsing rights
 #[derive(Debug, Clone, Getters)]
 pub struct RightsConstants {
@@ -42,10 +44,6 @@ pub struct RightsConstants {
 pub enum RightsConstantError {
     #[error("The value is illegal, key: {key}")]
     WrongValue { key: &'static str },
-    #[error("Key cannot be parsed, key: {key}")]
-    Parsing { key: &'static str },
-    #[error("Key cannot be found in constants, key: {key}")]
-    KeyNotFound { key: &'static str },
 }
 
 impl RightsConstants {
@@ -58,80 +56,14 @@ impl RightsConstants {
     pub(crate) fn parse_rights_constants(
         context_proto_param: &ContextProtocolParam,
     ) -> Result<Self, anyhow::Error> {
-        if let Some(constatns_deserialized) =
-            serde_json::from_str::<serde_json::Value>(&context_proto_param.constants_data)?
-                .as_object()
-        {
-            let blocks_per_cycle = get_constant_i64(constatns_deserialized, "blocks_per_cycle")?;
-            let preserved_cycles = get_constant_i64(constatns_deserialized, "preserved_cycles")?;
-            let nonce_length = get_constant_i64(constatns_deserialized, "nonce_length")?;
-            let time_between_blocks = get_time_between_blocks(constatns_deserialized)?;
-            let endorsers_per_block =
-                get_constant_i64(constatns_deserialized, "endorsers_per_block")?;
+        let protocol_constants: ProtocolConstants = serde_json::from_str(&context_proto_param.constants_data)?;
 
-            Ok(Self {
-                blocks_per_cycle: blocks_per_cycle as i32,
-                preserved_cycles: preserved_cycles as u8,
-                nonce_length: nonce_length as u8,
-                time_between_blocks,
-                endorsers_per_block: endorsers_per_block as u16,
-            })
-        } else {
-            bail!("Constants not an object")
-        }
-    }
-}
-
-fn get_constant_i64(
-    constants: &serde_json::Map<String, serde_json::Value>,
-    key: &'static str,
-) -> Result<i64, RightsConstantError> {
-    if let Some(value) = constants.get(key) {
-        if let Some(i64_value) = value.as_i64() {
-            Ok(i64_value)
-        } else {
-            if let Some(str_num) = value.as_str() {
-                return str_num
-                    .parse()
-                    .map_err(|_| RightsConstantError::Parsing { key });
-            }
-            Err(RightsConstantError::Parsing { key })
-        }
-    } else {
-        Err(RightsConstantError::KeyNotFound { key })
-    }
-}
-
-fn get_time_between_blocks(
-    constants: &serde_json::Map<String, serde_json::Value>,
-) -> Result<Vec<i64>, RightsConstantError> {
-    let mut ret: Vec<i64> = Vec::new();
-    if let Some(value) = constants.get("time_between_blocks") {
-        if let Some(array) = value.as_array() {
-            for e in array {
-                if let Some(str_element) = e.as_str() {
-                    let parsed =
-                        str_element
-                            .parse::<i64>()
-                            .map_err(|_| RightsConstantError::Parsing {
-                                key: "time_between_blocks",
-                            })?;
-                    ret.push(parsed);
-                } else {
-                    return Err(RightsConstantError::Parsing {
-                        key: "time_between_blocks",
-                    });
-                }
-            }
-            Ok(ret)
-        } else {
-            Err(RightsConstantError::Parsing {
-                key: "time_between_blocks",
-            })
-        }
-    } else {
-        Err(RightsConstantError::KeyNotFound {
-            key: "time_between_blocks",
+        Ok(Self {
+            blocks_per_cycle: protocol_constants.blocks_per_cycle,
+            preserved_cycles: protocol_constants.preserved_cycles,
+            nonce_length: protocol_constants.nonce_length,
+            time_between_blocks: protocol_constants.time_between_blocks,
+            endorsers_per_block: protocol_constants.endorsers_per_block ,
         })
     }
 }

--- a/rpc/src/services/protocol/proto_008/helpers.rs
+++ b/rpc/src/services/protocol/proto_008/helpers.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use crypto::hash::ChainId;
 use anyhow::bail;
 use getset::Getters;
+use thiserror::Error;
 
 use crypto::{
     blake2b::{self, Blake2bError},

--- a/rpc/src/services/protocol/proto_008/mod.rs
+++ b/rpc/src/services/protocol/proto_008/mod.rs
@@ -1,6 +1,81 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
+use serde::Deserialize;
+use getset::CopyGetters;
+use num::BigInt;
+
 mod helpers;
 pub(crate) mod rights_service;
 pub(crate) mod votes_service;
+
+use super::{vec_string_to_int, string_to_int};
+
+#[derive(Debug, Deserialize, Clone, CopyGetters)]
+pub(crate) struct ProtocolConstants {
+    proof_of_work_nonce_size: u8,
+    nonce_length: u8,
+    max_anon_ops_per_block: u8,
+    max_operation_data_length: i32,
+    max_proposals_per_delegate: u8,
+    preserved_cycles: u8,
+
+    #[get_copy = "pub(crate)"]
+    blocks_per_cycle: i32,
+    
+    blocks_per_commitment: i32,
+    blocks_per_roll_snapshot: i32,
+    blocks_per_voting_period: i32,
+
+    #[serde(with = "vec_string_to_int")]
+    time_between_blocks: Vec<i64>,
+    
+    endorsers_per_block: u16,
+
+    #[serde(with = "string_to_int")]
+    hard_gas_limit_per_operation: BigInt,
+
+    #[serde(with = "string_to_int")]
+    hard_gas_limit_per_block: BigInt,
+
+    #[serde(with = "string_to_int")]
+    proof_of_work_threshold: BigInt,
+
+    #[serde(with = "string_to_int")]
+    tokens_per_roll: BigInt,
+    michelson_maximum_type_size: u16,
+
+    #[serde(with = "string_to_int")]
+    seed_nonce_revelation_tip: BigInt,
+
+    origination_size: i32,
+
+    #[serde(with = "string_to_int")]
+    block_security_deposit: BigInt,
+
+    #[serde(with = "string_to_int")]
+    endorsement_security_deposit: BigInt,
+
+    #[serde(with = "vec_string_to_int")]
+    baking_reward_per_endorsement: Vec<BigInt>,
+
+    #[serde(with = "vec_string_to_int")]
+    endorsement_reward: Vec<BigInt>,
+
+    #[serde(with = "string_to_int")]
+    cost_per_byte: BigInt,
+
+    #[serde(with = "string_to_int")]
+    hard_storage_limit_per_operation: BigInt,
+
+    quorum_min: i32,
+    quorum_max: i32,
+    min_proposal_quorum: i32,
+    initial_endorsers: u16,
+
+    #[serde(with = "string_to_int")]
+    delay_per_missing_endorsement: i64,
+
+    #[serde(with = "string_to_int")]
+    test_chain_duration: i64,
+}

--- a/rpc/src/services/protocol/proto_008/mod.rs
+++ b/rpc/src/services/protocol/proto_008/mod.rs
@@ -1,15 +1,15 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use serde::Deserialize;
 use getset::CopyGetters;
 use num::BigInt;
+use serde::Deserialize;
 
 mod helpers;
 pub(crate) mod rights_service;
 pub(crate) mod votes_service;
 
-use super::{vec_string_to_int, string_to_int};
+use super::{string_to_int, vec_string_to_int};
 
 #[derive(Debug, Deserialize, Clone, CopyGetters)]
 pub(crate) struct ProtocolConstants {
@@ -22,14 +22,14 @@ pub(crate) struct ProtocolConstants {
 
     #[get_copy = "pub(crate)"]
     blocks_per_cycle: i32,
-    
+
     blocks_per_commitment: i32,
     blocks_per_roll_snapshot: i32,
     blocks_per_voting_period: i32,
 
     #[serde(with = "vec_string_to_int")]
     time_between_blocks: Vec<i64>,
-    
+
     endorsers_per_block: u16,
 
     #[serde(with = "string_to_int")]

--- a/rpc/src/services/protocol/proto_008/rights_service.rs
+++ b/rpc/src/services/protocol/proto_008/rights_service.rs
@@ -16,15 +16,13 @@ use std::convert::TryInto;
 use anyhow::format_err;
 use itertools::Itertools;
 
-use crypto::hash::ChainId;
 use tezos_messages::base::rpc_support::{RpcJsonMap, ToRpcJsonMap};
 use tezos_messages::base::signature_public_key_hash::SignaturePublicKeyHash;
-use tezos_messages::protocol::proto_008::rights::{BakingRights, EndorsingRight};
+use tezos_messages::protocol::proto_008_2::rights::{BakingRights, EndorsingRight};
 
 use storage::cycle_storage::CycleData;
 use storage::CycleMetaStorage;
 
-use crate::server::RpcServiceEnvironment;
 use crate::services::dev_services::contract_id_to_contract_address_for_index;
 use crate::services::protocol::proto_008::helpers::{
     get_cycle_data, get_prng_number, init_prng, level_position, EndorserSlots, RightsConstants,
@@ -58,8 +56,6 @@ pub(crate) async fn check_and_get_baking_rights(
     max_priority: Option<&str>,
     has_all: bool,
     cycle_meta_storage: &CycleMetaStorage,
-    chain_id: &ChainId,
-    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -72,8 +68,6 @@ pub(crate) async fn check_and_get_baking_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
-        chain_id,
-        env,
         true,
     )
     .await?;
@@ -314,8 +308,6 @@ pub(crate) async fn check_and_get_endorsing_rights(
     cycle: Option<&str>,
     has_all: bool,
     cycle_meta_storage: &CycleMetaStorage,
-    chain_id: &ChainId,
-    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -328,8 +320,6 @@ pub(crate) async fn check_and_get_endorsing_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
-        chain_id,
-        env,
         false,
     )
     .await?;

--- a/rpc/src/services/protocol/proto_008/rights_service.rs
+++ b/rpc/src/services/protocol/proto_008/rights_service.rs
@@ -110,25 +110,17 @@ pub(crate) fn get_baking_rights(
     let cycle_position = *rights_metadata.block_cycle_position();
 
     // build a reverse map of rols so we have access in O(1)
-    // let rolls_map: HashMap<i32, String> = HashMap::new();
-    let rolls_map: HashMap<i32, String> = cycle_meta_data
-        .rolls_data()
-        .iter()
-        .map(|(delegate, rolls)| {
-            rolls
-                .iter()
-                .map(|roll| {
-                    (
-                        *roll,
-                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
-                            .unwrap()
-                            .to_string_representation(),
-                    )
-                })
-                .collect::<HashMap<i32, String>>()
-        })
-        .flatten()
-        .collect();
+    let mut rolls_map: HashMap<i32, String> = HashMap::new();
+
+    for (delegate, rolls) in cycle_meta_data.rolls_data() {
+        for roll in rolls {
+            rolls_map.insert(
+                *roll,
+                SignaturePublicKeyHash::from_tagged_bytes(delegate.to_vec())?
+                    .to_string_representation(),
+            );
+        }
+    }
 
     // iterate through the whole cycle if necessery
     if let Some(cycle) = parameters.requested_cycle() {
@@ -348,24 +340,18 @@ fn get_endorsing_rights(
     // define helper and output variables
     let mut endorsing_rights = Vec::<EndorsingRight>::new();
 
-    let rolls_map: HashMap<i32, String> = cycle_meta_data
-        .rolls_data()
-        .iter()
-        .map(|(delegate, rolls)| {
-            rolls
-                .iter()
-                .map(|roll| {
-                    (
-                        *roll,
-                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
-                            .unwrap()
-                            .to_string_representation(),
-                    )
-                })
-                .collect::<HashMap<i32, String>>()
-        })
-        .flatten()
-        .collect();
+    // build a reverse map of rols so we have access in O(1)
+    let mut rolls_map: HashMap<i32, String> = HashMap::new();
+
+    for (delegate, rolls) in cycle_meta_data.rolls_data() {
+        for roll in rolls {
+            rolls_map.insert(
+                *roll,
+                SignaturePublicKeyHash::from_tagged_bytes(delegate.to_vec())?
+                    .to_string_representation(),
+            );
+        }
+    }
 
     // when query param cycle is specified then iterate over all cycle levels, else only given level
     if let Some(cycle) = parameters.requested_cycle() {

--- a/rpc/src/services/protocol/proto_008/rights_service.rs
+++ b/rpc/src/services/protocol/proto_008/rights_service.rs
@@ -1,27 +1,44 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
+// TODO: (anagy) - check TODO's
+// TODO: refactor errors so this will be removed
+// Enum defining possible response structures for RPC calls
+// there is reason to have this structure because of format of error responses from ocaml node:
+// [{"kind":"permanent","id":"proto.005-PsBabyM1.context.storage_error","missing_key":["cycle","4","random_seed"],"function":"get"}]
+// [{"kind":"permanent","id":"proto.005-PsBabyM1.seed.unknown_seed","oldest":9,"requested":20,"latest":15}]
+// if there have to be same response format then RpcErrorMsg is covering it
+// this enum can be removed if errors are generated from error context directly in result_to_json_response function
+
 use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;
 
 use anyhow::format_err;
 use itertools::Itertools;
 
-use crate::services::dev_services::contract_id_to_contract_address_for_index;
+use crypto::hash::ChainId;
 use tezos_messages::base::rpc_support::{RpcJsonMap, ToRpcJsonMap};
 use tezos_messages::base::signature_public_key_hash::SignaturePublicKeyHash;
 use tezos_messages::protocol::proto_008::rights::{BakingRights, EndorsingRight};
-use tezos_wrapper::TezedgeContextClient;
 
+use storage::cycle_storage::CycleData;
+use storage::CycleMetaStorage;
+
+use crate::server::RpcServiceEnvironment;
+use crate::services::dev_services::contract_id_to_contract_address_for_index;
 use crate::services::protocol::proto_008::helpers::{
-    get_prng_number, init_prng, EndorserSlots, RightsConstants, RightsContextData, RightsParams,
+    get_cycle_data, get_prng_number, init_prng, level_position, EndorserSlots, RightsConstants,
+    RightsParams,
 };
 use crate::services::protocol::ContextProtocolParam;
+
+use super::helpers::RightsMetadata;
 
 /// Return generated baking rights.
 ///
 /// # Arguments
 ///
+/// * `block_id` - Url path parameter 'block_id', it contains string "head", block level or block hash.
 /// * `level` - Url query parameter 'level'.
 /// * `delegate` - Url query parameter 'delegate'.
 /// * `cycle` - Url query parameter 'cycle'.
@@ -32,14 +49,17 @@ use crate::services::protocol::ContextProtocolParam;
 /// * `state` - Current RPC collected state (head).
 ///
 /// Prepare all data to generate baking rights and then use Tezos PRNG to generate them.
-pub(crate) fn check_and_get_baking_rights(
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn check_and_get_baking_rights(
     context_proto_params: ContextProtocolParam,
     level: Option<&str>,
     delegate: Option<&str>,
     cycle: Option<&str>,
     max_priority: Option<&str>,
     has_all: bool,
-    context: &TezedgeContextClient,
+    cycle_meta_storage: &CycleMetaStorage,
+    chain_id: &ChainId,
+    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -52,16 +72,24 @@ pub(crate) fn check_and_get_baking_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
+        chain_id,
+        env,
         true,
-    )?;
+    )
+    .await?;
 
-    let context_data: RightsContextData = RightsContextData::prepare_context_data_for_rights(
+    let cycle_meta_data = get_cycle_data(
         params.clone(),
-        constants.clone(),
-        (&context_proto_params.block_header.header.context(), context),
+        *params.rights_metadata().block_cycle(),
+        cycle_meta_storage,
     )?;
 
-    get_baking_rights(&context_data, &params, &constants)
+    get_baking_rights(
+        &cycle_meta_data,
+        &params,
+        &constants,
+        params.rights_metadata(),
+    )
 }
 
 /// Use prepared data to generate baking rights
@@ -73,9 +101,10 @@ pub(crate) fn check_and_get_baking_rights(
 /// * `constants` - Context constants used in baking and endorsing rights [RightsConstants](RightsConstants::parse_rights_constants).
 #[inline]
 pub(crate) fn get_baking_rights(
-    context_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
     parameters: &RightsParams,
     constants: &RightsConstants,
+    rights_metadata: &RightsMetadata,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let mut baking_rights = Vec::<BakingRights>::new();
 
@@ -84,22 +113,48 @@ pub(crate) fn get_baking_rights(
 
     let timestamp = parameters.block_timestamp();
     let block_level = parameters.block_level();
+    let cycle_position = *rights_metadata.block_cycle_position();
+
+    // build a reverse map of rols so we have access in O(1)
+    // let rolls_map: HashMap<i32, String> = HashMap::new();
+    let rolls_map: HashMap<i32, String> = cycle_meta_data
+        .rolls_data()
+        .iter()
+        .map(|(delegate, rolls)| {
+            rolls
+                .iter()
+                .map(|roll| {
+                    (
+                        *roll,
+                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
+                            .unwrap()
+                            .to_string_representation(),
+                    )
+                })
+                .collect::<HashMap<i32, String>>()
+        })
+        .flatten()
+        .collect();
 
     // iterate through the whole cycle if necessery
     if let Some(cycle) = parameters.requested_cycle() {
-        let first_block_level = cycle * (blocks_per_cycle as i64) + 1;
-        let last_block_level = first_block_level + (blocks_per_cycle as i64);
+        let first_block_level: i32 = cycle * blocks_per_cycle + 1;
+        let last_block_level = first_block_level + blocks_per_cycle;
 
         for level in first_block_level..last_block_level {
-            let seconds_to_add = (level - block_level).abs() * time_between_blocks[0];
+            let block_level_diff: i64 = (level - block_level).abs().into();
+            let seconds_to_add: i64 = block_level_diff * time_between_blocks[0];
             let estimated_timestamp = timestamp + seconds_to_add;
+            let cycle_position = level_position(level, blocks_per_cycle)?;
 
             // assign rolls goes here
             baking_rights_assign_rolls(
-                &parameters,
-                &constants,
-                &context_data,
-                level.try_into()?,
+                parameters,
+                constants,
+                cycle_meta_data,
+                &rolls_map,
+                level,
+                cycle_position,
                 estimated_timestamp,
                 true,
                 &mut baking_rights,
@@ -109,14 +164,17 @@ pub(crate) fn get_baking_rights(
         }
     } else {
         let level = *parameters.requested_level();
-        let seconds_to_add = (level - block_level).abs() * time_between_blocks[0];
+        let block_level_diff: i64 = (level - block_level).abs().into();
+        let seconds_to_add: i64 = block_level_diff * time_between_blocks[0];
         let estimated_timestamp = timestamp + seconds_to_add;
         // assign rolls goes here
         baking_rights_assign_rolls(
-            &parameters,
-            &constants,
-            &context_data,
-            level.try_into()?,
+            parameters,
+            constants,
+            cycle_meta_data,
+            &rolls_map,
+            level,
+            cycle_position,
             estimated_timestamp,
             false,
             &mut baking_rights,
@@ -155,11 +213,14 @@ pub(crate) fn get_baking_rights(
 ///
 /// Baking priorities are are assigned to Roles, the default behavior is to include only the top priority for the delegate
 #[inline]
+#[allow(clippy::too_many_arguments)]
 fn baking_rights_assign_rolls(
     parameters: &RightsParams,
     constants: &RightsConstants,
-    context_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
+    rolls_map: &HashMap<i32, String>,
     level: i32,
+    cycle_position: i32,
     estimated_head_timestamp: i64,
     is_cycle: bool,
     baking_rights: &mut Vec<BakingRights>,
@@ -174,20 +235,19 @@ fn baking_rights_assign_rolls(
     let max_priority = *parameters.max_priority();
     let has_all = parameters.has_all();
     let block_level = *parameters.block_level();
-    let last_roll = *context_data.last_roll();
-    let rolls_map = context_data.rolls();
-    let display_level: i32 = (*parameters.display_level()).try_into()?;
+    let last_roll = *cycle_meta_data.last_roll();
+    let display_level: i32 = *parameters.display_level();
 
     for priority in 0..max_priority + 1 {
         // draw the rolls for the requested parameters
         let delegate_to_assign;
         // TODO: priority can overflow in the ocaml code, do a priority % i32::max_value()
         let mut state = init_prng(
-            &context_data,
-            &constants,
+            cycle_meta_data,
+            constants,
             BAKING_USE_STRING,
-            level,
-            priority.try_into()?,
+            cycle_position,
+            priority,
         )?;
 
         loop {
@@ -207,7 +267,7 @@ fn baking_rights_assign_rolls(
         }
 
         // we omit the estimated_time field if the block on the requested level is already baked
-        let priority_timestamp = if block_level < (level as i64) {
+        let priority_timestamp = if block_level < level {
             let time = if time_between_blocks.len() == 1 {
                 time_between_blocks[0]
             } else {
@@ -223,7 +283,7 @@ fn baking_rights_assign_rolls(
 
         baking_rights.push(BakingRights::new(
             rights_level,
-            SignaturePublicKeyHash::from_b58_hash(&delegate_to_assign)?,
+            SignaturePublicKeyHash::from_b58_hash(delegate_to_assign)?,
             priority as u16,
             priority_timestamp,
         ));
@@ -236,6 +296,7 @@ fn baking_rights_assign_rolls(
 ///
 /// # Arguments
 ///
+/// * `block_id` - Url path parameter 'block_id', it contains string "head", block level or block hash.
 /// * `level` - Url query parameter 'level'.
 /// * `delegate` - Url query parameter 'delegate'.
 /// * `cycle` - Url query parameter 'cycle'.
@@ -245,13 +306,16 @@ fn baking_rights_assign_rolls(
 /// * `state` - Current RPC collected state (head).
 ///
 /// Prepare all data to generate endorsing rights and then use Tezos PRNG to generate them.
-pub(crate) fn check_and_get_endorsing_rights(
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn check_and_get_endorsing_rights(
     context_proto_params: ContextProtocolParam,
     level: Option<&str>,
     delegate: Option<&str>,
     cycle: Option<&str>,
     has_all: bool,
-    context: &TezedgeContextClient,
+    cycle_meta_storage: &CycleMetaStorage,
+    chain_id: &ChainId,
+    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -264,16 +328,19 @@ pub(crate) fn check_and_get_endorsing_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
+        chain_id,
+        env,
         false,
-    )?;
+    )
+    .await?;
 
-    let context_data: RightsContextData = RightsContextData::prepare_context_data_for_rights(
+    let cycle_meta_data = get_cycle_data(
         params.clone(),
-        constants.clone(),
-        (&context_proto_params.block_header.header.context(), context),
+        *params.rights_metadata().block_cycle(),
+        cycle_meta_storage,
     )?;
 
-    get_endorsing_rights(&context_data, &params, &constants)
+    get_endorsing_rights(&cycle_meta_data, &params, &constants)
 }
 
 /// Use prepared data to generate endosring rights
@@ -284,31 +351,52 @@ pub(crate) fn check_and_get_endorsing_rights(
 /// * `parameters` - Parameters created by [RightsParams](RightsParams::parse_rights_parameters).
 /// * `constants` - Context constants used in baking and endorsing rights [RightsConstants](RightsConstants::parse_rights_constants).
 fn get_endorsing_rights(
-    context_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
     parameters: &RightsParams,
     constants: &RightsConstants,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     // define helper and output variables
     let mut endorsing_rights = Vec::<EndorsingRight>::new();
 
+    let rolls_map: HashMap<i32, String> = cycle_meta_data
+        .rolls_data()
+        .iter()
+        .map(|(delegate, rolls)| {
+            rolls
+                .iter()
+                .map(|roll| {
+                    (
+                        *roll,
+                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
+                            .unwrap()
+                            .to_string_representation(),
+                    )
+                })
+                .collect::<HashMap<i32, String>>()
+        })
+        .flatten()
+        .collect();
+
     // when query param cycle is specified then iterate over all cycle levels, else only given level
     if let Some(cycle) = parameters.requested_cycle() {
         let blocks_per_cycle = *constants.blocks_per_cycle();
-        let first_cycle_level = cycle * (blocks_per_cycle as i64) + 1;
-        let last_cycle_level = first_cycle_level + (blocks_per_cycle as i64);
+        let first_cycle_level = cycle * blocks_per_cycle + 1;
+        let last_cycle_level = first_cycle_level + blocks_per_cycle;
         for level in first_cycle_level..last_cycle_level {
             // get estimated time first because is equal for all endorsers in given level
             // the base level for estimated time computation is level of previous block
             let estimated_time: Option<i64> =
                 parameters.get_estimated_time(constants, Some(level - 1));
+            let cycle_position = level_position(level, blocks_per_cycle)?;
 
             complete_endorsing_rights_for_level(
-                context_data,
+                cycle_meta_data,
                 parameters,
                 constants,
-                level,
+                &rolls_map,
                 level,
                 estimated_time,
+                cycle_position,
                 &mut endorsing_rights,
             )?;
             // endorsing_rights = merge_slices!(&endorsing_rights, &level_endorsing_rights);
@@ -318,12 +406,13 @@ fn get_endorsing_rights(
         let estimated_time: Option<i64> = parameters.get_estimated_time(constants, None);
 
         complete_endorsing_rights_for_level(
-            context_data,
+            cycle_meta_data,
             parameters,
             constants,
-            *parameters.requested_level(),
+            &rolls_map,
             *parameters.display_level(),
             estimated_time,
+            *parameters.rights_metadata().block_cycle_position(),
             &mut endorsing_rights,
         )?;
     };
@@ -347,17 +436,20 @@ fn get_endorsing_rights(
 /// * `display_level` - Level to be displayed in output.
 /// * `estimated_time` - Estimated time of endorsement, is set to None if in past relative to block_id.
 #[inline]
+#[allow(clippy::too_many_arguments)]
 fn complete_endorsing_rights_for_level(
-    context_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
     parameters: &RightsParams,
     constants: &RightsConstants,
-    level: i64,
-    display_level: i64,
+    rolls_map: &HashMap<i32, String>,
+    display_level: i32,
     estimated_time: Option<i64>,
+    cycle_position: i32,
     endorsing_rights: &mut Vec<EndorsingRight>,
 ) -> Result<(), anyhow::Error> {
     // endorsers_slots is needed to group all slots by delegate
-    let endorsers_slots = get_endorsers_slots(constants, context_data, level)?;
+    let endorsers_slots =
+        get_endorsers_slots(constants, cycle_meta_data, rolls_map, cycle_position)?;
 
     // convert contract id to hash contract address hex byte string (needed for ordering)
     let mut endorers_slots_keys_for_order: HashMap<String, String> = HashMap::new();
@@ -388,8 +480,8 @@ fn complete_endorsing_rights_for_level(
         }
 
         endorsing_rights.push(EndorsingRight::new(
-            display_level.try_into()?,
-            SignaturePublicKeyHash::from_b58_hash(&delegate_contract_id)?,
+            display_level,
+            SignaturePublicKeyHash::from_b58_hash(delegate_contract_id)?,
             delegate_data.slots().clone(),
             estimated_time,
         ))
@@ -407,28 +499,29 @@ fn complete_endorsing_rights_for_level(
 #[inline]
 fn get_endorsers_slots(
     constants: &RightsConstants,
-    context_data: &RightsContextData,
-    level: i64,
+    cycle_meta_data: &CycleData,
+    rolls_map: &HashMap<i32, String>,
+    cycle_position: i32,
 ) -> Result<HashMap<String, EndorserSlots>, anyhow::Error> {
     // special byte string used in Tezos PRNG
     const ENDORSEMENT_USE_STRING: &[u8] = b"level endorsement:";
     // prepare helper variable
     let mut endorsers_slots: HashMap<String, EndorserSlots> = HashMap::new();
 
-    for endorser_slot in (0..*constants.endorsers_per_block() as u8).rev() {
+    for endorser_slot in (0..*constants.endorsers_per_block()).rev() {
         // generate PRNG per endorsement slot and take delegates by roll number from context_rolls
         // if roll number is not found then reroll with new state till roll nuber is found in context_rolls
         let mut state = init_prng(
-            &context_data,
-            &constants,
+            cycle_meta_data,
+            constants,
             ENDORSEMENT_USE_STRING,
-            level.try_into()?,
+            cycle_position,
             endorser_slot.try_into()?,
         )?;
         loop {
-            let (random_num, sequence) = get_prng_number(state, *context_data.last_roll())?;
+            let (random_num, sequence) = get_prng_number(state, *cycle_meta_data.last_roll())?;
 
-            if let Some(delegate) = context_data.rolls().get(&random_num) {
+            if let Some(delegate) = rolls_map.get(&random_num) {
                 // collect all slots for each delegate
                 let endorsers_slots_entry = endorsers_slots
                     .entry(delegate.clone())

--- a/rpc/src/services/protocol/proto_008/votes_service.rs
+++ b/rpc/src/services/protocol/proto_008/votes_service.rs
@@ -20,7 +20,7 @@ pub fn get_votes_listings(
     // filter out the listings data
     let mut listings_data = if let Some(val) = env
         .tezedge_context()
-        .get_key_values_by_prefix(&context_hash, context_key_owned!("data/votes/listings"))?
+        .get_key_values_by_prefix(context_hash, context_key_owned!("data/votes/listings"))?
     {
         val
     } else {

--- a/rpc/src/services/protocol/proto_008_2/helpers.rs
+++ b/rpc/src/services/protocol/proto_008_2/helpers.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 use std::convert::TryFrom;
-use std::sync::Arc;
 
-use crypto::hash::ChainId;
 use anyhow::bail;
 use getset::Getters;
 use thiserror::Error;
@@ -16,12 +14,8 @@ use crypto::{
 use storage::cycle_storage::CycleData;
 use storage::{num_from_slice, BlockHeaderWithHash, CycleMetaStorage};
 
-use crate::helpers::{parse_block_hash, BlockMetadata};
 use crate::merge_slices;
-use crate::server::RpcServiceEnvironment;
-use crate::services::protocol::{
-    parse_block_metadata_level, ContextProtocolParam, MetadataParsingError,
-};
+use crate::services::protocol::ContextProtocolParam;
 
 use super::ProtocolConstants;
 
@@ -187,8 +181,6 @@ impl RightsParams {
         param_has_all: bool,
         rights_constants: &RightsConstants,
         block_header: &BlockHeaderWithHash,
-        chain_id: &ChainId,
-        env: &RpcServiceEnvironment,
         is_baking_rights: bool,
     ) -> Result<Self, anyhow::Error> {
         let block_level = block_header.header.level();
@@ -196,6 +188,7 @@ impl RightsParams {
         let blocks_per_cycle = *rights_constants.blocks_per_cycle();
 
         // this is the cycle of block_id level
+        let current_cycle = cycle_from_level(block_level, blocks_per_cycle)?;
 
         // display_level is here because of corner case where all levels < 1 are computed as level 1 but oputputed as they are
         let mut display_level: i32 = block_level;
@@ -230,29 +223,11 @@ impl RightsParams {
             }
         };
 
-        let block_metadata = match crate::services::base_services::get_block_metadata(
-            chain_id,
-            &parse_block_hash(chain_id, &requested_level.to_string(), env)?,
-            env,
-        )
-        .await
-        {
-            Ok(metadata) => Some(metadata),
-            Err(_) => None,
-        };
-
-        let rights_metadata = if let Some(metadata) = block_metadata {
-            RightsMetadata::extract_from_block_metadata(metadata)?
-        } else if param_level.is_some() {
-            RightsMetadata::calculate(blocks_per_cycle, requested_level)?
-        } else {
-            // this should never happen. When block_metadata is not available it means we requested a future level (thus level is always Some())
-            bail!("No level parameter in url")
-        };
+        let rights_metadata = RightsMetadata::calculate(blocks_per_cycle, requested_level)?;
 
         Self::validate_cycle(
             cycle_from_level(requested_level, blocks_per_cycle)?,
-            rights_metadata.block_cycle,
+            current_cycle,
             preserved_cycles,
         )?;
 
@@ -260,7 +235,7 @@ impl RightsParams {
         let requested_cycle = match param_cycle {
             Some(val) => Some(Self::validate_cycle(
                 val.parse()?,
-                rights_metadata.block_cycle,
+                current_cycle,
                 preserved_cycles,
             )?),
             None => None,
@@ -482,24 +457,6 @@ pub struct RightsMetadata {
 }
 
 impl RightsMetadata {
-    pub fn extract_from_block_metadata(
-        block_metadata: Arc<BlockMetadata>,
-    ) -> Result<Self, MetadataParsingError> {
-        let (block_cycle, block_cycle_position) =
-            match parse_block_metadata_level(&block_metadata, "level_info") {
-                Ok(cycle_data) => cycle_data,
-                Err(MetadataParsingError::KeyNotFoundError { key: _ }) => {
-                    // No level info found, trying the older scheme
-                    parse_block_metadata_level(&block_metadata, "level")?
-                }
-                Err(e) => return Err(e),
-            };
-        Ok(Self {
-            block_cycle,
-            block_cycle_position,
-        })
-    }
-
     pub fn calculate(
         blocks_per_cycle: i32,
         requested_level: i32,

--- a/rpc/src/services/protocol/proto_008_2/helpers.rs
+++ b/rpc/src/services/protocol/proto_008_2/helpers.rs
@@ -50,14 +50,15 @@ impl RightsConstants {
     pub(crate) fn parse_rights_constants(
         context_proto_param: &ContextProtocolParam,
     ) -> Result<Self, anyhow::Error> {
-        let protocol_constants: ProtocolConstants = serde_json::from_str(&context_proto_param.constants_data)?;
+        let protocol_constants: ProtocolConstants =
+            serde_json::from_str(&context_proto_param.constants_data)?;
 
         Ok(Self {
             blocks_per_cycle: protocol_constants.blocks_per_cycle,
             preserved_cycles: protocol_constants.preserved_cycles,
             nonce_length: protocol_constants.nonce_length,
             time_between_blocks: protocol_constants.time_between_blocks,
-            endorsers_per_block: protocol_constants.endorsers_per_block ,
+            endorsers_per_block: protocol_constants.endorsers_per_block,
         })
     }
 }
@@ -68,11 +69,7 @@ pub(crate) fn get_cycle_data(
     cycle_meta_storage: &CycleMetaStorage,
 ) -> Result<CycleData, anyhow::Error> {
     // prepare cycle for which rollers are selected
-    let requested_cycle = if let Some(cycle) = *parameters.requested_cycle() {
-        cycle
-    } else {
-        block_cycle
-    };
+    let requested_cycle = parameters.requested_cycle().unwrap_or(block_cycle);
 
     if let Some(cycle_meta_data) = cycle_meta_storage.get(&requested_cycle)? {
         Ok(cycle_meta_data)
@@ -387,9 +384,6 @@ pub fn init_prng(
     let state = cycle_meta_data.seed_bytes();
     let zero_bytes: Vec<u8> = vec![0; nonce_size];
 
-    // the position of the block in its cycle; has to be i32
-    // let cycle_position: i32 = level_position(level, blocks_per_cycle)?;
-
     // take the state (initially the random seed), zero bytes, the use string and the blocks position in the cycle as bytes, merge them together and hash the result
     let rd = blake2b::digest_256(&merge_slices!(
         state,
@@ -462,7 +456,6 @@ impl RightsMetadata {
         requested_level: i32,
     ) -> Result<Self, RightsConstantError> {
         Ok(Self {
-            // (cycle_from_level(requested_level, blocks_per_cycle)?, level_position(requested_level, blocks_per_cycle)?)
             block_cycle: cycle_from_level(requested_level, blocks_per_cycle)?,
             block_cycle_position: level_position(requested_level, blocks_per_cycle)?,
         })

--- a/rpc/src/services/protocol/proto_008_2/helpers.rs
+++ b/rpc/src/services/protocol/proto_008_2/helpers.rs
@@ -23,6 +23,8 @@ use crate::services::protocol::{
     parse_block_metadata_level, ContextProtocolParam, MetadataParsingError,
 };
 
+use super::ProtocolConstants;
+
 /// Context constants used in baking and endorsing rights
 #[derive(Debug, Clone, Getters)]
 pub struct RightsConstants {
@@ -42,10 +44,6 @@ pub struct RightsConstants {
 pub enum RightsConstantError {
     #[error("The value is illegal, key: {key}")]
     WrongValue { key: &'static str },
-    #[error("Key cannot be parsed, key: {key}")]
-    Parsing { key: &'static str },
-    #[error("Key cannot be found in constants, key: {key}")]
-    KeyNotFound { key: &'static str },
 }
 
 impl RightsConstants {
@@ -58,80 +56,14 @@ impl RightsConstants {
     pub(crate) fn parse_rights_constants(
         context_proto_param: &ContextProtocolParam,
     ) -> Result<Self, anyhow::Error> {
-        if let Some(constatns_deserialized) =
-            serde_json::from_str::<serde_json::Value>(&context_proto_param.constants_data)?
-                .as_object()
-        {
-            let blocks_per_cycle = get_constant_i64(constatns_deserialized, "blocks_per_cycle")?;
-            let preserved_cycles = get_constant_i64(constatns_deserialized, "preserved_cycles")?;
-            let nonce_length = get_constant_i64(constatns_deserialized, "nonce_length")?;
-            let time_between_blocks = get_time_between_blocks(constatns_deserialized)?;
-            let endorsers_per_block =
-                get_constant_i64(constatns_deserialized, "endorsers_per_block")?;
+        let protocol_constants: ProtocolConstants = serde_json::from_str(&context_proto_param.constants_data)?;
 
-            Ok(Self {
-                blocks_per_cycle: blocks_per_cycle as i32,
-                preserved_cycles: preserved_cycles as u8,
-                nonce_length: nonce_length as u8,
-                time_between_blocks,
-                endorsers_per_block: endorsers_per_block as u16,
-            })
-        } else {
-            bail!("Constants not an object")
-        }
-    }
-}
-
-fn get_constant_i64(
-    constants: &serde_json::Map<String, serde_json::Value>,
-    key: &'static str,
-) -> Result<i64, RightsConstantError> {
-    if let Some(value) = constants.get(key) {
-        if let Some(i64_value) = value.as_i64() {
-            Ok(i64_value)
-        } else {
-            if let Some(str_num) = value.as_str() {
-                return str_num
-                    .parse()
-                    .map_err(|_| RightsConstantError::Parsing { key });
-            }
-            Err(RightsConstantError::Parsing { key })
-        }
-    } else {
-        Err(RightsConstantError::KeyNotFound { key })
-    }
-}
-
-fn get_time_between_blocks(
-    constants: &serde_json::Map<String, serde_json::Value>,
-) -> Result<Vec<i64>, RightsConstantError> {
-    let mut ret: Vec<i64> = Vec::new();
-    if let Some(value) = constants.get("time_between_blocks") {
-        if let Some(array) = value.as_array() {
-            for e in array {
-                if let Some(str_element) = e.as_str() {
-                    let parsed =
-                        str_element
-                            .parse::<i64>()
-                            .map_err(|_| RightsConstantError::Parsing {
-                                key: "time_between_blocks",
-                            })?;
-                    ret.push(parsed);
-                } else {
-                    return Err(RightsConstantError::Parsing {
-                        key: "time_between_blocks",
-                    });
-                }
-            }
-            Ok(ret)
-        } else {
-            Err(RightsConstantError::Parsing {
-                key: "time_between_blocks",
-            })
-        }
-    } else {
-        Err(RightsConstantError::KeyNotFound {
-            key: "time_between_blocks",
+        Ok(Self {
+            blocks_per_cycle: protocol_constants.blocks_per_cycle,
+            preserved_cycles: protocol_constants.preserved_cycles,
+            nonce_length: protocol_constants.nonce_length,
+            time_between_blocks: protocol_constants.time_between_blocks,
+            endorsers_per_block: protocol_constants.endorsers_per_block ,
         })
     }
 }

--- a/rpc/src/services/protocol/proto_008_2/helpers.rs
+++ b/rpc/src/services/protocol/proto_008_2/helpers.rs
@@ -1,26 +1,27 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::sync::Arc;
 
-use anyhow::{bail, format_err};
+use crypto::hash::ChainId;
+use anyhow::bail;
 use getset::Getters;
-use tezos_context::context_key_owned;
 use thiserror::Error;
 
-use crypto::hash::ContextHash;
 use crypto::{
     blake2b::{self, Blake2bError},
     crypto_box::PublicKeyError,
 };
-use storage::{num_from_slice, BlockHeaderWithHash};
-use tezos_messages::base::signature_public_key_hash::SignaturePublicKeyHash;
-use tezos_messages::p2p::binary_message::BinaryRead;
-use tezos_wrapper::TezedgeContextClient;
+use storage::cycle_storage::CycleData;
+use storage::{num_from_slice, BlockHeaderWithHash, CycleMetaStorage};
 
+use crate::helpers::{parse_block_hash, BlockMetadata};
 use crate::merge_slices;
-use crate::services::protocol::ContextProtocolParam;
+use crate::server::RpcServiceEnvironment;
+use crate::services::protocol::{
+    parse_block_metadata_level, ContextProtocolParam, MetadataParsingError,
+};
 
 /// Context constants used in baking and endorsing rights
 #[derive(Debug, Clone, Getters)]
@@ -34,31 +35,20 @@ pub struct RightsConstants {
     #[get = "pub(crate)"]
     time_between_blocks: Vec<i64>,
     #[get = "pub(crate)"]
-    blocks_per_roll_snapshot: i32,
-    #[get = "pub(crate)"]
     endorsers_per_block: u16,
 }
 
-impl RightsConstants {
-    /// simple constructor to create RightsConstants
-    pub fn new(
-        blocks_per_cycle: i32,
-        preserved_cycles: u8,
-        nonce_length: u8,
-        time_between_blocks: Vec<i64>,
-        blocks_per_roll_snapshot: i32,
-        endorsers_per_block: u16,
-    ) -> Self {
-        Self {
-            blocks_per_cycle,
-            preserved_cycles,
-            nonce_length,
-            time_between_blocks,
-            blocks_per_roll_snapshot,
-            endorsers_per_block,
-        }
-    }
+#[derive(Debug, Error)]
+pub enum RightsConstantError {
+    #[error("The value is illegal, key: {key}")]
+    WrongValue { key: &'static str },
+    #[error("Key cannot be parsed, key: {key}")]
+    Parsing { key: &'static str },
+    #[error("Key cannot be found in constants, key: {key}")]
+    KeyNotFound { key: &'static str },
+}
 
+impl RightsConstants {
     /// Get all context constants which are used in endorsing and baking rights generation
     ///
     /// # Arguments
@@ -68,165 +58,103 @@ impl RightsConstants {
     pub(crate) fn parse_rights_constants(
         context_proto_param: &ContextProtocolParam,
     ) -> Result<Self, anyhow::Error> {
-        let dynamic =
-            tezos_messages::protocol::proto_008_2::constants::ParametricConstants::from_bytes(
-                &context_proto_param.constants_data,
-            )?;
-        let fixed = tezos_messages::protocol::proto_008_2::constants::FIXED;
-
-        Ok(RightsConstants::new(
-            dynamic.blocks_per_cycle(),
-            dynamic.preserved_cycles(),
-            fixed.nonce_length(),
-            dynamic.time_between_blocks().clone(),
-            dynamic.blocks_per_roll_snapshot(),
-            dynamic.endorsers_per_block(),
-        ))
-    }
-}
-
-/// Data from context DB for completing baking and endorsing rights
-#[derive(Debug, Clone, Getters)]
-pub struct RightsContextData {
-    /// Random seed for Tezos PRNG
-    #[get = "pub(crate)"]
-    random_seed: Vec<u8>,
-
-    /// Number of last roll so Tezos PRNG will not overflow
-    #[get = "pub(crate)"]
-    last_roll: i32,
-
-    /// List of rolls mapped to rollers contract id
-    #[get = "pub(crate)"]
-    rolls: HashMap<i32, String>,
-}
-
-impl RightsContextData {
-    /// Simple constructor to create RightsContextData
-    pub fn new(random_seed: Vec<u8>, last_roll: i32, rolls: HashMap<i32, String>) -> Self {
-        Self {
-            random_seed,
-            last_roll,
-            rolls,
-        }
-    }
-
-    /// Get context data roll_snapshot, random_seed, last_roll and rolls from context list
-    ///
-    /// # Arguments
-    ///
-    /// * `parameters` - Parameters created by [RightsParams](RightsParams::parse_rights_parameters).
-    /// * `constants` - Context constants used in baking and endorsing rights.
-    /// * `list` - Context list handler.
-    ///
-    /// Return RightsContextData.
-    pub(crate) fn prepare_context_data_for_rights(
-        parameters: RightsParams,
-        constants: RightsConstants,
-        (ctx_hash, context): (&ContextHash, &TezedgeContextClient),
-    ) -> Result<Self, anyhow::Error> {
-        // prepare constants that are used
-        let blocks_per_cycle = *constants.blocks_per_cycle();
-
-        // prepare parameters that are used
-        let requested_level = *parameters.requested_level();
-
-        // prepare cycle for which rollers are selected
-        let requested_cycle = if let Some(cycle) = *parameters.requested_cycle() {
-            cycle
-        } else {
-            cycle_from_level(requested_level, blocks_per_cycle)?
-        };
-
-        // get index of roll snapshot
-        let roll_snapshot: i16 = {
-            if let Some(data) = context.get_key_from_history(
-                &ctx_hash,
-                context_key_owned!("data/cycle/{}/roll_snapshot", requested_cycle),
-            )? {
-                num_from_slice!(data, 0, i16)
-            } else {
-                // key not found - prepare error for later processing
-                return Err(format_err!("roll_snapshot"));
-            }
-        };
-
-        let random_seed = {
-            if let Some(data) = context.get_key_from_history(
-                &ctx_hash,
-                context_key_owned!("data/cycle/{}/random_seed", requested_cycle),
-            )? {
-                data
-            } else {
-                // key not found - prepare error for later processing
-                return Err(format_err!("random_seed"));
-            }
-        };
-
-        // Snapshots of last_roll are listed from 0 same as roll_snapshot.
-        let last_roll = {
-            if let Some(data) = context.get_key_from_history(
-                &ctx_hash,
-                context_key_owned!("data/cycle/{}/last_roll/{}", requested_cycle, roll_snapshot),
-            )? {
-                num_from_slice!(data, 0, i32)
-            } else {
-                // key not found - prepare error for later processing
-                return Err(format_err!("last_roll"));
-            }
-        };
-
-        // get list of rolls from context list
-        let context_rolls = if let Some(rolls) =
-            Self::get_context_rolls((&ctx_hash, &context), requested_cycle, roll_snapshot)?
+        if let Some(constatns_deserialized) =
+            serde_json::from_str::<serde_json::Value>(&context_proto_param.constants_data)?
+                .as_object()
         {
-            rolls
-        } else {
-            return Err(format_err!("rolls"));
-        };
+            let blocks_per_cycle = get_constant_i64(constatns_deserialized, "blocks_per_cycle")?;
+            let preserved_cycles = get_constant_i64(constatns_deserialized, "preserved_cycles")?;
+            let nonce_length = get_constant_i64(constatns_deserialized, "nonce_length")?;
+            let time_between_blocks = get_time_between_blocks(constatns_deserialized)?;
+            let endorsers_per_block =
+                get_constant_i64(constatns_deserialized, "endorsers_per_block")?;
 
-        Ok(Self::new(random_seed.to_vec(), last_roll, context_rolls))
+            Ok(Self {
+                blocks_per_cycle: blocks_per_cycle as i32,
+                preserved_cycles: preserved_cycles as u8,
+                nonce_length: nonce_length as u8,
+                time_between_blocks,
+                endorsers_per_block: endorsers_per_block as u16,
+            })
+        } else {
+            bail!("Constants not an object")
+        }
     }
+}
 
-    /// get list of rollers from context list selected by snapshot level
-    ///
-    /// # Arguments
-    ///
-    /// * `context` - context list HashMap from [get_context_as_hashmap](RightsContextData::get_context_as_hashmap)
-    ///
-    /// Return rollers for [RightsContextData.rolls](RightsContextData.rolls)
-    fn get_context_rolls(
-        (ctx_hash, context): (&ContextHash, &TezedgeContextClient),
-        cycle: i64,
-        snapshot: i16,
-    ) -> Result<Option<HashMap<i32, String>>, anyhow::Error> {
-        let rolls = if let Some(val) = context.get_key_values_by_prefix(
-            &ctx_hash,
-            context_key_owned!("data/rolls/owner/snapshot/{}/{}", cycle, snapshot),
-        )? {
-            val
+fn get_constant_i64(
+    constants: &serde_json::Map<String, serde_json::Value>,
+    key: &'static str,
+) -> Result<i64, RightsConstantError> {
+    if let Some(value) = constants.get(key) {
+        if let Some(i64_value) = value.as_i64() {
+            Ok(i64_value)
         } else {
-            bail!("No rolls found in context")
-        };
-
-        let mut roll_owners: HashMap<i32, String> = HashMap::new();
-
-        // iterate through all the owners,the roll_num is the last component of the key, decode the value (it is a public key) to get the public key hash address (tz1...)
-        for (key, value) in rolls.into_iter() {
-            if key.last().is_none() {
-                continue;
+            if let Some(str_num) = value.as_str() {
+                return str_num
+                    .parse()
+                    .map_err(|_| RightsConstantError::Parsing { key });
             }
-            let roll_num = key.last().unwrap();
+            Err(RightsConstantError::Parsing { key })
+        }
+    } else {
+        Err(RightsConstantError::KeyNotFound { key })
+    }
+}
 
-            // the values are public keys
-            let delegate = SignaturePublicKeyHash::from_tagged_bytes(value.clone())?
-                .to_string_representation();
-            roll_owners.insert(roll_num.parse()?, delegate);
+fn get_time_between_blocks(
+    constants: &serde_json::Map<String, serde_json::Value>,
+) -> Result<Vec<i64>, RightsConstantError> {
+    let mut ret: Vec<i64> = Vec::new();
+    if let Some(value) = constants.get("time_between_blocks") {
+        if let Some(array) = value.as_array() {
+            for e in array {
+                if let Some(str_element) = e.as_str() {
+                    let parsed =
+                        str_element
+                            .parse::<i64>()
+                            .map_err(|_| RightsConstantError::Parsing {
+                                key: "time_between_blocks",
+                            })?;
+                    ret.push(parsed);
+                } else {
+                    return Err(RightsConstantError::Parsing {
+                        key: "time_between_blocks",
+                    });
+                }
+            }
+            Ok(ret)
+        } else {
+            Err(RightsConstantError::Parsing {
+                key: "time_between_blocks",
+            })
         }
-        if roll_owners.is_empty() {
-            bail!("No rolls assigned, all rolls happened to be DELETED")
-        }
-        Ok(Some(roll_owners))
+    } else {
+        Err(RightsConstantError::KeyNotFound {
+            key: "time_between_blocks",
+        })
+    }
+}
+
+pub(crate) fn get_cycle_data(
+    parameters: RightsParams,
+    block_cycle: i32,
+    cycle_meta_storage: &CycleMetaStorage,
+) -> Result<CycleData, anyhow::Error> {
+    // prepare cycle for which rollers are selected
+    let requested_cycle = if let Some(cycle) = *parameters.requested_cycle() {
+        cycle
+    } else {
+        block_cycle
+    };
+
+    if let Some(cycle_meta_data) = cycle_meta_storage.get(&requested_cycle)? {
+        Ok(cycle_meta_data)
+    } else {
+        bail!(
+            "No cycle data found for requested_cycle: {}",
+            requested_cycle
+        )
     }
 }
 
@@ -235,7 +163,7 @@ impl RightsContextData {
 pub struct RightsParams {
     /// Level (height) of block. Parsed from url path parameter 'block_id'.
     #[get = "pub(crate)"]
-    block_level: i64,
+    block_level: i32,
 
     /// Header timestamp of block. Parsed from url path parameter 'block_id'.
     #[get = "pub(crate)"]
@@ -247,41 +175,46 @@ pub struct RightsParams {
 
     /// Cycle for whitch all rights will be listed. Url query parameter 'cycle'.
     #[get = "pub(crate)"]
-    requested_cycle: Option<i64>,
+    requested_cycle: Option<i32>,
 
     /// Level (height) of block for whitch all rights will be listed. Url query parameter 'level'.
     #[get = "pub(crate)"]
-    requested_level: i64,
+    requested_level: i32,
 
     /// Level to be displayed in output.
     #[get = "pub(crate)"]
-    display_level: i64,
+    display_level: i32,
 
     /// Level for estimated_time computation. Endorsing rights only.
     #[get = "pub(crate)"]
-    timestamp_level: i64,
+    timestamp_level: i32,
 
     /// Max priority to which baking rights are listed. Url query parameter 'max_priority'.
     #[get = "pub(crate)"]
-    max_priority: i64,
+    max_priority: i32,
 
     /// Indicate that baking rights for maximum priority should be listed. Url query parameter 'all'.
     #[get = "pub(crate)"]
     has_all: bool,
+
+    #[get = "pub(crate)"]
+    rights_metadata: RightsMetadata,
 }
 
 impl RightsParams {
     /// Simple constructor to create RightsParams
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
-        block_level: i64,
+        block_level: i32,
         block_timestamp: i64,
         requested_delegate: Option<String>,
-        requested_cycle: Option<i64>,
-        requested_level: i64,
-        display_level: i64,
-        timestamp_level: i64,
-        max_priority: i64,
+        requested_cycle: Option<i32>,
+        requested_level: i32,
+        display_level: i32,
+        timestamp_level: i32,
+        max_priority: i32,
         has_all: bool,
+        rights_metadata: RightsMetadata,
     ) -> Self {
         Self {
             block_level,
@@ -293,6 +226,7 @@ impl RightsParams {
             timestamp_level,
             max_priority,
             has_all,
+            rights_metadata,
         }
     }
 
@@ -312,7 +246,8 @@ impl RightsParams {
     /// * `is_baking_rights` - flag to identify if are parsed baking or endorsing rights
     ///
     /// Return RightsParams
-    pub(crate) fn parse_rights_parameters(
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn parse_rights_parameters(
         param_level: Option<&str>,
         param_delegate: Option<&str>,
         param_cycle: Option<&str>,
@@ -320,30 +255,25 @@ impl RightsParams {
         param_has_all: bool,
         rights_constants: &RightsConstants,
         block_header: &BlockHeaderWithHash,
+        chain_id: &ChainId,
+        env: &RpcServiceEnvironment,
         is_baking_rights: bool,
     ) -> Result<Self, anyhow::Error> {
-        let block_level: i64 = block_header.header.level().into();
+        let block_level = block_header.header.level();
         let preserved_cycles = *rights_constants.preserved_cycles();
         let blocks_per_cycle = *rights_constants.blocks_per_cycle();
 
         // this is the cycle of block_id level
-        let current_cycle = cycle_from_level(block_level, blocks_per_cycle)?;
 
         // display_level is here because of corner case where all levels < 1 are computed as level 1 but oputputed as they are
-        let mut display_level: i64 = block_level;
+        let mut display_level: i32 = block_level;
         // endorsing rights only: timestamp_level is the base level for timestamp computation is taken from last known block (block_id) timestamp + time_between_blocks[0]
-        let mut timestamp_level: i64 = block_level;
+        let mut timestamp_level: i32 = block_level;
         // Check the param_level, if there is a level specified validate it, if no set it to the block_level
         // requested_level is used to get data from context list
-        let requested_level: i64 = match param_level {
+        let requested_level: i32 = match param_level {
             Some(level) => {
                 let level = level.parse()?;
-                // check the bounds for the requested level (if it is in the previous/next preserved cycles)
-                Self::validate_cycle(
-                    cycle_from_level(level, blocks_per_cycle)?,
-                    current_cycle,
-                    preserved_cycles,
-                )?;
                 // display level is always same as level requested
                 display_level = level;
                 // endorsing rights: to compute timestamp for level parameter there need to be taken timestamp of previous block
@@ -368,11 +298,37 @@ impl RightsParams {
             }
         };
 
+        let block_metadata = match crate::services::base_services::get_block_metadata(
+            chain_id,
+            &parse_block_hash(chain_id, &requested_level.to_string(), env)?,
+            env,
+        )
+        .await
+        {
+            Ok(metadata) => Some(metadata),
+            Err(_) => None,
+        };
+
+        let rights_metadata = if let Some(metadata) = block_metadata {
+            RightsMetadata::extract_from_block_metadata(metadata)?
+        } else if param_level.is_some() {
+            RightsMetadata::calculate(blocks_per_cycle, requested_level)?
+        } else {
+            // this should never happen. When block_metadata is not available it means we requested a future level (thus level is always Some())
+            bail!("No level parameter in url")
+        };
+
+        Self::validate_cycle(
+            cycle_from_level(requested_level, blocks_per_cycle)?,
+            rights_metadata.block_cycle,
+            preserved_cycles,
+        )?;
+
         // validate requested cycle
         let requested_cycle = match param_cycle {
             Some(val) => Some(Self::validate_cycle(
                 val.parse()?,
-                current_cycle,
+                rights_metadata.block_cycle,
                 preserved_cycles,
             )?),
             None => None,
@@ -400,6 +356,7 @@ impl RightsParams {
             timestamp_level, // endorsing rights only
             max_priority,
             param_has_all,
+            rights_metadata,
         ))
     }
 
@@ -415,7 +372,7 @@ impl RightsParams {
     pub fn get_estimated_time(
         &self,
         constants: &RightsConstants,
-        level: Option<i64>,
+        level: Option<i32>,
     ) -> Option<i64> {
         // if is cycle then level is provided as parameter else use prepared timestamp_level
         let timestamp_level = level.unwrap_or(self.timestamp_level);
@@ -434,13 +391,17 @@ impl RightsParams {
     /// Validate if cycle requested as url query parameter (cycle or level) is available in context list by checking preserved_cycles constant
     #[inline]
     fn validate_cycle(
-        requested_cycle: i64,
-        current_cycle: i64,
+        requested_cycle: i32,
+        current_cycle: i32,
         preserved_cycles: u8,
-    ) -> Result<i64, anyhow::Error> {
-        if (requested_cycle - current_cycle).abs() <= (preserved_cycles as i64) {
+    ) -> Result<i32, anyhow::Error> {
+        if (requested_cycle - current_cycle).abs() <= preserved_cycles.into() {
             Ok(requested_cycle)
         } else {
+            // TODO: proper json response is needed for this
+            // Octez is:
+            //    [{ "kind": "permanent", "id": "proto.008-PtEdo2Zk.seed.unknown_seed",
+            //        "oldest": 330, "requested": 200, "latest": 340 }]
             bail!("Requested cycle out of bounds") //TODO: prepare cycle error
         }
     }
@@ -467,47 +428,6 @@ impl EndorserSlots {
     /// Push endorsing slot to slots
     pub fn push_to_slot(&mut self, slot: u16) {
         self.slots.push(slot);
-    }
-}
-
-/// Return cycle in which is given level
-///
-/// # Arguments
-///
-/// * `level` - level to specify cycle for
-/// * `blocks_per_cycle` - context constant
-///
-/// Level 0 (genesis block) is not part of any cycle (cycle 0 starts at level 1),
-/// hence the blocks_per_cycle - 1 for last cycle block.
-pub fn cycle_from_level(level: i64, blocks_per_cycle: i32) -> Result<i64, anyhow::Error> {
-    // check if blocks_per_cycle is not 0 to prevent panic
-    if blocks_per_cycle > 0 {
-        Ok((level - 1) / (blocks_per_cycle as i64))
-    } else {
-        bail!("wrong value blocks_per_cycle={}", blocks_per_cycle)
-    }
-}
-
-/// Return the position of the block in its cycle
-///
-/// # Arguments
-///
-/// * `level` - level to specify cycle for
-/// * `blocks_per_cycle` - context constant
-///
-/// Level 0 (genesis block) is not part of any cycle (cycle 0 starts at level 1),
-/// hence the blocks_per_cycle - 1 for last cycle block.
-pub fn level_position(level: i32, blocks_per_cycle: i32) -> Result<i32, anyhow::Error> {
-    // check if blocks_per_cycle is not 0 to prevent panic
-    if blocks_per_cycle <= 0 {
-        bail!("wrong value blocks_per_cycle={}", blocks_per_cycle);
-    }
-    let cycle_position = (level % blocks_per_cycle) - 1;
-    if cycle_position < 0 {
-        //for last block
-        Ok(blocks_per_cycle - 1)
-    } else {
-        Ok(cycle_position)
     }
 }
 
@@ -549,24 +469,23 @@ pub type TezosPRNGResult = Result<(i32, RandomSeedState), TezosPRNGError>;
 /// Return first random sequence state to use in [get_prng_number](`get_prng_number`)
 #[inline]
 pub fn init_prng(
-    cycle_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
     constants: &RightsConstants,
     use_string_bytes: &[u8],
-    level: i32,
+    cycle_position: i32,
     offset: i32,
 ) -> Result<RandomSeedState, anyhow::Error> {
     // a safe way to convert betwwen types is to use try_from
     let nonce_size = usize::try_from(*constants.nonce_length())?;
-    let blocks_per_cycle = *constants.blocks_per_cycle();
-    let state = cycle_data.random_seed();
+    let state = cycle_meta_data.seed_bytes();
     let zero_bytes: Vec<u8> = vec![0; nonce_size];
 
     // the position of the block in its cycle; has to be i32
-    let cycle_position: i32 = level_position(level, blocks_per_cycle)?;
+    // let cycle_position: i32 = level_position(level, blocks_per_cycle)?;
 
     // take the state (initially the random seed), zero bytes, the use string and the blocks position in the cycle as bytes, merge them together and hash the result
     let rd = blake2b::digest_256(&merge_slices!(
-        &state,
+        state,
         &zero_bytes,
         use_string_bytes,
         &cycle_position.to_be_bytes()
@@ -619,4 +538,89 @@ pub fn get_prng_number(state: RandomSeedState, bound: i32) -> TezosPRNGResult {
         };
     }
     Ok((v, sequence))
+}
+
+#[derive(Debug, Clone, Getters)]
+pub struct RightsMetadata {
+    #[get = "pub(crate)"]
+    block_cycle: i32,
+
+    #[get = "pub(crate)"]
+    block_cycle_position: i32,
+}
+
+impl RightsMetadata {
+    pub fn extract_from_block_metadata(
+        block_metadata: Arc<BlockMetadata>,
+    ) -> Result<Self, MetadataParsingError> {
+        let (block_cycle, block_cycle_position) =
+            match parse_block_metadata_level(&block_metadata, "level_info") {
+                Ok(cycle_data) => cycle_data,
+                Err(MetadataParsingError::KeyNotFoundError { key: _ }) => {
+                    // No level info found, trying the older scheme
+                    parse_block_metadata_level(&block_metadata, "level")?
+                }
+                Err(e) => return Err(e),
+            };
+        Ok(Self {
+            block_cycle,
+            block_cycle_position,
+        })
+    }
+
+    pub fn calculate(
+        blocks_per_cycle: i32,
+        requested_level: i32,
+    ) -> Result<Self, RightsConstantError> {
+        Ok(Self {
+            // (cycle_from_level(requested_level, blocks_per_cycle)?, level_position(requested_level, blocks_per_cycle)?)
+            block_cycle: cycle_from_level(requested_level, blocks_per_cycle)?,
+            block_cycle_position: level_position(requested_level, blocks_per_cycle)?,
+        })
+    }
+}
+
+/// Return cycle in which is given level
+///
+/// # Arguments
+///
+/// * `level` - level to specify cycle for
+/// * `blocks_per_cycle` - context constant
+///
+/// Level 0 (genesis block) is not part of any cycle (cycle 0 starts at level 1),
+/// hence the blocks_per_cycle - 1 for last cycle block.
+pub fn cycle_from_level(level: i32, blocks_per_cycle: i32) -> Result<i32, RightsConstantError> {
+    // check if blocks_per_cycle is not 0 to prevent panic
+    if blocks_per_cycle > 0 {
+        Ok((level - 1) / blocks_per_cycle)
+    } else {
+        Err(RightsConstantError::WrongValue {
+            key: "blocks_per_cycle",
+        })
+    }
+}
+
+/// Return the position of the block in its cycle
+///
+/// # Arguments
+///
+/// * `level` - level to specify cycle for
+/// * `blocks_per_cycle` - context constant
+///
+/// Level 0 (genesis block) is not part of any cycle (cycle 0 starts at level 1),
+/// hence the blocks_per_cycle - 1 for last cycle block.
+pub fn level_position(level: i32, blocks_per_cycle: i32) -> Result<i32, RightsConstantError> {
+    // check if blocks_per_cycle is not 0 to prevent panic
+    if blocks_per_cycle <= 0 {
+        return Err(RightsConstantError::WrongValue {
+            key: "blocks_per_cycle",
+        });
+    }
+    let cycle_position = (level % blocks_per_cycle) - 1;
+    if cycle_position < 0 {
+        //for last block
+        Ok(blocks_per_cycle - 1)
+    } else {
+        Ok(cycle_position)
+    }
 }

--- a/rpc/src/services/protocol/proto_008_2/mod.rs
+++ b/rpc/src/services/protocol/proto_008_2/mod.rs
@@ -1,6 +1,81 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
+use serde::Deserialize;
+use getset::CopyGetters;
+use num::BigInt;
+
 mod helpers;
 pub(crate) mod rights_service;
 pub(crate) mod votes_service;
+
+use super::{vec_string_to_int, string_to_int};
+
+#[derive(Debug, Deserialize, Clone, CopyGetters)]
+pub(crate) struct ProtocolConstants {
+    proof_of_work_nonce_size: u8,
+    nonce_length: u8,
+    max_anon_ops_per_block: u8,
+    max_operation_data_length: i32,
+    max_proposals_per_delegate: u8,
+    preserved_cycles: u8,
+
+    #[get_copy = "pub(crate)"]
+    blocks_per_cycle: i32,
+    
+    blocks_per_commitment: i32,
+    blocks_per_roll_snapshot: i32,
+    blocks_per_voting_period: i32,
+
+    #[serde(with = "vec_string_to_int")]
+    time_between_blocks: Vec<i64>,
+    
+    endorsers_per_block: u16,
+
+    #[serde(with = "string_to_int")]
+    hard_gas_limit_per_operation: BigInt,
+
+    #[serde(with = "string_to_int")]
+    hard_gas_limit_per_block: BigInt,
+
+    #[serde(with = "string_to_int")]
+    proof_of_work_threshold: BigInt,
+
+    #[serde(with = "string_to_int")]
+    tokens_per_roll: BigInt,
+    michelson_maximum_type_size: u16,
+
+    #[serde(with = "string_to_int")]
+    seed_nonce_revelation_tip: BigInt,
+
+    origination_size: i32,
+
+    #[serde(with = "string_to_int")]
+    block_security_deposit: BigInt,
+
+    #[serde(with = "string_to_int")]
+    endorsement_security_deposit: BigInt,
+
+    #[serde(with = "vec_string_to_int")]
+    baking_reward_per_endorsement: Vec<BigInt>,
+
+    #[serde(with = "vec_string_to_int")]
+    endorsement_reward: Vec<BigInt>,
+
+    #[serde(with = "string_to_int")]
+    cost_per_byte: BigInt,
+
+    #[serde(with = "string_to_int")]
+    hard_storage_limit_per_operation: BigInt,
+
+    quorum_min: i32,
+    quorum_max: i32,
+    min_proposal_quorum: i32,
+    initial_endorsers: u16,
+
+    #[serde(with = "string_to_int")]
+    delay_per_missing_endorsement: i64,
+
+    #[serde(with = "string_to_int")]
+    test_chain_duration: i64,
+}

--- a/rpc/src/services/protocol/proto_008_2/mod.rs
+++ b/rpc/src/services/protocol/proto_008_2/mod.rs
@@ -1,15 +1,15 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use serde::Deserialize;
 use getset::CopyGetters;
 use num::BigInt;
+use serde::Deserialize;
 
 mod helpers;
 pub(crate) mod rights_service;
 pub(crate) mod votes_service;
 
-use super::{vec_string_to_int, string_to_int};
+use super::{string_to_int, vec_string_to_int};
 
 #[derive(Debug, Deserialize, Clone, CopyGetters)]
 pub(crate) struct ProtocolConstants {
@@ -22,14 +22,14 @@ pub(crate) struct ProtocolConstants {
 
     #[get_copy = "pub(crate)"]
     blocks_per_cycle: i32,
-    
+
     blocks_per_commitment: i32,
     blocks_per_roll_snapshot: i32,
     blocks_per_voting_period: i32,
 
     #[serde(with = "vec_string_to_int")]
     time_between_blocks: Vec<i64>,
-    
+
     endorsers_per_block: u16,
 
     #[serde(with = "string_to_int")]

--- a/rpc/src/services/protocol/proto_008_2/rights_service.rs
+++ b/rpc/src/services/protocol/proto_008_2/rights_service.rs
@@ -1,27 +1,44 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
+// TODO: (anagy) - check TODO's
+// TODO: refactor errors so this will be removed
+// Enum defining possible response structures for RPC calls
+// there is reason to have this structure because of format of error responses from ocaml node:
+// [{"kind":"permanent","id":"proto.005-PsBabyM1.context.storage_error","missing_key":["cycle","4","random_seed"],"function":"get"}]
+// [{"kind":"permanent","id":"proto.005-PsBabyM1.seed.unknown_seed","oldest":9,"requested":20,"latest":15}]
+// if there have to be same response format then RpcErrorMsg is covering it
+// this enum can be removed if errors are generated from error context directly in result_to_json_response function
+
 use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;
 
 use anyhow::format_err;
 use itertools::Itertools;
 
-use crate::services::dev_services::contract_id_to_contract_address_for_index;
+use crypto::hash::ChainId;
 use tezos_messages::base::rpc_support::{RpcJsonMap, ToRpcJsonMap};
 use tezos_messages::base::signature_public_key_hash::SignaturePublicKeyHash;
 use tezos_messages::protocol::proto_008_2::rights::{BakingRights, EndorsingRight};
-use tezos_wrapper::TezedgeContextClient;
 
+use storage::cycle_storage::CycleData;
+use storage::CycleMetaStorage;
+
+use crate::server::RpcServiceEnvironment;
+use crate::services::dev_services::contract_id_to_contract_address_for_index;
 use crate::services::protocol::proto_008_2::helpers::{
-    get_prng_number, init_prng, EndorserSlots, RightsConstants, RightsContextData, RightsParams,
+    get_cycle_data, get_prng_number, init_prng, level_position, EndorserSlots, RightsConstants,
+    RightsParams,
 };
 use crate::services::protocol::ContextProtocolParam;
+
+use super::helpers::RightsMetadata;
 
 /// Return generated baking rights.
 ///
 /// # Arguments
 ///
+/// * `block_id` - Url path parameter 'block_id', it contains string "head", block level or block hash.
 /// * `level` - Url query parameter 'level'.
 /// * `delegate` - Url query parameter 'delegate'.
 /// * `cycle` - Url query parameter 'cycle'.
@@ -32,14 +49,17 @@ use crate::services::protocol::ContextProtocolParam;
 /// * `state` - Current RPC collected state (head).
 ///
 /// Prepare all data to generate baking rights and then use Tezos PRNG to generate them.
-pub(crate) fn check_and_get_baking_rights(
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn check_and_get_baking_rights(
     context_proto_params: ContextProtocolParam,
     level: Option<&str>,
     delegate: Option<&str>,
     cycle: Option<&str>,
     max_priority: Option<&str>,
     has_all: bool,
-    context: &TezedgeContextClient,
+    cycle_meta_storage: &CycleMetaStorage,
+    chain_id: &ChainId,
+    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -52,16 +72,24 @@ pub(crate) fn check_and_get_baking_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
+        chain_id,
+        env,
         true,
-    )?;
+    )
+    .await?;
 
-    let context_data: RightsContextData = RightsContextData::prepare_context_data_for_rights(
+    let cycle_meta_data = get_cycle_data(
         params.clone(),
-        constants.clone(),
-        (&context_proto_params.block_header.header.context(), context),
+        *params.rights_metadata().block_cycle(),
+        cycle_meta_storage,
     )?;
 
-    get_baking_rights(&context_data, &params, &constants)
+    get_baking_rights(
+        &cycle_meta_data,
+        &params,
+        &constants,
+        params.rights_metadata(),
+    )
 }
 
 /// Use prepared data to generate baking rights
@@ -73,9 +101,10 @@ pub(crate) fn check_and_get_baking_rights(
 /// * `constants` - Context constants used in baking and endorsing rights [RightsConstants](RightsConstants::parse_rights_constants).
 #[inline]
 pub(crate) fn get_baking_rights(
-    context_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
     parameters: &RightsParams,
     constants: &RightsConstants,
+    rights_metadata: &RightsMetadata,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let mut baking_rights = Vec::<BakingRights>::new();
 
@@ -84,22 +113,48 @@ pub(crate) fn get_baking_rights(
 
     let timestamp = parameters.block_timestamp();
     let block_level = parameters.block_level();
+    let cycle_position = *rights_metadata.block_cycle_position();
+
+    // build a reverse map of rols so we have access in O(1)
+    // let rolls_map: HashMap<i32, String> = HashMap::new();
+    let rolls_map: HashMap<i32, String> = cycle_meta_data
+        .rolls_data()
+        .iter()
+        .map(|(delegate, rolls)| {
+            rolls
+                .iter()
+                .map(|roll| {
+                    (
+                        *roll,
+                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
+                            .unwrap()
+                            .to_string_representation(),
+                    )
+                })
+                .collect::<HashMap<i32, String>>()
+        })
+        .flatten()
+        .collect();
 
     // iterate through the whole cycle if necessery
     if let Some(cycle) = parameters.requested_cycle() {
-        let first_block_level = cycle * (blocks_per_cycle as i64) + 1;
-        let last_block_level = first_block_level + (blocks_per_cycle as i64);
+        let first_block_level: i32 = cycle * blocks_per_cycle + 1;
+        let last_block_level = first_block_level + blocks_per_cycle;
 
         for level in first_block_level..last_block_level {
-            let seconds_to_add = (level - block_level).abs() * time_between_blocks[0];
+            let block_level_diff: i64 = (level - block_level).abs().into();
+            let seconds_to_add: i64 = block_level_diff * time_between_blocks[0];
             let estimated_timestamp = timestamp + seconds_to_add;
+            let cycle_position = level_position(level, blocks_per_cycle)?;
 
             // assign rolls goes here
             baking_rights_assign_rolls(
-                &parameters,
-                &constants,
-                &context_data,
-                level.try_into()?,
+                parameters,
+                constants,
+                cycle_meta_data,
+                &rolls_map,
+                level,
+                cycle_position,
                 estimated_timestamp,
                 true,
                 &mut baking_rights,
@@ -109,14 +164,17 @@ pub(crate) fn get_baking_rights(
         }
     } else {
         let level = *parameters.requested_level();
-        let seconds_to_add = (level - block_level).abs() * time_between_blocks[0];
+        let block_level_diff: i64 = (level - block_level).abs().into();
+        let seconds_to_add: i64 = block_level_diff * time_between_blocks[0];
         let estimated_timestamp = timestamp + seconds_to_add;
         // assign rolls goes here
         baking_rights_assign_rolls(
-            &parameters,
-            &constants,
-            &context_data,
-            level.try_into()?,
+            parameters,
+            constants,
+            cycle_meta_data,
+            &rolls_map,
+            level,
+            cycle_position,
             estimated_timestamp,
             false,
             &mut baking_rights,
@@ -155,11 +213,14 @@ pub(crate) fn get_baking_rights(
 ///
 /// Baking priorities are are assigned to Roles, the default behavior is to include only the top priority for the delegate
 #[inline]
+#[allow(clippy::too_many_arguments)]
 fn baking_rights_assign_rolls(
     parameters: &RightsParams,
     constants: &RightsConstants,
-    context_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
+    rolls_map: &HashMap<i32, String>,
     level: i32,
+    cycle_position: i32,
     estimated_head_timestamp: i64,
     is_cycle: bool,
     baking_rights: &mut Vec<BakingRights>,
@@ -174,20 +235,19 @@ fn baking_rights_assign_rolls(
     let max_priority = *parameters.max_priority();
     let has_all = parameters.has_all();
     let block_level = *parameters.block_level();
-    let last_roll = *context_data.last_roll();
-    let rolls_map = context_data.rolls();
-    let display_level: i32 = (*parameters.display_level()).try_into()?;
+    let last_roll = *cycle_meta_data.last_roll();
+    let display_level: i32 = *parameters.display_level();
 
     for priority in 0..max_priority + 1 {
         // draw the rolls for the requested parameters
         let delegate_to_assign;
         // TODO: priority can overflow in the ocaml code, do a priority % i32::max_value()
         let mut state = init_prng(
-            &context_data,
-            &constants,
+            cycle_meta_data,
+            constants,
             BAKING_USE_STRING,
-            level,
-            priority.try_into()?,
+            cycle_position,
+            priority,
         )?;
 
         loop {
@@ -207,7 +267,7 @@ fn baking_rights_assign_rolls(
         }
 
         // we omit the estimated_time field if the block on the requested level is already baked
-        let priority_timestamp = if block_level < (level as i64) {
+        let priority_timestamp = if block_level < level {
             let time = if time_between_blocks.len() == 1 {
                 time_between_blocks[0]
             } else {
@@ -223,7 +283,7 @@ fn baking_rights_assign_rolls(
 
         baking_rights.push(BakingRights::new(
             rights_level,
-            SignaturePublicKeyHash::from_b58_hash(&delegate_to_assign)?,
+            SignaturePublicKeyHash::from_b58_hash(delegate_to_assign)?,
             priority as u16,
             priority_timestamp,
         ));
@@ -236,6 +296,7 @@ fn baking_rights_assign_rolls(
 ///
 /// # Arguments
 ///
+/// * `block_id` - Url path parameter 'block_id', it contains string "head", block level or block hash.
 /// * `level` - Url query parameter 'level'.
 /// * `delegate` - Url query parameter 'delegate'.
 /// * `cycle` - Url query parameter 'cycle'.
@@ -245,13 +306,16 @@ fn baking_rights_assign_rolls(
 /// * `state` - Current RPC collected state (head).
 ///
 /// Prepare all data to generate endorsing rights and then use Tezos PRNG to generate them.
-pub(crate) fn check_and_get_endorsing_rights(
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn check_and_get_endorsing_rights(
     context_proto_params: ContextProtocolParam,
     level: Option<&str>,
     delegate: Option<&str>,
     cycle: Option<&str>,
     has_all: bool,
-    context: &TezedgeContextClient,
+    cycle_meta_storage: &CycleMetaStorage,
+    chain_id: &ChainId,
+    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -264,16 +328,19 @@ pub(crate) fn check_and_get_endorsing_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
+        chain_id,
+        env,
         false,
-    )?;
+    )
+    .await?;
 
-    let context_data: RightsContextData = RightsContextData::prepare_context_data_for_rights(
+    let cycle_meta_data = get_cycle_data(
         params.clone(),
-        constants.clone(),
-        (&context_proto_params.block_header.header.context(), context),
+        *params.rights_metadata().block_cycle(),
+        cycle_meta_storage,
     )?;
 
-    get_endorsing_rights(&context_data, &params, &constants)
+    get_endorsing_rights(&cycle_meta_data, &params, &constants)
 }
 
 /// Use prepared data to generate endosring rights
@@ -284,31 +351,52 @@ pub(crate) fn check_and_get_endorsing_rights(
 /// * `parameters` - Parameters created by [RightsParams](RightsParams::parse_rights_parameters).
 /// * `constants` - Context constants used in baking and endorsing rights [RightsConstants](RightsConstants::parse_rights_constants).
 fn get_endorsing_rights(
-    context_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
     parameters: &RightsParams,
     constants: &RightsConstants,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     // define helper and output variables
     let mut endorsing_rights = Vec::<EndorsingRight>::new();
 
+    let rolls_map: HashMap<i32, String> = cycle_meta_data
+        .rolls_data()
+        .iter()
+        .map(|(delegate, rolls)| {
+            rolls
+                .iter()
+                .map(|roll| {
+                    (
+                        *roll,
+                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
+                            .unwrap()
+                            .to_string_representation(),
+                    )
+                })
+                .collect::<HashMap<i32, String>>()
+        })
+        .flatten()
+        .collect();
+
     // when query param cycle is specified then iterate over all cycle levels, else only given level
     if let Some(cycle) = parameters.requested_cycle() {
         let blocks_per_cycle = *constants.blocks_per_cycle();
-        let first_cycle_level = cycle * (blocks_per_cycle as i64) + 1;
-        let last_cycle_level = first_cycle_level + (blocks_per_cycle as i64);
+        let first_cycle_level = cycle * blocks_per_cycle + 1;
+        let last_cycle_level = first_cycle_level + blocks_per_cycle;
         for level in first_cycle_level..last_cycle_level {
             // get estimated time first because is equal for all endorsers in given level
             // the base level for estimated time computation is level of previous block
             let estimated_time: Option<i64> =
                 parameters.get_estimated_time(constants, Some(level - 1));
+            let cycle_position = level_position(level, blocks_per_cycle)?;
 
             complete_endorsing_rights_for_level(
-                context_data,
+                cycle_meta_data,
                 parameters,
                 constants,
-                level,
+                &rolls_map,
                 level,
                 estimated_time,
+                cycle_position,
                 &mut endorsing_rights,
             )?;
             // endorsing_rights = merge_slices!(&endorsing_rights, &level_endorsing_rights);
@@ -318,12 +406,13 @@ fn get_endorsing_rights(
         let estimated_time: Option<i64> = parameters.get_estimated_time(constants, None);
 
         complete_endorsing_rights_for_level(
-            context_data,
+            cycle_meta_data,
             parameters,
             constants,
-            *parameters.requested_level(),
+            &rolls_map,
             *parameters.display_level(),
             estimated_time,
+            *parameters.rights_metadata().block_cycle_position(),
             &mut endorsing_rights,
         )?;
     };
@@ -347,17 +436,20 @@ fn get_endorsing_rights(
 /// * `display_level` - Level to be displayed in output.
 /// * `estimated_time` - Estimated time of endorsement, is set to None if in past relative to block_id.
 #[inline]
+#[allow(clippy::too_many_arguments)]
 fn complete_endorsing_rights_for_level(
-    context_data: &RightsContextData,
+    cycle_meta_data: &CycleData,
     parameters: &RightsParams,
     constants: &RightsConstants,
-    level: i64,
-    display_level: i64,
+    rolls_map: &HashMap<i32, String>,
+    display_level: i32,
     estimated_time: Option<i64>,
+    cycle_position: i32,
     endorsing_rights: &mut Vec<EndorsingRight>,
 ) -> Result<(), anyhow::Error> {
     // endorsers_slots is needed to group all slots by delegate
-    let endorsers_slots = get_endorsers_slots(constants, context_data, level)?;
+    let endorsers_slots =
+        get_endorsers_slots(constants, cycle_meta_data, rolls_map, cycle_position)?;
 
     // convert contract id to hash contract address hex byte string (needed for ordering)
     let mut endorers_slots_keys_for_order: HashMap<String, String> = HashMap::new();
@@ -388,8 +480,8 @@ fn complete_endorsing_rights_for_level(
         }
 
         endorsing_rights.push(EndorsingRight::new(
-            display_level.try_into()?,
-            SignaturePublicKeyHash::from_b58_hash(&delegate_contract_id)?,
+            display_level,
+            SignaturePublicKeyHash::from_b58_hash(delegate_contract_id)?,
             delegate_data.slots().clone(),
             estimated_time,
         ))
@@ -407,28 +499,29 @@ fn complete_endorsing_rights_for_level(
 #[inline]
 fn get_endorsers_slots(
     constants: &RightsConstants,
-    context_data: &RightsContextData,
-    level: i64,
+    cycle_meta_data: &CycleData,
+    rolls_map: &HashMap<i32, String>,
+    cycle_position: i32,
 ) -> Result<HashMap<String, EndorserSlots>, anyhow::Error> {
     // special byte string used in Tezos PRNG
     const ENDORSEMENT_USE_STRING: &[u8] = b"level endorsement:";
     // prepare helper variable
     let mut endorsers_slots: HashMap<String, EndorserSlots> = HashMap::new();
 
-    for endorser_slot in (0..*constants.endorsers_per_block() as u8).rev() {
+    for endorser_slot in (0..*constants.endorsers_per_block()).rev() {
         // generate PRNG per endorsement slot and take delegates by roll number from context_rolls
         // if roll number is not found then reroll with new state till roll nuber is found in context_rolls
         let mut state = init_prng(
-            &context_data,
-            &constants,
+            cycle_meta_data,
+            constants,
             ENDORSEMENT_USE_STRING,
-            level.try_into()?,
+            cycle_position,
             endorser_slot.try_into()?,
         )?;
         loop {
-            let (random_num, sequence) = get_prng_number(state, *context_data.last_roll())?;
+            let (random_num, sequence) = get_prng_number(state, *cycle_meta_data.last_roll())?;
 
-            if let Some(delegate) = context_data.rolls().get(&random_num) {
+            if let Some(delegate) = rolls_map.get(&random_num) {
                 // collect all slots for each delegate
                 let endorsers_slots_entry = endorsers_slots
                     .entry(delegate.clone())

--- a/rpc/src/services/protocol/proto_008_2/rights_service.rs
+++ b/rpc/src/services/protocol/proto_008_2/rights_service.rs
@@ -110,25 +110,17 @@ pub(crate) fn get_baking_rights(
     let cycle_position = *rights_metadata.block_cycle_position();
 
     // build a reverse map of rols so we have access in O(1)
-    // let rolls_map: HashMap<i32, String> = HashMap::new();
-    let rolls_map: HashMap<i32, String> = cycle_meta_data
-        .rolls_data()
-        .iter()
-        .map(|(delegate, rolls)| {
-            rolls
-                .iter()
-                .map(|roll| {
-                    (
-                        *roll,
-                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
-                            .unwrap()
-                            .to_string_representation(),
-                    )
-                })
-                .collect::<HashMap<i32, String>>()
-        })
-        .flatten()
-        .collect();
+    let mut rolls_map: HashMap<i32, String> = HashMap::new();
+
+    for (delegate, rolls) in cycle_meta_data.rolls_data() {
+        for roll in rolls {
+            rolls_map.insert(
+                *roll,
+                SignaturePublicKeyHash::from_tagged_bytes(delegate.to_vec())?
+                    .to_string_representation(),
+            );
+        }
+    }
 
     // iterate through the whole cycle if necessery
     if let Some(cycle) = parameters.requested_cycle() {
@@ -348,24 +340,18 @@ fn get_endorsing_rights(
     // define helper and output variables
     let mut endorsing_rights = Vec::<EndorsingRight>::new();
 
-    let rolls_map: HashMap<i32, String> = cycle_meta_data
-        .rolls_data()
-        .iter()
-        .map(|(delegate, rolls)| {
-            rolls
-                .iter()
-                .map(|roll| {
-                    (
-                        *roll,
-                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
-                            .unwrap()
-                            .to_string_representation(),
-                    )
-                })
-                .collect::<HashMap<i32, String>>()
-        })
-        .flatten()
-        .collect();
+    // build a reverse map of rols so we have access in O(1)
+    let mut rolls_map: HashMap<i32, String> = HashMap::new();
+
+    for (delegate, rolls) in cycle_meta_data.rolls_data() {
+        for roll in rolls {
+            rolls_map.insert(
+                *roll,
+                SignaturePublicKeyHash::from_tagged_bytes(delegate.to_vec())?
+                    .to_string_representation(),
+            );
+        }
+    }
 
     // when query param cycle is specified then iterate over all cycle levels, else only given level
     if let Some(cycle) = parameters.requested_cycle() {

--- a/rpc/src/services/protocol/proto_008_2/rights_service.rs
+++ b/rpc/src/services/protocol/proto_008_2/rights_service.rs
@@ -16,7 +16,6 @@ use std::convert::TryInto;
 use anyhow::format_err;
 use itertools::Itertools;
 
-use crypto::hash::ChainId;
 use tezos_messages::base::rpc_support::{RpcJsonMap, ToRpcJsonMap};
 use tezos_messages::base::signature_public_key_hash::SignaturePublicKeyHash;
 use tezos_messages::protocol::proto_008_2::rights::{BakingRights, EndorsingRight};
@@ -24,7 +23,6 @@ use tezos_messages::protocol::proto_008_2::rights::{BakingRights, EndorsingRight
 use storage::cycle_storage::CycleData;
 use storage::CycleMetaStorage;
 
-use crate::server::RpcServiceEnvironment;
 use crate::services::dev_services::contract_id_to_contract_address_for_index;
 use crate::services::protocol::proto_008_2::helpers::{
     get_cycle_data, get_prng_number, init_prng, level_position, EndorserSlots, RightsConstants,
@@ -58,8 +56,6 @@ pub(crate) async fn check_and_get_baking_rights(
     max_priority: Option<&str>,
     has_all: bool,
     cycle_meta_storage: &CycleMetaStorage,
-    chain_id: &ChainId,
-    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -72,8 +68,6 @@ pub(crate) async fn check_and_get_baking_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
-        chain_id,
-        env,
         true,
     )
     .await?;
@@ -314,8 +308,6 @@ pub(crate) async fn check_and_get_endorsing_rights(
     cycle: Option<&str>,
     has_all: bool,
     cycle_meta_storage: &CycleMetaStorage,
-    chain_id: &ChainId,
-    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -328,8 +320,6 @@ pub(crate) async fn check_and_get_endorsing_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
-        chain_id,
-        env,
         false,
     )
     .await?;

--- a/rpc/src/services/protocol/proto_008_2/votes_service.rs
+++ b/rpc/src/services/protocol/proto_008_2/votes_service.rs
@@ -20,7 +20,7 @@ pub fn get_votes_listings(
     // filter out the listings data
     let mut listings_data = if let Some(val) = env
         .tezedge_context()
-        .get_key_values_by_prefix(&context_hash, context_key_owned!("data/votes/listings"))?
+        .get_key_values_by_prefix(context_hash, context_key_owned!("data/votes/listings"))?
     {
         val
     } else {

--- a/rpc/src/services/protocol/proto_009/helpers.rs
+++ b/rpc/src/services/protocol/proto_009/helpers.rs
@@ -23,6 +23,8 @@ use crate::services::protocol::{
     parse_block_metadata_level, ContextProtocolParam, MetadataParsingError,
 };
 
+use super::ProtocolConstants;
+
 /// Context constants used in baking and endorsing rights
 #[derive(Debug, Clone, Getters)]
 pub struct RightsConstants {
@@ -42,10 +44,6 @@ pub struct RightsConstants {
 pub enum RightsConstantError {
     #[error("The value is illegal, key: {key}")]
     WrongValue { key: &'static str },
-    #[error("Key cannot be parsed, key: {key}")]
-    Parsing { key: &'static str },
-    #[error("Key cannot be found in constants, key: {key}")]
-    KeyNotFound { key: &'static str },
 }
 
 impl RightsConstants {
@@ -58,83 +56,14 @@ impl RightsConstants {
     pub(crate) fn parse_rights_constants(
         context_proto_param: &ContextProtocolParam,
     ) -> Result<Self, anyhow::Error> {
-        // let constatns_deserialized = context_proto_param.constants_data;
+        let protocol_constants: ProtocolConstants = serde_json::from_str(&context_proto_param.constants_data)?;
 
-        // TODO: fix unwraps
-        if let Some(constatns_deserialized) =
-            serde_json::from_str::<serde_json::Value>(&context_proto_param.constants_data)?
-                .as_object()
-        {
-            let blocks_per_cycle = get_constant_i64(constatns_deserialized, "blocks_per_cycle")?;
-            let preserved_cycles = get_constant_i64(constatns_deserialized, "preserved_cycles")?;
-            let nonce_length = get_constant_i64(constatns_deserialized, "nonce_length")?;
-            let time_between_blocks = get_time_between_blocks(constatns_deserialized)?;
-            let endorsers_per_block =
-                get_constant_i64(constatns_deserialized, "endorsers_per_block")?;
-
-            Ok(Self {
-                blocks_per_cycle: blocks_per_cycle as i32,
-                preserved_cycles: preserved_cycles as u8,
-                nonce_length: nonce_length as u8,
-                time_between_blocks,
-                endorsers_per_block: endorsers_per_block as u16,
-            })
-        } else {
-            bail!("Constants not an object")
-        }
-    }
-}
-
-fn get_constant_i64(
-    constants: &serde_json::Map<String, serde_json::Value>,
-    key: &'static str,
-) -> Result<i64, RightsConstantError> {
-    if let Some(value) = constants.get(key) {
-        if let Some(i64_value) = value.as_i64() {
-            Ok(i64_value)
-        } else {
-            if let Some(str_num) = value.as_str() {
-                return str_num
-                    .parse()
-                    .map_err(|_| RightsConstantError::Parsing { key });
-            }
-            Err(RightsConstantError::Parsing { key })
-        }
-    } else {
-        Err(RightsConstantError::KeyNotFound { key })
-    }
-}
-
-fn get_time_between_blocks(
-    constants: &serde_json::Map<String, serde_json::Value>,
-) -> Result<Vec<i64>, RightsConstantError> {
-    let mut ret: Vec<i64> = Vec::new();
-    if let Some(value) = constants.get("time_between_blocks") {
-        if let Some(array) = value.as_array() {
-            for e in array {
-                if let Some(str_element) = e.as_str() {
-                    let parsed =
-                        str_element
-                            .parse::<i64>()
-                            .map_err(|_| RightsConstantError::Parsing {
-                                key: "time_between_blocks",
-                            })?;
-                    ret.push(parsed);
-                } else {
-                    return Err(RightsConstantError::Parsing {
-                        key: "time_between_blocks",
-                    });
-                }
-            }
-            Ok(ret)
-        } else {
-            Err(RightsConstantError::Parsing {
-                key: "time_between_blocks",
-            })
-        }
-    } else {
-        Err(RightsConstantError::KeyNotFound {
-            key: "time_between_blocks",
+        Ok(Self {
+            blocks_per_cycle: protocol_constants.blocks_per_cycle,
+            preserved_cycles: protocol_constants.preserved_cycles,
+            nonce_length: protocol_constants.nonce_length,
+            time_between_blocks: protocol_constants.time_between_blocks,
+            endorsers_per_block: protocol_constants.endorsers_per_block ,
         })
     }
 }

--- a/rpc/src/services/protocol/proto_009/helpers.rs
+++ b/rpc/src/services/protocol/proto_009/helpers.rs
@@ -2,13 +2,11 @@
 // SPDX-License-Identifier: MIT
 
 use std::convert::TryFrom;
-use std::sync::Arc;
 
 use anyhow::bail;
 use getset::Getters;
 use thiserror::Error;
 
-use crypto::hash::ChainId;
 use crypto::{
     blake2b::{self, Blake2bError},
     crypto_box::PublicKeyError,
@@ -16,12 +14,8 @@ use crypto::{
 use storage::cycle_storage::CycleData;
 use storage::{num_from_slice, BlockHeaderWithHash, CycleMetaStorage};
 
-use crate::helpers::{parse_block_hash, BlockMetadata};
 use crate::merge_slices;
-use crate::server::RpcServiceEnvironment;
-use crate::services::protocol::{
-    parse_block_metadata_level, ContextProtocolParam, MetadataParsingError,
-};
+use crate::services::protocol::ContextProtocolParam;
 
 use super::ProtocolConstants;
 
@@ -186,8 +180,6 @@ impl RightsParams {
         param_has_all: bool,
         rights_constants: &RightsConstants,
         block_header: &BlockHeaderWithHash,
-        chain_id: &ChainId,
-        env: &RpcServiceEnvironment,
         is_baking_rights: bool,
     ) -> Result<Self, anyhow::Error> {
         let block_level: i32 = block_header.header.level();
@@ -195,7 +187,7 @@ impl RightsParams {
         let blocks_per_cycle = *rights_constants.blocks_per_cycle();
 
         // this is the cycle of block_id level
-        // let current_cycle = cycle_from_level(block_level, blocks_per_cycle)?;
+        let current_cycle = cycle_from_level(block_level, blocks_per_cycle)?;
 
         // display_level is here because of corner case where all levels < 1 are computed as level 1 but oputputed as they are
         let mut display_level: i32 = block_level;
@@ -230,29 +222,11 @@ impl RightsParams {
             }
         };
 
-        let block_metadata = match crate::services::base_services::get_block_metadata(
-            chain_id,
-            &parse_block_hash(chain_id, &requested_level.to_string(), env)?,
-            env,
-        )
-        .await
-        {
-            Ok(metadata) => Some(metadata),
-            Err(_) => None,
-        };
-
-        let rights_metadata = if let Some(metadata) = block_metadata {
-            RightsMetadata::extract_from_block_metadata(metadata)?
-        } else if param_level.is_some() {
-            RightsMetadata::calculate(blocks_per_cycle, requested_level)?
-        } else {
-            // this should never happen. When block_metadata is not available it means we requested a future level (thus level is always Some())
-            bail!("No level parameter in url")
-        };
+        let rights_metadata = RightsMetadata::calculate(blocks_per_cycle, requested_level)?;
 
         Self::validate_cycle(
             cycle_from_level(requested_level, blocks_per_cycle)?,
-            rights_metadata.block_cycle,
+            current_cycle,
             preserved_cycles,
         )?;
 
@@ -260,7 +234,7 @@ impl RightsParams {
         let requested_cycle = match param_cycle {
             Some(val) => Some(Self::validate_cycle(
                 val.parse()?,
-                rights_metadata.block_cycle,
+                current_cycle,
                 preserved_cycles,
             )?),
             None => None,
@@ -327,7 +301,7 @@ impl RightsParams {
         current_cycle: i32,
         preserved_cycles: u8,
     ) -> Result<i32, anyhow::Error> {
-        if (requested_cycle - current_cycle).abs() <= (preserved_cycles as i32) {
+        if (requested_cycle - current_cycle).abs() <= preserved_cycles.into() {
             Ok(requested_cycle)
         } else {
             // TODO: proper json response is needed for this
@@ -479,24 +453,6 @@ pub struct RightsMetadata {
 }
 
 impl RightsMetadata {
-    pub fn extract_from_block_metadata(
-        block_metadata: Arc<BlockMetadata>,
-    ) -> Result<Self, MetadataParsingError> {
-        let (block_cycle, block_cycle_position) =
-            match parse_block_metadata_level(&block_metadata, "level_info") {
-                Ok(cycle_data) => cycle_data,
-                Err(MetadataParsingError::KeyNotFoundError { key: _ }) => {
-                    // No level info found, trying the older scheme
-                    parse_block_metadata_level(&block_metadata, "level")?
-                }
-                Err(e) => return Err(e),
-            };
-        Ok(Self {
-            block_cycle,
-            block_cycle_position,
-        })
-    }
-
     pub fn calculate(
         blocks_per_cycle: i32,
         requested_level: i32,

--- a/rpc/src/services/protocol/proto_009/helpers.rs
+++ b/rpc/src/services/protocol/proto_009/helpers.rs
@@ -50,14 +50,15 @@ impl RightsConstants {
     pub(crate) fn parse_rights_constants(
         context_proto_param: &ContextProtocolParam,
     ) -> Result<Self, anyhow::Error> {
-        let protocol_constants: ProtocolConstants = serde_json::from_str(&context_proto_param.constants_data)?;
+        let protocol_constants: ProtocolConstants =
+            serde_json::from_str(&context_proto_param.constants_data)?;
 
         Ok(Self {
             blocks_per_cycle: protocol_constants.blocks_per_cycle,
             preserved_cycles: protocol_constants.preserved_cycles,
             nonce_length: protocol_constants.nonce_length,
             time_between_blocks: protocol_constants.time_between_blocks,
-            endorsers_per_block: protocol_constants.endorsers_per_block ,
+            endorsers_per_block: protocol_constants.endorsers_per_block,
         })
     }
 }
@@ -68,11 +69,7 @@ pub(crate) fn get_cycle_data(
     cycle_meta_storage: &CycleMetaStorage,
 ) -> Result<CycleData, anyhow::Error> {
     // prepare cycle for which rollers are selected
-    let requested_cycle = if let Some(cycle) = *parameters.requested_cycle() {
-        cycle
-    } else {
-        block_cycle
-    };
+    let requested_cycle = parameters.requested_cycle().unwrap_or(block_cycle);
 
     if let Some(cycle_meta_data) = cycle_meta_storage.get(&requested_cycle)? {
         Ok(cycle_meta_data)
@@ -458,7 +455,6 @@ impl RightsMetadata {
         requested_level: i32,
     ) -> Result<Self, RightsConstantError> {
         Ok(Self {
-            // (cycle_from_level(requested_level, blocks_per_cycle)?, level_position(requested_level, blocks_per_cycle)?)
             block_cycle: cycle_from_level(requested_level, blocks_per_cycle)?,
             block_cycle_position: level_position(requested_level, blocks_per_cycle)?,
         })

--- a/rpc/src/services/protocol/proto_009/mod.rs
+++ b/rpc/src/services/protocol/proto_009/mod.rs
@@ -1,6 +1,81 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
+use serde::Deserialize;
+use getset::CopyGetters;
+use num::BigInt;
+
 mod helpers;
 pub(crate) mod rights_service;
 pub(crate) mod votes_service;
+
+use super::{vec_string_to_int, string_to_int};
+
+#[derive(Debug, Deserialize, Clone, CopyGetters)]
+pub(crate) struct ProtocolConstants {
+    proof_of_work_nonce_size: u8,
+    nonce_length: u8,
+    max_anon_ops_per_block: u8,
+    max_operation_data_length: i32,
+    max_proposals_per_delegate: u8,
+    preserved_cycles: u8,
+
+    #[get_copy = "pub(crate)"]
+    blocks_per_cycle: i32,
+    
+    blocks_per_commitment: i32,
+    blocks_per_roll_snapshot: i32,
+    blocks_per_voting_period: i32,
+
+    #[serde(with = "vec_string_to_int")]
+    time_between_blocks: Vec<i64>,
+    
+    endorsers_per_block: u16,
+
+    #[serde(with = "string_to_int")]
+    hard_gas_limit_per_operation: BigInt,
+
+    #[serde(with = "string_to_int")]
+    hard_gas_limit_per_block: BigInt,
+
+    #[serde(with = "string_to_int")]
+    proof_of_work_threshold: BigInt,
+
+    #[serde(with = "string_to_int")]
+    tokens_per_roll: BigInt,
+    michelson_maximum_type_size: u16,
+
+    #[serde(with = "string_to_int")]
+    seed_nonce_revelation_tip: BigInt,
+
+    origination_size: i32,
+
+    #[serde(with = "string_to_int")]
+    block_security_deposit: BigInt,
+
+    #[serde(with = "string_to_int")]
+    endorsement_security_deposit: BigInt,
+
+    #[serde(with = "vec_string_to_int")]
+    baking_reward_per_endorsement: Vec<BigInt>,
+
+    #[serde(with = "vec_string_to_int")]
+    endorsement_reward: Vec<BigInt>,
+
+    #[serde(with = "string_to_int")]
+    cost_per_byte: BigInt,
+
+    #[serde(with = "string_to_int")]
+    hard_storage_limit_per_operation: BigInt,
+
+    quorum_min: i32,
+    quorum_max: i32,
+    min_proposal_quorum: i32,
+    initial_endorsers: u16,
+
+    #[serde(with = "string_to_int")]
+    delay_per_missing_endorsement: i64,
+
+    #[serde(with = "string_to_int")]
+    test_chain_duration: i64,
+}

--- a/rpc/src/services/protocol/proto_009/mod.rs
+++ b/rpc/src/services/protocol/proto_009/mod.rs
@@ -1,0 +1,6 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+mod helpers;
+pub(crate) mod rights_service;
+pub(crate) mod votes_service;

--- a/rpc/src/services/protocol/proto_009/mod.rs
+++ b/rpc/src/services/protocol/proto_009/mod.rs
@@ -1,15 +1,15 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use serde::Deserialize;
 use getset::CopyGetters;
 use num::BigInt;
+use serde::Deserialize;
 
 mod helpers;
 pub(crate) mod rights_service;
 pub(crate) mod votes_service;
 
-use super::{vec_string_to_int, string_to_int};
+use super::{string_to_int, vec_string_to_int};
 
 #[derive(Debug, Deserialize, Clone, CopyGetters)]
 pub(crate) struct ProtocolConstants {
@@ -22,14 +22,14 @@ pub(crate) struct ProtocolConstants {
 
     #[get_copy = "pub(crate)"]
     blocks_per_cycle: i32,
-    
+
     blocks_per_commitment: i32,
     blocks_per_roll_snapshot: i32,
     blocks_per_voting_period: i32,
 
     #[serde(with = "vec_string_to_int")]
     time_between_blocks: Vec<i64>,
-    
+
     endorsers_per_block: u16,
 
     #[serde(with = "string_to_int")]

--- a/rpc/src/services/protocol/proto_009/rights_service.rs
+++ b/rpc/src/services/protocol/proto_009/rights_service.rs
@@ -98,24 +98,17 @@ pub(crate) fn get_baking_rights(
     let cycle_position = *rights_metadata.block_cycle_position();
 
     // build a reverse map of rols so we have access in O(1)
-    let rolls_map: HashMap<i32, String> = cycle_meta_data
-        .rolls_data()
-        .iter()
-        .map(|(delegate, rolls)| {
-            rolls
-                .iter()
-                .map(|roll| {
-                    (
-                        *roll,
-                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
-                            .unwrap()
-                            .to_string_representation(),
-                    )
-                })
-                .collect::<HashMap<i32, String>>()
-        })
-        .flatten()
-        .collect();
+    let mut rolls_map: HashMap<i32, String> = HashMap::new();
+
+    for (delegate, rolls) in cycle_meta_data.rolls_data() {
+        for roll in rolls {
+            rolls_map.insert(
+                *roll,
+                SignaturePublicKeyHash::from_tagged_bytes(delegate.to_vec())?
+                    .to_string_representation(),
+            );
+        }
+    }
 
     // iterate through the whole cycle if necessery
     if let Some(cycle) = parameters.requested_cycle() {
@@ -335,24 +328,18 @@ fn get_endorsing_rights(
     // define helper and output variables
     let mut endorsing_rights = Vec::<EndorsingRight>::new();
 
-    let rolls_map: HashMap<i32, String> = cycle_meta_data
-        .rolls_data()
-        .iter()
-        .map(|(delegate, rolls)| {
-            rolls
-                .iter()
-                .map(|roll| {
-                    (
-                        *roll,
-                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
-                            .unwrap()
-                            .to_string_representation(),
-                    )
-                })
-                .collect::<HashMap<i32, String>>()
-        })
-        .flatten()
-        .collect();
+    // build a reverse map of rols so we have access in O(1)
+    let mut rolls_map: HashMap<i32, String> = HashMap::new();
+
+    for (delegate, rolls) in cycle_meta_data.rolls_data() {
+        for roll in rolls {
+            rolls_map.insert(
+                *roll,
+                SignaturePublicKeyHash::from_tagged_bytes(delegate.to_vec())?
+                    .to_string_representation(),
+            );
+        }
+    }
 
     // when query param cycle is specified then iterate over all cycle levels, else only given level
     if let Some(cycle) = parameters.requested_cycle() {

--- a/rpc/src/services/protocol/proto_009/rights_service.rs
+++ b/rpc/src/services/protocol/proto_009/rights_service.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;
 
 use crypto::hash::ChainId;
-use failure::format_err;
+use anyhow::format_err;
 use itertools::Itertools;
 
 use crate::server::RpcServiceEnvironment;
@@ -48,7 +48,7 @@ pub(crate) async fn check_and_get_baking_rights(
     cycle_meta_storage: &CycleMetaStorage,
     chain_id: &ChainId,
     env: &RpcServiceEnvironment,
-) -> Result<Option<Vec<RpcJsonMap>>, failure::Error> {
+) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
 
@@ -93,7 +93,7 @@ pub(crate) fn get_baking_rights(
     parameters: &RightsParams,
     constants: &RightsConstants,
     rights_metadata: &RightsMetadata,
-) -> Result<Option<Vec<RpcJsonMap>>, failure::Error> {
+) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let mut baking_rights = Vec::<BakingRights>::new();
 
     let blocks_per_cycle: i32 = *constants.blocks_per_cycle();
@@ -212,7 +212,7 @@ fn baking_rights_assign_rolls(
     estimated_head_timestamp: i64,
     is_cycle: bool,
     baking_rights: &mut Vec<BakingRights>,
-) -> Result<(), failure::Error> {
+) -> Result<(), anyhow::Error> {
     const BAKING_USE_STRING: &[u8] = b"level baking:";
 
     // hashset is defined to keep track of the delegates with priorities already assigned
@@ -303,7 +303,7 @@ pub(crate) async fn check_and_get_endorsing_rights(
     cycle_meta_storage: &CycleMetaStorage,
     chain_id: &ChainId,
     env: &RpcServiceEnvironment,
-) -> Result<Option<Vec<RpcJsonMap>>, failure::Error> {
+) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
 
@@ -341,7 +341,7 @@ fn get_endorsing_rights(
     cycle_meta_data: &CycleData,
     parameters: &RightsParams,
     constants: &RightsConstants,
-) -> Result<Option<Vec<RpcJsonMap>>, failure::Error> {
+) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     // define helper and output variables
     let mut endorsing_rights = Vec::<EndorsingRight>::new();
 
@@ -434,7 +434,7 @@ fn complete_endorsing_rights_for_level(
     estimated_time: Option<i64>,
     cycle_position: i32,
     endorsing_rights: &mut Vec<EndorsingRight>,
-) -> Result<(), failure::Error> {
+) -> Result<(), anyhow::Error> {
     // endorsers_slots is needed to group all slots by delegate
     let endorsers_slots =
         get_endorsers_slots(constants, cycle_meta_data, rolls_map, cycle_position)?;
@@ -490,7 +490,7 @@ fn get_endorsers_slots(
     cycle_meta_data: &CycleData,
     rolls_map: &HashMap<i32, String>,
     cycle_position: i32,
-) -> Result<HashMap<String, EndorserSlots>, failure::Error> {
+) -> Result<HashMap<String, EndorserSlots>, anyhow::Error> {
     // special byte string used in Tezos PRNG
     const ENDORSEMENT_USE_STRING: &[u8] = b"level endorsement:";
     // prepare helper variable

--- a/rpc/src/services/protocol/proto_009/rights_service.rs
+++ b/rpc/src/services/protocol/proto_009/rights_service.rs
@@ -4,11 +4,9 @@
 use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;
 
-use crypto::hash::ChainId;
 use anyhow::format_err;
 use itertools::Itertools;
 
-use crate::server::RpcServiceEnvironment;
 use crate::services::dev_services::contract_id_to_contract_address_for_index;
 use tezos_messages::base::rpc_support::{RpcJsonMap, ToRpcJsonMap};
 use tezos_messages::base::signature_public_key_hash::SignaturePublicKeyHash;
@@ -46,8 +44,6 @@ pub(crate) async fn check_and_get_baking_rights(
     max_priority: Option<&str>,
     has_all: bool,
     cycle_meta_storage: &CycleMetaStorage,
-    chain_id: &ChainId,
-    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -60,8 +56,6 @@ pub(crate) async fn check_and_get_baking_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
-        chain_id,
-        env,
         true,
     )
     .await?;
@@ -301,8 +295,6 @@ pub(crate) async fn check_and_get_endorsing_rights(
     cycle: Option<&str>,
     has_all: bool,
     cycle_meta_storage: &CycleMetaStorage,
-    chain_id: &ChainId,
-    env: &RpcServiceEnvironment,
 ) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params)?;
@@ -315,8 +307,6 @@ pub(crate) async fn check_and_get_endorsing_rights(
         has_all,
         &constants,
         &context_proto_params.block_header,
-        chain_id,
-        env,
         false,
     )
     .await?;

--- a/rpc/src/services/protocol/proto_009/votes_service.rs
+++ b/rpc/src/services/protocol/proto_009/votes_service.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 use crypto::hash::ContextHash;
-use failure::format_err;
+use anyhow::format_err;
 use itertools::Itertools;
 
 use storage::num_from_slice;

--- a/rpc/src/services/protocol/proto_009/votes_service.rs
+++ b/rpc/src/services/protocol/proto_009/votes_service.rs
@@ -1,8 +1,8 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use crypto::hash::ContextHash;
 use anyhow::format_err;
+use crypto::hash::ContextHash;
 use itertools::Itertools;
 
 use storage::num_from_slice;

--- a/rpc/src/services/protocol/proto_010/mod.rs
+++ b/rpc/src/services/protocol/proto_010/mod.rs
@@ -1,0 +1,6 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+mod helpers;
+pub(crate) mod rights_service;
+pub(crate) mod votes_service;

--- a/rpc/src/services/protocol/proto_010/mod.rs
+++ b/rpc/src/services/protocol/proto_010/mod.rs
@@ -1,15 +1,15 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use serde::Deserialize;
 use getset::CopyGetters;
 use num::BigInt;
+use serde::Deserialize;
 
 mod helpers;
 pub(crate) mod rights_service;
 pub(crate) mod votes_service;
 
-use super::{vec_string_to_int, string_to_int};
+use super::{string_to_int, vec_string_to_int};
 
 #[derive(Debug, Deserialize, Clone, CopyGetters)]
 pub(crate) struct ProtocolConstants {
@@ -19,7 +19,7 @@ pub(crate) struct ProtocolConstants {
     max_operation_data_length: i32,
     max_proposals_per_delegate: u8,
     preserved_cycles: u8,
-    
+
     #[get_copy = "pub(crate)"]
     blocks_per_cycle: i32,
 
@@ -29,7 +29,7 @@ pub(crate) struct ProtocolConstants {
 
     #[serde(with = "vec_string_to_int")]
     time_between_blocks: Vec<i64>,
-    
+
     endorsers_per_block: u16,
 
     #[serde(with = "string_to_int")]

--- a/rpc/src/services/protocol/proto_010/mod.rs
+++ b/rpc/src/services/protocol/proto_010/mod.rs
@@ -1,6 +1,87 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
+use serde::Deserialize;
+use getset::CopyGetters;
+use num::BigInt;
+
 mod helpers;
 pub(crate) mod rights_service;
 pub(crate) mod votes_service;
+
+use super::{vec_string_to_int, string_to_int};
+
+#[derive(Debug, Deserialize, Clone, CopyGetters)]
+pub(crate) struct ProtocolConstants {
+    proof_of_work_nonce_size: u8,
+    nonce_length: u8,
+    max_anon_ops_per_block: u8,
+    max_operation_data_length: i32,
+    max_proposals_per_delegate: u8,
+    preserved_cycles: u8,
+    
+    #[get_copy = "pub(crate)"]
+    blocks_per_cycle: i32,
+
+    blocks_per_commitment: i32,
+    blocks_per_roll_snapshot: i32,
+    blocks_per_voting_period: i32,
+
+    #[serde(with = "vec_string_to_int")]
+    time_between_blocks: Vec<i64>,
+    
+    endorsers_per_block: u16,
+
+    #[serde(with = "string_to_int")]
+    hard_gas_limit_per_operation: BigInt,
+
+    #[serde(with = "string_to_int")]
+    hard_gas_limit_per_block: BigInt,
+
+    #[serde(with = "string_to_int")]
+    proof_of_work_threshold: BigInt,
+
+    #[serde(with = "string_to_int")]
+    tokens_per_roll: BigInt,
+    michelson_maximum_type_size: u16,
+
+    #[serde(with = "string_to_int")]
+    seed_nonce_revelation_tip: BigInt,
+
+    origination_size: i32,
+
+    #[serde(with = "string_to_int")]
+    block_security_deposit: BigInt,
+
+    #[serde(with = "string_to_int")]
+    endorsement_security_deposit: BigInt,
+
+    #[serde(with = "vec_string_to_int")]
+    baking_reward_per_endorsement: Vec<BigInt>,
+
+    #[serde(with = "vec_string_to_int")]
+    endorsement_reward: Vec<BigInt>,
+
+    #[serde(with = "string_to_int")]
+    cost_per_byte: BigInt,
+
+    #[serde(with = "string_to_int")]
+    hard_storage_limit_per_operation: BigInt,
+
+    quorum_min: i32,
+    quorum_max: i32,
+    min_proposal_quorum: i32,
+    initial_endorsers: u16,
+
+    #[serde(with = "string_to_int")]
+    delay_per_missing_endorsement: i64,
+
+    #[serde(with = "string_to_int")]
+    minimal_block_delay: i64,
+
+    #[serde(with = "string_to_int")]
+    liquidity_baking_subsidy: BigInt,
+
+    liquidity_baking_sunset_level: i32,
+    liquidity_baking_escape_ema_threshold: i32,
+}

--- a/rpc/src/services/protocol/proto_010/rights_service.rs
+++ b/rpc/src/services/protocol/proto_010/rights_service.rs
@@ -102,25 +102,17 @@ pub(crate) fn get_baking_rights(
     let cycle_position = *rights_metadata.block_cycle_position();
 
     // build a reverse map of rols so we have access in O(1)
-    // let rolls_map: HashMap<i32, String> = HashMap::new();
-    let rolls_map: HashMap<i32, String> = cycle_meta_data
-        .rolls_data()
-        .iter()
-        .map(|(delegate, rolls)| {
-            rolls
-                .iter()
-                .map(|roll| {
-                    (
-                        *roll,
-                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
-                            .unwrap()
-                            .to_string_representation(),
-                    )
-                })
-                .collect::<HashMap<i32, String>>()
-        })
-        .flatten()
-        .collect();
+    let mut rolls_map: HashMap<i32, String> = HashMap::new();
+
+    for (delegate, rolls) in cycle_meta_data.rolls_data() {
+        for roll in rolls {
+            rolls_map.insert(
+                *roll,
+                SignaturePublicKeyHash::from_tagged_bytes(delegate.to_vec())?
+                    .to_string_representation(),
+            );
+        }
+    }
 
     // iterate through the whole cycle if necessery
     if let Some((cycle, cycle_era)) = parameters.requested_cycle() {
@@ -350,24 +342,18 @@ fn get_endorsing_rights(
     // define helper and output variables
     let mut endorsing_rights = Vec::<EndorsingRight>::new();
 
-    let rolls_map: HashMap<i32, String> = cycle_meta_data
-        .rolls_data()
-        .iter()
-        .map(|(delegate, rolls)| {
-            rolls
-                .iter()
-                .map(|roll| {
-                    (
-                        *roll,
-                        SignaturePublicKeyHash::from_tagged_bytes(delegate.clone())
-                            .unwrap()
-                            .to_string_representation(),
-                    )
-                })
-                .collect::<HashMap<i32, String>>()
-        })
-        .flatten()
-        .collect();
+    // build a reverse map of rols so we have access in O(1)
+    let mut rolls_map: HashMap<i32, String> = HashMap::new();
+
+    for (delegate, rolls) in cycle_meta_data.rolls_data() {
+        for roll in rolls {
+            rolls_map.insert(
+                *roll,
+                SignaturePublicKeyHash::from_tagged_bytes(delegate.to_vec())?
+                    .to_string_representation(),
+            );
+        }
+    }
 
     // when query param cycle is specified then iterate over all cycle levels, else only given level
     if let Some((cycle, cycle_era)) = parameters.requested_cycle() {

--- a/rpc/src/services/protocol/proto_010/rights_service.rs
+++ b/rpc/src/services/protocol/proto_010/rights_service.rs
@@ -4,7 +4,7 @@
 use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;
 
-use failure::format_err;
+use anyhow::format_err;
 use itertools::Itertools;
 
 use crate::server::RpcServiceEnvironment;
@@ -46,7 +46,7 @@ pub(crate) async fn check_and_get_baking_rights(
     has_all: bool,
     cycle_meta_storage: &CycleMetaStorage,
     env: &RpcServiceEnvironment,
-) -> Result<Option<Vec<RpcJsonMap>>, failure::Error> {
+) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params, env)?;
 
@@ -92,7 +92,7 @@ pub(crate) fn get_baking_rights(
     parameters: &RightsParams,
     constants: &RightsConstants,
     rights_metadata: &RightsMetadata,
-) -> Result<Option<Vec<RpcJsonMap>>, failure::Error> {
+) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let mut baking_rights = Vec::<BakingRights>::new();
 
     let minimal_block_delay = *constants.minimal_block_delay();
@@ -215,7 +215,7 @@ fn baking_rights_assign_rolls(
     estimated_head_timestamp: i64,
     is_cycle: bool,
     baking_rights: &mut Vec<BakingRights>,
-) -> Result<(), failure::Error> {
+) -> Result<(), anyhow::Error> {
     const BAKING_USE_STRING: &[u8] = b"level baking:";
 
     // hashset is defined to keep track of the delegates with priorities already assigned
@@ -310,7 +310,7 @@ pub(crate) async fn check_and_get_endorsing_rights(
     has_all: bool,
     cycle_meta_storage: &CycleMetaStorage,
     env: &RpcServiceEnvironment,
-) -> Result<Option<Vec<RpcJsonMap>>, failure::Error> {
+) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     let constants: RightsConstants =
         RightsConstants::parse_rights_constants(&context_proto_params, env)?;
 
@@ -346,7 +346,7 @@ fn get_endorsing_rights(
     cycle_meta_data: &CycleData,
     parameters: &RightsParams,
     constants: &RightsConstants,
-) -> Result<Option<Vec<RpcJsonMap>>, failure::Error> {
+) -> Result<Option<Vec<RpcJsonMap>>, anyhow::Error> {
     // define helper and output variables
     let mut endorsing_rights = Vec::<EndorsingRight>::new();
 
@@ -442,7 +442,7 @@ fn complete_endorsing_rights_for_level(
     estimated_time: Option<i64>,
     cycle_position: i32,
     endorsing_rights: &mut Vec<EndorsingRight>,
-) -> Result<(), failure::Error> {
+) -> Result<(), anyhow::Error> {
     // endorsers_slots is needed to group all slots by delegate
     let endorsers_slots =
         get_endorsers_slots(constants, cycle_meta_data, rolls_map, cycle_position)?;
@@ -498,7 +498,7 @@ fn get_endorsers_slots(
     cycle_meta_data: &CycleData,
     rolls_map: &HashMap<i32, String>,
     cycle_position: i32,
-) -> Result<HashMap<String, EndorserSlots>, failure::Error> {
+) -> Result<HashMap<String, EndorserSlots>, anyhow::Error> {
     // special byte string used in Tezos PRNG
     const ENDORSEMENT_USE_STRING: &[u8] = b"level endorsement:";
     // prepare helper variable

--- a/rpc/src/services/protocol/proto_010/votes_service.rs
+++ b/rpc/src/services/protocol/proto_010/votes_service.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 use crypto::hash::ContextHash;
-use failure::format_err;
+use anyhow::format_err;
 use itertools::Itertools;
 
 use storage::num_from_slice;

--- a/rpc/src/services/protocol/proto_010/votes_service.rs
+++ b/rpc/src/services/protocol/proto_010/votes_service.rs
@@ -1,8 +1,8 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use crypto::hash::ContextHash;
 use anyhow::format_err;
+use crypto::hash::ContextHash;
 use itertools::Itertools;
 
 use storage::num_from_slice;

--- a/rpc/src/services/protocol/proto_010/votes_service.rs
+++ b/rpc/src/services/protocol/proto_010/votes_service.rs
@@ -1,14 +1,14 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use anyhow::format_err;
 use crypto::hash::ContextHash;
+use failure::format_err;
 use itertools::Itertools;
 
 use storage::num_from_slice;
 use tezos_context::context_key_owned;
 use tezos_messages::base::signature_public_key_hash::SignaturePublicKeyHash;
-use tezos_messages::protocol::proto_006::votes::VoteListings;
+use tezos_messages::protocol::proto_010::votes::VoteListings;
 
 use crate::server::RpcServiceEnvironment;
 use crate::services::protocol::VotesError;
@@ -18,7 +18,7 @@ pub fn get_votes_listings(
     context_hash: &ContextHash,
 ) -> Result<Option<serde_json::Value>, VotesError> {
     // filter out the listings data
-    let listings_data = if let Some(val) = env
+    let mut listings_data = if let Some(val) = env
         .tezedge_context()
         .get_key_values_by_prefix(context_hash, context_key_owned!("data/votes/listings"))?
     {
@@ -28,6 +28,10 @@ pub fn get_votes_listings(
             reason: format_err!("No votes listings found in context"),
         });
     };
+
+    // sort the raw data from the context
+    listings_data.sort();
+    listings_data.reverse();
 
     // convert the raw context data to VoteListings
     let mut listings = Vec::with_capacity(listings_data.len());
@@ -45,8 +49,5 @@ pub fn get_votes_listings(
         ));
     }
 
-    // sort the vector in reverse ordering (as in ocaml node)
-    listings.sort();
-    listings.reverse();
     Ok(Some(serde_json::to_value(listings)?))
 }

--- a/rpc/tests/integration_tests.rs
+++ b/rpc/tests/integration_tests.rs
@@ -558,9 +558,6 @@ async fn integration_tests_rpc(from_block: i64, to_block: i64) {
         )
         .await
         .expect("Failed to get constants");
-        // let PRESERVED_CYCLES = constants_json["PRESERVED_CYCLES"]
-        //     .as_i64()
-        //     .unwrap_or_else(|| panic!("No constant 'PRESERVED_CYCLES' for block_id: {}", level));
         let blocks_per_cycle = constants_json["blocks_per_cycle"]
             .as_i64()
             .unwrap_or_else(|| panic!("No constant 'blocks_per_cycle' for block_id: {}", level));

--- a/rpc/tests/integration_tests.rs
+++ b/rpc/tests/integration_tests.rs
@@ -174,10 +174,7 @@ async fn integration_test_mainnet_rights_rpc(head_level: i64 /* , latest_cycle: 
     // this also covers the case when we are requesting the last block of a cycle
     println!("\n===Checking furthest future block===");
     let furthest_cycle_future = current_cycle + PRESERVED_CYCLES;
-    let furthest_level_future = get_last_level_in_cycle(
-        furthest_cycle_future,
-        &get_era_from_cycle(furthest_cycle_future, &cycle_eras),
-    );
+    let furthest_level_future = get_last_level_in_cycle(furthest_cycle_future, &current_era);
 
     test_rpc_compare_json(&format!(
         "{}/{}/{}?level={}",
@@ -252,7 +249,7 @@ async fn integration_test_mainnet_rights_rpc(head_level: i64 /* , latest_cycle: 
     ))
     .await
     .expect("test failed");
-    
+
     println!("\n===Checking (from florence) first granda block===");
     test_rpc_compare_json(&format!(
         "{}/{}/{}?level={}",

--- a/shell/src/chain_feeder.rs
+++ b/shell/src/chain_feeder.rs
@@ -21,12 +21,13 @@ use crypto::hash::{BlockHash, ChainId};
 use storage::chain_meta_storage::ChainMetaStorageReader;
 use storage::{
     block_meta_storage, BlockAdditionalData, BlockHeaderWithHash, BlockMetaStorageReader,
-    PersistentStorage,
+    CycleErasStorage, CycleMetaStorage, PersistentStorage,
 };
 use storage::{
     initialize_storage_with_genesis_block, store_applied_block_result, store_commit_genesis_result,
-    BlockMetaStorage, BlockStorage, BlockStorageReader, ChainMetaStorage, OperationsMetaStorage,
-    OperationsStorage, OperationsStorageReader, StorageError, StorageInitInfo,
+    BlockMetaStorage, BlockStorage, BlockStorageReader, ChainMetaStorage, ConstantsStorage,
+    OperationsMetaStorage, OperationsStorage, OperationsStorageReader, StorageError,
+    StorageInitInfo,
 };
 use tezos_api::environment::TezosEnvironmentConfiguration;
 use tezos_api::ffi::ApplyBlockRequest;
@@ -553,6 +554,9 @@ impl BlockApplierThreadSpawner {
                 let chain_meta_storage = ChainMetaStorage::new(&persistent_storage);
                 let operations_storage = OperationsStorage::new(&persistent_storage);
                 let operations_meta_storage = OperationsMetaStorage::new(&persistent_storage);
+                let cycle_meta_storage = CycleMetaStorage::new(&persistent_storage);
+                let cycle_eras_storage = CycleErasStorage::new(&persistent_storage);
+                let constants_storage = ConstantsStorage::new(&persistent_storage);
 
                 block_applier_run.store(true, Ordering::Release);
                 info!(log, "Chain feeder started processing");
@@ -569,6 +573,9 @@ impl BlockApplierThreadSpawner {
                             &chain_meta_storage,
                             &operations_storage,
                             &operations_meta_storage,
+                            &cycle_meta_storage,
+                            &cycle_eras_storage,
+                            &constants_storage,
                             &protocol_controller.api,
                             &mut block_applier_event_receiver,
                             &log,
@@ -612,6 +619,9 @@ fn feed_chain_to_protocol(
     chain_meta_storage: &ChainMetaStorage,
     operations_storage: &OperationsStorage,
     operations_meta_storage: &OperationsMetaStorage,
+    cycle_meta_storage: &CycleMetaStorage,
+    cycle_eras_storage: &CycleErasStorage,
+    constants_storage: &ConstantsStorage,
     protocol_controller: &ProtocolController,
     block_applier_event_receiver: &mut QueueReceiver<Event>,
     log: &Logger,
@@ -698,6 +708,9 @@ fn feed_chain_to_protocol(
                             load_metadata_elapsed,
                             block_storage,
                             block_meta_storage,
+                            cycle_meta_storage,
+                            cycle_eras_storage,
+                            constants_storage,
                             protocol_controller,
                             init_storage_data,
                             log,
@@ -850,6 +863,9 @@ fn _apply_block(
     load_metadata_elapsed: Duration,
     block_storage: &BlockStorage,
     block_meta_storage: &BlockMetaStorage,
+    cycle_meta_storage: &CycleMetaStorage,
+    cycle_eras_storage: &CycleErasStorage,
+    constants_storage: &ConstantsStorage,
     protocol_controller: &ProtocolController,
     storage_init_info: &StorageInitInfo,
     log: &Logger,
@@ -910,6 +926,9 @@ fn _apply_block(
         &block_hash,
         apply_block_result,
         &mut block_meta,
+        cycle_meta_storage,
+        cycle_eras_storage,
+        constants_storage,
     )?;
     let store_result_elapsed = store_result_timer.elapsed();
 

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -16,6 +16,7 @@ itertools = "0.10"
 num_cpus = "1.13"
 rocksdb = {version = "0.17", features = ["snappy", "lz4", "zstd", "zlib"], default-features = false }
 serde = { version = "1.0", features = ["derive", "rc"] }
+serde_json = "1.0"
 slog = { version = "2.7", features = ["max_level_trace", "release_max_level_debug"] }
 sled = "0.34.6"
 strum = "0.20"
@@ -39,7 +40,6 @@ harness = false
 hex = "0.4"
 lazy_static = "1.4"
 rand = "0.7.3"
-serde_json = "1.0"
 criterion = "0.3"
 fs_extra = "1.2.0"
 # TODO - TE-498 - remove dependency to OLD commit log

--- a/storage/src/constants_storage.rs
+++ b/storage/src/constants_storage.rs
@@ -1,0 +1,78 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+// use std::io::SeekFrom;
+use std::sync::Arc;
+
+use rocksdb::{Cache, ColumnFamilyDescriptor};
+
+use crypto::hash::ProtocolHash;
+
+use crate::database::tezedge_database::{KVStoreKeyValueSchema, TezedgeDatabaseWithIterator};
+use crate::persistent::database::{default_table_options, RocksDbKeyValueSchema};
+use crate::persistent::KeyValueSchema;
+use crate::{PersistentStorage, StorageError};
+
+pub type ConstantsStorageKV = dyn TezedgeDatabaseWithIterator<ConstantsStorage> + Sync + Send;
+
+// TODO: double check the type
+type ConstantsKey = ProtocolHash;
+
+#[derive(Clone)]
+pub struct ConstantsStorage {
+    kv: Arc<ConstantsStorageKV>,
+}
+
+pub type ConstantsData = String;
+
+impl ConstantsStorage {
+    pub fn new(persistent_storage: &PersistentStorage) -> Self {
+        Self {
+            kv: persistent_storage.main_db(),
+        }
+    }
+
+    pub fn store_constants_data(
+        &self,
+        protocol_hash: ProtocolHash,
+        new_constants: String,
+    ) -> Result<(), StorageError> {
+        self.put(&protocol_hash, &new_constants)?;
+
+        Ok(())
+    }
+
+    #[inline]
+    fn put(&self, key: &ConstantsKey, data: &str) -> Result<(), StorageError> {
+        self.kv
+            .put(key, &data.to_string())
+            .map_err(StorageError::from)
+    }
+
+    pub fn get(&self, key: &ConstantsKey) -> Result<Option<ConstantsData>, StorageError> {
+        self.kv.get(key).map_err(StorageError::from)
+    }
+}
+
+impl KeyValueSchema for ConstantsStorage {
+    type Key = ConstantsKey;
+    type Value = ConstantsData;
+}
+
+impl RocksDbKeyValueSchema for ConstantsStorage {
+    fn descriptor(cache: &Cache) -> ColumnFamilyDescriptor {
+        let cf_opts = default_table_options(cache);
+        ColumnFamilyDescriptor::new(Self::name(), cf_opts)
+    }
+
+    #[inline]
+    fn name() -> &'static str {
+        "constants_storage"
+    }
+}
+
+impl KVStoreKeyValueSchema for ConstantsStorage {
+    fn column_name() -> &'static str {
+        Self::name()
+    }
+}

--- a/storage/src/constants_storage.rs
+++ b/storage/src/constants_storage.rs
@@ -15,7 +15,6 @@ use crate::{PersistentStorage, StorageError};
 
 pub type ConstantsStorageKV = dyn TezedgeDatabaseWithIterator<ConstantsStorage> + Sync + Send;
 
-// TODO: double check the type
 type ConstantsKey = ProtocolHash;
 
 #[derive(Clone)]

--- a/storage/src/cycle_eras_storage.rs
+++ b/storage/src/cycle_eras_storage.rs
@@ -1,0 +1,98 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+// use std::io::SeekFrom;
+use std::sync::Arc;
+
+use getset::Getters;
+use rocksdb::{Cache, ColumnFamilyDescriptor};
+use serde::{Deserialize, Serialize};
+
+use crypto::hash::ProtocolHash;
+
+use crate::database::tezedge_database::{KVStoreKeyValueSchema, TezedgeDatabaseWithIterator};
+use crate::persistent::database::{default_table_options, RocksDbKeyValueSchema};
+use crate::persistent::{BincodeEncoded, KeyValueSchema};
+use crate::{PersistentStorage, StorageError};
+
+pub type CycleErasStorageKV = dyn TezedgeDatabaseWithIterator<CycleErasStorage> + Sync + Send;
+
+// TODO: double check the type
+type CycleErasKey = ProtocolHash;
+
+#[derive(Clone)]
+pub struct CycleErasStorage {
+    kv: Arc<CycleErasStorageKV>,
+}
+
+pub type CycleErasData = Vec<CycleEra>;
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Getters)]
+pub struct CycleEra {
+    #[get = "pub"]
+    first_level: i32,
+
+    #[get = "pub"]
+    first_cycle: i32,
+
+    #[get = "pub"]
+    blocks_per_cycle: i32,
+
+    #[get = "pub"]
+    blocks_per_commitment: i32,
+}
+
+impl CycleErasStorage {
+    pub fn new(persistent_storage: &PersistentStorage) -> Self {
+        Self {
+            kv: persistent_storage.main_db(),
+        }
+    }
+
+    pub fn store_cycle_eras_data(
+        &self,
+        protocol_hash: ProtocolHash,
+        new_cycle_eras_json: String,
+    ) -> Result<(), StorageError> {
+        // deserialize the JSON into the CycleErasData struct
+        let decoded_cycle_eras: CycleErasData = serde_json::from_str(&new_cycle_eras_json)?;
+
+        self.put(&protocol_hash, decoded_cycle_eras)?;
+
+        Ok(())
+    }
+
+    #[inline]
+    fn put(&self, key: &CycleErasKey, data: CycleErasData) -> Result<(), StorageError> {
+        self.kv.put(key, &data).map_err(StorageError::from)
+    }
+
+    pub fn get(&self, key: &CycleErasKey) -> Result<Option<CycleErasData>, StorageError> {
+        self.kv.get(key).map_err(StorageError::from)
+    }
+}
+
+impl BincodeEncoded for CycleErasData {}
+
+impl KeyValueSchema for CycleErasStorage {
+    type Key = CycleErasKey;
+    type Value = CycleErasData;
+}
+
+impl RocksDbKeyValueSchema for CycleErasStorage {
+    fn descriptor(cache: &Cache) -> ColumnFamilyDescriptor {
+        let cf_opts = default_table_options(cache);
+        ColumnFamilyDescriptor::new(Self::name(), cf_opts)
+    }
+
+    #[inline]
+    fn name() -> &'static str {
+        "cycle_eras_storage"
+    }
+}
+
+impl KVStoreKeyValueSchema for CycleErasStorage {
+    fn column_name() -> &'static str {
+        Self::name()
+    }
+}

--- a/storage/src/cycle_storage.rs
+++ b/storage/src/cycle_storage.rs
@@ -1,0 +1,109 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+// use std::io::SeekFrom;
+use std::sync::Arc;
+
+use getset::Getters;
+use rocksdb::{Cache, ColumnFamilyDescriptor};
+use serde::{Deserialize, Serialize};
+
+use tezos_api::ffi::CycleRollsOwnerSnapshot;
+
+use crate::database::tezedge_database::{KVStoreKeyValueSchema, TezedgeDatabaseWithIterator};
+use crate::persistent::database::{default_table_options, RocksDbKeyValueSchema};
+use crate::persistent::{BincodeEncoded, KeyValueSchema};
+use crate::{PersistentStorage, StorageError};
+
+pub type CycleMetaStorageKV = dyn TezedgeDatabaseWithIterator<CycleMetaStorage> + Sync + Send;
+
+type CycleKey = i32;
+
+#[derive(Clone)]
+pub struct CycleMetaStorage {
+    kv: Arc<CycleMetaStorageKV>,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Getters)]
+pub struct CycleData {
+    #[get = "pub"]
+    seed_bytes: Vec<u8>,
+
+    #[get = "pub"]
+    rolls_data: Vec<(Vec<u8>, Vec<i32>)>,
+
+    #[get = "pub"]
+    last_roll: i32,
+}
+
+impl From<CycleRollsOwnerSnapshot> for CycleData {
+    fn from(data: CycleRollsOwnerSnapshot) -> CycleData {
+        CycleData {
+            seed_bytes: data.seed_bytes,
+            rolls_data: data.rolls_data,
+            last_roll: data.last_roll,
+        }
+    }
+}
+
+impl CycleData {
+    pub fn new(seed_bytes: Vec<u8>, rolls_data: Vec<(Vec<u8>, Vec<i32>)>, last_roll: i32) -> Self {
+        Self {
+            seed_bytes,
+            rolls_data,
+            last_roll,
+        }
+    }
+}
+
+impl CycleMetaStorage {
+    pub fn new(persistent_storage: &PersistentStorage) -> Self {
+        Self {
+            kv: persistent_storage.main_db(),
+        }
+    }
+
+    pub fn store_cycle_data(
+        &self,
+        ffi_cycle_data: CycleRollsOwnerSnapshot,
+    ) -> Result<(), StorageError> {
+        // add some additional logic here if necessary
+        self.put(&ffi_cycle_data.cycle, &ffi_cycle_data.clone().into())?;
+
+        Ok(())
+    }
+
+    #[inline]
+    fn put(&self, key: &CycleKey, data: &CycleData) -> Result<(), StorageError> {
+        self.kv.put(key, data).map_err(StorageError::from)
+    }
+
+    pub fn get(&self, key: &CycleKey) -> Result<Option<CycleData>, StorageError> {
+        self.kv.get(key).map_err(StorageError::from)
+    }
+}
+
+impl BincodeEncoded for CycleData {}
+
+impl KeyValueSchema for CycleMetaStorage {
+    type Key = CycleKey;
+    type Value = CycleData;
+}
+
+impl RocksDbKeyValueSchema for CycleMetaStorage {
+    fn descriptor(cache: &Cache) -> ColumnFamilyDescriptor {
+        let cf_opts = default_table_options(cache);
+        ColumnFamilyDescriptor::new(Self::name(), cf_opts)
+    }
+
+    #[inline]
+    fn name() -> &'static str {
+        "cycle_data_storage"
+    }
+}
+
+impl KVStoreKeyValueSchema for CycleMetaStorage {
+    fn column_name() -> &'static str {
+        Self::name()
+    }
+}

--- a/storage/src/cycle_storage.rs
+++ b/storage/src/cycle_storage.rs
@@ -1,7 +1,6 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-// use std::io::SeekFrom;
 use std::sync::Arc;
 
 use getset::Getters;

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -340,10 +340,6 @@ pub fn store_applied_block_result(
 
     // store new cycle eras if they are present
     if let Some(new_cycle_eras) = block_result.new_cycle_eras_json {
-        println!(
-            "Storing cycle eras data for protocol: {}",
-            block_result.next_protocol_hash.to_base58_check()
-        );
         cycle_eras_storage
             .store_cycle_eras_data(block_result.next_protocol_hash.clone(), new_cycle_eras)?;
     }

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -37,6 +37,9 @@ pub use crate::block_meta_storage::{
 pub use crate::block_storage::{BlockJsonData, BlockStorage, BlockStorageReader};
 pub use crate::chain_meta_storage::ChainMetaStorage;
 use crate::commit_log::{CommitLogError, CommitLogs};
+pub use crate::constants_storage::ConstantsStorage;
+pub use crate::cycle_eras_storage::CycleErasStorage;
+pub use crate::cycle_storage::CycleMetaStorage;
 use crate::database::tezedge_database::TezedgeDatabase;
 pub use crate::mempool_storage::{MempoolStorage, MempoolStorageKV};
 pub use crate::operations_meta_storage::{OperationsMetaStorage, OperationsMetaStorageKV};
@@ -53,6 +56,9 @@ pub mod block_meta_storage;
 pub mod block_storage;
 pub mod chain_meta_storage;
 pub mod commit_log;
+pub mod constants_storage;
+pub mod cycle_eras_storage;
+pub mod cycle_storage;
 pub mod database;
 pub mod mempool_storage;
 pub mod operations_meta_storage;
@@ -143,6 +149,8 @@ pub enum StorageError {
     HashDecodeError { error: FromBase58CheckError },
     #[error("Database error: {error:?}")]
     MainDBError { error: database::error::Error },
+    #[fail(display = "Deserialization: {}", error)]
+    SerdeJsonError { error: serde_json::Error },
 }
 
 impl From<DBError> for StorageError {
@@ -197,6 +205,12 @@ impl From<FromBase58CheckError> for StorageError {
 impl From<database::error::Error> for StorageError {
     fn from(error: database::error::Error) -> Self {
         StorageError::MainDBError { error }
+    }
+}
+
+impl From<serde_json::Error> for StorageError {
+    fn from(error: serde_json::Error) -> Self {
+        StorageError::SerdeJsonError { error }
     }
 }
 
@@ -270,6 +284,9 @@ pub fn store_applied_block_result(
     block_hash: &BlockHash,
     block_result: ApplyBlockResponse,
     block_metadata: &mut block_meta_storage::Meta,
+    cycle_meta_storage: &CycleMetaStorage,
+    cycle_eras_storage: &CycleErasStorage,
+    constants_storage: &ConstantsStorage,
 ) -> Result<BlockAdditionalData, StorageError> {
     // store result data - json and additional data
     let block_json_data = BlockJsonData::new(
@@ -284,7 +301,7 @@ pub fn store_applied_block_result(
         block_result.max_operations_ttl.try_into().unwrap(),
         block_result.last_allowed_fork_level,
         block_result.protocol_hash,
-        block_result.next_protocol_hash,
+        block_result.next_protocol_hash.clone(),
         block_result.block_metadata_hash,
         {
             // Note: Ocaml introduces this two attributes (block_metadata_hash, ops_metadata_hash) in 008 edo
@@ -309,6 +326,33 @@ pub fn store_applied_block_result(
 
     // populate predecessor storage
     block_meta_storage.store_predecessors(&block_hash, &block_metadata)?;
+
+    // populate cycle data if is present in the response
+    for cycle_data in block_result.cycle_rolls_owner_snapshots.into_iter() {
+        println!("Storing data for cycle: {}", cycle_data.cycle);
+        cycle_meta_storage.store_cycle_data(cycle_data)?;
+    }
+
+    // store new constants if they are present
+    if let Some(constants) = block_result.new_protocol_constants_json {
+        // cons
+        println!(
+            "Storing constants data for protocol: {}",
+            &block_result.next_protocol_hash.to_base58_check()
+        );
+        constants_storage
+            .store_constants_data(block_result.next_protocol_hash.clone(), constants)?;
+    }
+
+    // store new cycle eras if they are present
+    if let Some(new_cycle_eras) = block_result.new_cycle_eras_json {
+        println!(
+            "Storing cycle eras data for protocol: {}",
+            block_result.next_protocol_hash.to_base58_check()
+        );
+        cycle_eras_storage
+            .store_cycle_eras_data(block_result.next_protocol_hash.clone(), new_cycle_eras)?;
+    }
 
     // if everything is stored and ok, we can considere this block as applied
     // mark current head as applied
@@ -477,6 +521,9 @@ pub mod initializer {
                 crate::ChainMetaStorage::descriptor(cache),
                 crate::PredecessorStorage::descriptor(cache),
                 crate::BlockAdditionalData::descriptor(&cache),
+                crate::CycleMetaStorage::descriptor(cache),
+                crate::CycleErasStorage::descriptor(cache),
+                crate::ConstantsStorage::descriptor(cache),
             ]
         }
     }

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -149,7 +149,7 @@ pub enum StorageError {
     HashDecodeError { error: FromBase58CheckError },
     #[error("Database error: {error:?}")]
     MainDBError { error: database::error::Error },
-    #[fail(display = "Deserialization: {}", error)]
+    #[error("Deserialization: {error}")]
     SerdeJsonError { error: serde_json::Error },
 }
 

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -329,17 +329,11 @@ pub fn store_applied_block_result(
 
     // populate cycle data if is present in the response
     for cycle_data in block_result.cycle_rolls_owner_snapshots.into_iter() {
-        println!("Storing data for cycle: {}", cycle_data.cycle);
         cycle_meta_storage.store_cycle_data(cycle_data)?;
     }
 
     // store new constants if they are present
     if let Some(constants) = block_result.new_protocol_constants_json {
-        // cons
-        println!(
-            "Storing constants data for protocol: {}",
-            &block_result.next_protocol_hash.to_base58_check()
-        );
         constants_storage
             .store_constants_data(block_result.next_protocol_hash.clone(), constants)?;
     }

--- a/storage/tests/storage_for_shell.rs
+++ b/storage/tests/storage_for_shell.rs
@@ -37,6 +37,9 @@ fn test_storage() -> Result<(), Error> {
     let block_meta_storage = BlockMetaStorage::new(tmp_storage.storage());
     let chain_meta_storage = ChainMetaStorage::new(tmp_storage.storage());
     let operations_meta_storage = OperationsMetaStorage::new(tmp_storage.storage());
+    let cycle_meta_storage = CycleMetaStorage::new(tmp_storage.storage());
+    let cycle_eras_storage = CycleErasStorage::new(tmp_storage.storage());
+    let constants_storage = ConstantsStorage::new(tmp_storage.storage());
 
     // tezos env - sample
     let tezos_env = TezosEnvironmentConfiguration {
@@ -225,6 +228,9 @@ fn test_storage() -> Result<(), Error> {
         &block.hash,
         apply_result.clone(),
         &mut metadata,
+        &cycle_meta_storage,
+        &cycle_eras_storage,
+        &constants_storage,
     )?;
 
     // set block as current head

--- a/tezos/messages/src/protocol/mod.rs
+++ b/tezos/messages/src/protocol/mod.rs
@@ -27,6 +27,8 @@ pub mod proto_006;
 pub mod proto_007;
 pub mod proto_008;
 pub mod proto_008_2;
+pub mod proto_009;
+pub mod proto_010;
 
 lazy_static! {
     pub static ref SUPPORTED_PROTOCOLS: HashMap<String, SupportedProtocol> = init();
@@ -52,6 +54,8 @@ pub enum SupportedProtocol {
     Proto007,
     Proto008,
     Proto008_2,
+    Proto009,
+    Proto010,
 }
 
 impl SupportedProtocol {
@@ -67,6 +71,8 @@ impl SupportedProtocol {
             SupportedProtocol::Proto007 => proto_007::PROTOCOL_HASH.to_string(),
             SupportedProtocol::Proto008 => proto_008::PROTOCOL_HASH.to_string(),
             SupportedProtocol::Proto008_2 => proto_008_2::PROTOCOL_HASH.to_string(),
+            SupportedProtocol::Proto009 => proto_009::PROTOCOL_HASH.to_string(),
+            SupportedProtocol::Proto010 => proto_010::PROTOCOL_HASH.to_string(),
         }
     }
 }
@@ -186,6 +192,18 @@ pub fn get_constants_for_rpc(
         }
         SupportedProtocol::Proto008_2 => {
             use crate::protocol::proto_008_2::constants::{ParametricConstants, FIXED};
+            let mut param = ParametricConstants::from_bytes(bytes)?.as_map();
+            param.extend(FIXED.clone().as_map());
+            Ok(Some(param))
+        }
+        SupportedProtocol::Proto009 => {
+            use crate::protocol::proto_009::constants::{ParametricConstants, FIXED};
+            let mut param = ParametricConstants::from_bytes(bytes)?.as_map();
+            param.extend(FIXED.clone().as_map());
+            Ok(Some(param))
+        }
+        SupportedProtocol::Proto010 => {
+            use crate::protocol::proto_010::constants::{ParametricConstants, FIXED};
             let mut param = ParametricConstants::from_bytes(bytes)?.as_map();
             param.extend(FIXED.clone().as_map());
             Ok(Some(param))

--- a/tezos/messages/src/protocol/proto_009/constants.rs
+++ b/tezos/messages/src/protocol/proto_009/constants.rs
@@ -1,0 +1,201 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use std::collections::HashMap;
+
+use getset::{CopyGetters, Getters};
+use serde::{Deserialize, Serialize};
+
+use tezos_encoding::nom::NomReader;
+use tezos_encoding::{
+    encoding::HasEncoding,
+    types::{Mutez, Zarith},
+};
+
+use crate::base::rpc_support::{ToRpcJsonMap, UniversalValue};
+
+pub const FIXED: FixedConstants = FixedConstants {
+    proof_of_work_nonce_size: 8,
+    nonce_length: 32,
+    max_anon_ops_per_block: 132,
+    max_operation_data_length: 16 * 1024,
+    max_proposals_per_delegate: 20,
+};
+
+#[derive(Serialize, Deserialize, Debug, Clone, CopyGetters)]
+pub struct FixedConstants {
+    proof_of_work_nonce_size: u8,
+    #[get_copy = "pub"]
+    nonce_length: u8,
+    max_anon_ops_per_block: u8,
+    max_operation_data_length: i32,
+    max_proposals_per_delegate: u8,
+}
+
+impl ToRpcJsonMap for FixedConstants {
+    fn as_map(&self) -> HashMap<&'static str, UniversalValue> {
+        let mut ret: HashMap<&'static str, UniversalValue> = Default::default();
+        ret.insert(
+            "proof_of_work_nonce_size",
+            UniversalValue::num(self.proof_of_work_nonce_size),
+        );
+        ret.insert("nonce_length", UniversalValue::num(self.nonce_length));
+        ret.insert(
+            "max_anon_ops_per_block",
+            UniversalValue::num(self.max_anon_ops_per_block),
+        );
+        ret.insert(
+            "max_operation_data_length",
+            UniversalValue::num(self.max_operation_data_length),
+        );
+        ret.insert(
+            "max_proposals_per_delegate",
+            UniversalValue::num(self.max_proposals_per_delegate),
+        );
+        ret
+    }
+}
+
+// -----------------------------------------------------------------------------------------------
+#[derive(Serialize, Deserialize, Debug, Clone, Getters, CopyGetters, HasEncoding, NomReader)]
+pub struct ParametricConstants {
+    #[get_copy = "pub"]
+    preserved_cycles: u8,
+    #[get_copy = "pub"]
+    blocks_per_cycle: i32,
+    blocks_per_commitment: i32,
+    #[get_copy = "pub"]
+    blocks_per_roll_snapshot: i32,
+    blocks_per_voting_period: i32,
+    #[get = "pub"]
+    #[encoding(dynamic, list)]
+    time_between_blocks: Vec<i64>,
+    #[get_copy = "pub"]
+    endorsers_per_block: u16,
+    hard_gas_limit_per_operation: Zarith,
+    hard_gas_limit_per_block: Zarith,
+    proof_of_work_threshold: i64,
+    tokens_per_roll: Mutez,
+    michelson_maximum_type_size: u16,
+    seed_nonce_revelation_tip: Mutez,
+    origination_size: i32,
+    block_security_deposit: Mutez,
+    endorsement_security_deposit: Mutez,
+    #[encoding(dynamic, list)]
+    baking_reward_per_endorsement: Vec<Mutez>,
+    #[encoding(dynamic, list)]
+    endorsement_reward: Vec<Mutez>,
+    cost_per_byte: Mutez,
+    hard_storage_limit_per_operation: Zarith,
+    test_chain_duration: i64,
+    quorum_min: i32,
+    quorum_max: i32,
+    min_proposal_quorum: i32,
+    initial_endorsers: u16,
+    delay_per_missing_endorsement: i64,
+}
+
+impl ToRpcJsonMap for ParametricConstants {
+    fn as_map(&self) -> HashMap<&'static str, UniversalValue> {
+        let mut ret: HashMap<&'static str, UniversalValue> = Default::default();
+        ret.insert(
+            "preserved_cycles",
+            UniversalValue::num(self.preserved_cycles),
+        );
+        ret.insert(
+            "blocks_per_cycle",
+            UniversalValue::num(self.blocks_per_cycle),
+        );
+        ret.insert(
+            "blocks_per_commitment",
+            UniversalValue::num(self.blocks_per_commitment),
+        );
+        ret.insert(
+            "blocks_per_roll_snapshot",
+            UniversalValue::num(self.blocks_per_roll_snapshot),
+        );
+        ret.insert(
+            "blocks_per_voting_period",
+            UniversalValue::num(self.blocks_per_voting_period),
+        );
+        ret.insert(
+            "time_between_blocks",
+            UniversalValue::i64_list(self.time_between_blocks.clone()),
+        );
+        ret.insert(
+            "endorsers_per_block",
+            UniversalValue::num(self.endorsers_per_block),
+        );
+        ret.insert(
+            "hard_gas_limit_per_operation",
+            UniversalValue::big_num(self.hard_gas_limit_per_operation.clone()),
+        );
+        ret.insert(
+            "hard_gas_limit_per_block",
+            UniversalValue::big_num(self.hard_gas_limit_per_block.clone()),
+        );
+        ret.insert(
+            "proof_of_work_threshold",
+            UniversalValue::i64(self.proof_of_work_threshold),
+        );
+        ret.insert(
+            "tokens_per_roll",
+            UniversalValue::big_num(self.tokens_per_roll.clone()),
+        );
+        ret.insert(
+            "michelson_maximum_type_size",
+            UniversalValue::num(self.michelson_maximum_type_size),
+        );
+        ret.insert(
+            "seed_nonce_revelation_tip",
+            UniversalValue::big_num(self.seed_nonce_revelation_tip.clone()),
+        );
+        ret.insert(
+            "origination_size",
+            UniversalValue::num(self.origination_size),
+        );
+        ret.insert(
+            "block_security_deposit",
+            UniversalValue::big_num(self.block_security_deposit.clone()),
+        );
+        ret.insert(
+            "endorsement_security_deposit",
+            UniversalValue::big_num(self.endorsement_security_deposit.clone()),
+        );
+        ret.insert(
+            "baking_reward_per_endorsement",
+            UniversalValue::big_num_list(self.baking_reward_per_endorsement.clone()),
+        );
+        ret.insert(
+            "endorsement_reward",
+            UniversalValue::big_num_list(self.endorsement_reward.clone()),
+        );
+        ret.insert(
+            "cost_per_byte",
+            UniversalValue::big_num(self.cost_per_byte.clone()),
+        );
+        ret.insert(
+            "hard_storage_limit_per_operation",
+            UniversalValue::big_num(self.hard_storage_limit_per_operation.clone()),
+        );
+        ret.insert(
+            "test_chain_duration",
+            UniversalValue::i64(self.test_chain_duration),
+        );
+        ret.insert("quorum_min", UniversalValue::num(self.quorum_min));
+        ret.insert("quorum_max", UniversalValue::num(self.quorum_max));
+        ret.insert(
+            "min_proposal_quorum",
+            UniversalValue::num(self.min_proposal_quorum),
+        );
+        ret.insert(
+            "initial_endorsers",
+            UniversalValue::num(self.initial_endorsers),
+        );
+        ret.insert(
+            "delay_per_missing_endorsement",
+            UniversalValue::i64(self.delay_per_missing_endorsement),
+        );
+        ret
+    }
+}

--- a/tezos/messages/src/protocol/proto_009/contract.rs
+++ b/tezos/messages/src/protocol/proto_009/contract.rs
@@ -1,0 +1,19 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use getset::Getters;
+use serde::Serialize;
+
+use tezos_encoding::{encoding::HasEncoding, nom::NomReader, types::Zarith};
+
+#[derive(Serialize, Debug, Clone, Getters, HasEncoding, NomReader)]
+pub struct Counter {
+    #[get = "pub"]
+    counter: Zarith,
+}
+
+impl Counter {
+    pub fn to_string_representation(&self) -> String {
+        self.counter.0.to_str_radix(10)
+    }
+}

--- a/tezos/messages/src/protocol/proto_009/mod.rs
+++ b/tezos/messages/src/protocol/proto_009/mod.rs
@@ -1,0 +1,8 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+pub mod constants;
+pub mod contract;
+pub mod rights;
+pub mod votes;
+
+pub const PROTOCOL_HASH: &str = "PsFLorenaUUuikDWvMDr6fGBRG8kt3e3D3fHoXK1j1BFRxeSH4i";

--- a/tezos/messages/src/protocol/proto_009/rights.rs
+++ b/tezos/messages/src/protocol/proto_009/rights.rs
@@ -1,0 +1,163 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use std::collections::HashMap;
+
+use serde::Serialize;
+
+use crate::base::rpc_support::{ToRpcJsonMap, UniversalValue};
+use crate::base::signature_public_key_hash::SignaturePublicKeyHash;
+
+/// Endorsing rights structure, final response look like Vec<EndorsingRight>
+#[derive(Serialize, Debug, Clone)]
+pub struct EndorsingRight {
+    /// block level for which endorsing rights are generated
+    pub level: i32,
+
+    /// endorser contract id
+    pub delegate: SignaturePublicKeyHash,
+
+    /// list of endorsement slots
+    pub slots: Vec<u16>,
+
+    /// estimated time of endorsement, is set to None if in past relative to block_id
+    pub estimated_time: Option<i64>,
+}
+
+impl EndorsingRight {
+    /// Simple constructor to construct EndorsingRight
+    pub fn new(
+        level: i32,
+        delegate: SignaturePublicKeyHash,
+        slots: Vec<u16>,
+        estimated_time: Option<i64>,
+    ) -> Self {
+        Self {
+            level,
+            delegate,
+            slots,
+            estimated_time,
+        }
+    }
+}
+
+impl ToRpcJsonMap for EndorsingRight {
+    fn as_map(&self) -> HashMap<&'static str, UniversalValue> {
+        let mut ret: HashMap<&'static str, UniversalValue> = Default::default();
+        ret.insert("level", UniversalValue::num(self.level));
+        ret.insert(
+            "delegate",
+            UniversalValue::string(self.delegate.to_string_representation()),
+        );
+        ret.insert("slots", UniversalValue::num_list(self.slots.iter()));
+        if let Some(ts) = self.estimated_time {
+            ret.insert("estimated_time", UniversalValue::timestamp_rfc3339(ts));
+        }
+        ret
+    }
+}
+
+/// Object containing information about the baking rights
+#[derive(Serialize, Debug, Clone)]
+pub struct BakingRights {
+    /// block level for which baking rights are generated
+    pub level: i32,
+
+    /// baker contract id
+    pub delegate: SignaturePublicKeyHash,
+
+    /// baker priority to bake block
+    pub priority: u16,
+
+    /// estimated time of baking based on baking priority, is set to None if in past relative to block_id
+    pub estimated_time: Option<i64>,
+}
+
+impl BakingRights {
+    /// Simple constructor to construct BakingRights
+    pub fn new(
+        level: i32,
+        delegate: SignaturePublicKeyHash,
+        priority: u16,
+        estimated_time: Option<i64>,
+    ) -> Self {
+        Self {
+            level,
+            delegate,
+            priority,
+            estimated_time,
+        }
+    }
+}
+
+impl ToRpcJsonMap for BakingRights {
+    fn as_map(&self) -> HashMap<&'static str, UniversalValue> {
+        let mut ret: HashMap<&'static str, UniversalValue> = Default::default();
+        ret.insert("level", UniversalValue::num(self.level));
+        ret.insert(
+            "delegate",
+            UniversalValue::string(self.delegate.to_string_representation()),
+        );
+        ret.insert("priority", UniversalValue::num(self.priority));
+        if let Some(ts) = self.estimated_time {
+            ret.insert("estimated_time", UniversalValue::timestamp_rfc3339(ts));
+        }
+        ret
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_json_diff::assert_json_eq;
+    use failure::Error;
+    use serde_json::json;
+
+    use crate::base::signature_public_key_hash::SignaturePublicKeyHash;
+    use crate::protocol::proto_009::rights::{BakingRights, EndorsingRight};
+    use crate::protocol::ToRpcJsonMap;
+
+    #[test]
+    fn test_endorsing_right_with_tz1_to_json() -> Result<(), Error> {
+        let er = EndorsingRight::new(
+            296772,
+            SignaturePublicKeyHash::from_b58_hash("tz1VxS7ff4YnZRs8b4mMP4WaMVpoQjuo1rjf")?,
+            vec![27, 16, 14, 13, 0],
+            Some(1585207011),
+        );
+
+        let json = er.as_map();
+        let expected_json = json!({"level":296772,"delegate":"tz1VxS7ff4YnZRs8b4mMP4WaMVpoQjuo1rjf","slots":[27,16,14,13,0],"estimated_time":"2020-03-26T07:16:51Z"});
+        assert_json_eq!(expected_json, serde_json::to_value(json)?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_endorsing_right_with_tz3_to_json() -> Result<(), Error> {
+        let er = EndorsingRight::new(
+            296771,
+            SignaturePublicKeyHash::from_b58_hash("tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5")?,
+            vec![30, 1],
+            Some(1585207011),
+        );
+
+        let json = er.as_map();
+        let expected_json = json!({"level":296771,"delegate":"tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5","slots":[30,1],"estimated_time":"2020-03-26T07:16:51Z"});
+        assert_json_eq!(expected_json, serde_json::to_value(json)?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_baking_right_to_json() -> Result<(), Error> {
+        let er = BakingRights::new(
+            296781,
+            SignaturePublicKeyHash::from_b58_hash("tz2BFE2MEHhphgcR7demCGQP2k1zG1iMj1oj")?,
+            123,
+            Some(1585207381),
+        );
+
+        let json = er.as_map();
+        let expected_json = json!({"level":296781,"delegate":"tz2BFE2MEHhphgcR7demCGQP2k1zG1iMj1oj","priority":123,"estimated_time":"2020-03-26T07:23:01Z"});
+        assert_json_eq!(expected_json, serde_json::to_value(json)?);
+        Ok(())
+    }
+}

--- a/tezos/messages/src/protocol/proto_009/rights.rs
+++ b/tezos/messages/src/protocol/proto_009/rights.rs
@@ -108,8 +108,8 @@ impl ToRpcJsonMap for BakingRights {
 
 #[cfg(test)]
 mod tests {
-    use assert_json_diff::assert_json_eq;
     use anyhow::Error;
+    use assert_json_diff::assert_json_eq;
     use serde_json::json;
 
     use crate::base::signature_public_key_hash::SignaturePublicKeyHash;

--- a/tezos/messages/src/protocol/proto_009/rights.rs
+++ b/tezos/messages/src/protocol/proto_009/rights.rs
@@ -109,7 +109,7 @@ impl ToRpcJsonMap for BakingRights {
 #[cfg(test)]
 mod tests {
     use assert_json_diff::assert_json_eq;
-    use failure::Error;
+    use anyhow::Error;
     use serde_json::json;
 
     use crate::base::signature_public_key_hash::SignaturePublicKeyHash;

--- a/tezos/messages/src/protocol/proto_009/votes.rs
+++ b/tezos/messages/src/protocol/proto_009/votes.rs
@@ -1,0 +1,24 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use getset::Getters;
+use serde::Serialize;
+
+/// Struct for the delegates and they voting power (in rolls)
+#[derive(Serialize, Debug, Clone, Getters, Eq, Ord, PartialEq, PartialOrd)]
+pub struct VoteListings {
+    /// Public key hash (address, e.g tz1...)
+    #[get = "pub"]
+    pkh: String,
+
+    /// Number of rolls the pkh owns
+    #[get = "pub"]
+    rolls: i32,
+}
+
+impl VoteListings {
+    /// Simple constructor to construct VoteListings
+    pub fn new(pkh: String, rolls: i32) -> Self {
+        Self { pkh, rolls }
+    }
+}

--- a/tezos/messages/src/protocol/proto_010/constants.rs
+++ b/tezos/messages/src/protocol/proto_010/constants.rs
@@ -1,0 +1,201 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use std::collections::HashMap;
+
+use getset::{CopyGetters, Getters};
+use serde::{Deserialize, Serialize};
+
+use tezos_encoding::nom::NomReader;
+use tezos_encoding::{
+    encoding::HasEncoding,
+    types::{Mutez, Zarith},
+};
+
+use crate::base::rpc_support::{ToRpcJsonMap, UniversalValue};
+
+pub const FIXED: FixedConstants = FixedConstants {
+    proof_of_work_nonce_size: 8,
+    nonce_length: 32,
+    max_anon_ops_per_block: 132,
+    max_operation_data_length: 16 * 1024,
+    max_proposals_per_delegate: 20,
+};
+
+#[derive(Serialize, Deserialize, Debug, Clone, CopyGetters)]
+pub struct FixedConstants {
+    proof_of_work_nonce_size: u8,
+    #[get_copy = "pub"]
+    nonce_length: u8,
+    max_anon_ops_per_block: u8,
+    max_operation_data_length: i32,
+    max_proposals_per_delegate: u8,
+}
+
+impl ToRpcJsonMap for FixedConstants {
+    fn as_map(&self) -> HashMap<&'static str, UniversalValue> {
+        let mut ret: HashMap<&'static str, UniversalValue> = Default::default();
+        ret.insert(
+            "proof_of_work_nonce_size",
+            UniversalValue::num(self.proof_of_work_nonce_size),
+        );
+        ret.insert("nonce_length", UniversalValue::num(self.nonce_length));
+        ret.insert(
+            "max_anon_ops_per_block",
+            UniversalValue::num(self.max_anon_ops_per_block),
+        );
+        ret.insert(
+            "max_operation_data_length",
+            UniversalValue::num(self.max_operation_data_length),
+        );
+        ret.insert(
+            "max_proposals_per_delegate",
+            UniversalValue::num(self.max_proposals_per_delegate),
+        );
+        ret
+    }
+}
+
+// -----------------------------------------------------------------------------------------------
+#[derive(Serialize, Deserialize, Debug, Clone, Getters, CopyGetters, HasEncoding, NomReader)]
+pub struct ParametricConstants {
+    #[get_copy = "pub"]
+    preserved_cycles: u8,
+    #[get_copy = "pub"]
+    blocks_per_cycle: i32,
+    blocks_per_commitment: i32,
+    #[get_copy = "pub"]
+    blocks_per_roll_snapshot: i32,
+    blocks_per_voting_period: i32,
+    #[get = "pub"]
+    #[encoding(dynamic, list)]
+    time_between_blocks: Vec<i64>,
+    #[get_copy = "pub"]
+    endorsers_per_block: u16,
+    hard_gas_limit_per_operation: Zarith,
+    hard_gas_limit_per_block: Zarith,
+    proof_of_work_threshold: i64,
+    tokens_per_roll: Mutez,
+    michelson_maximum_type_size: u16,
+    seed_nonce_revelation_tip: Mutez,
+    origination_size: i32,
+    block_security_deposit: Mutez,
+    endorsement_security_deposit: Mutez,
+    #[encoding(dynamic, list)]
+    baking_reward_per_endorsement: Vec<Mutez>,
+    #[encoding(dynamic, list)]
+    endorsement_reward: Vec<Mutez>,
+    cost_per_byte: Mutez,
+    hard_storage_limit_per_operation: Zarith,
+    test_chain_duration: i64,
+    quorum_min: i32,
+    quorum_max: i32,
+    min_proposal_quorum: i32,
+    initial_endorsers: u16,
+    delay_per_missing_endorsement: i64,
+}
+
+impl ToRpcJsonMap for ParametricConstants {
+    fn as_map(&self) -> HashMap<&'static str, UniversalValue> {
+        let mut ret: HashMap<&'static str, UniversalValue> = Default::default();
+        ret.insert(
+            "preserved_cycles",
+            UniversalValue::num(self.preserved_cycles),
+        );
+        ret.insert(
+            "blocks_per_cycle",
+            UniversalValue::num(self.blocks_per_cycle),
+        );
+        ret.insert(
+            "blocks_per_commitment",
+            UniversalValue::num(self.blocks_per_commitment),
+        );
+        ret.insert(
+            "blocks_per_roll_snapshot",
+            UniversalValue::num(self.blocks_per_roll_snapshot),
+        );
+        ret.insert(
+            "blocks_per_voting_period",
+            UniversalValue::num(self.blocks_per_voting_period),
+        );
+        ret.insert(
+            "time_between_blocks",
+            UniversalValue::i64_list(self.time_between_blocks.clone()),
+        );
+        ret.insert(
+            "endorsers_per_block",
+            UniversalValue::num(self.endorsers_per_block),
+        );
+        ret.insert(
+            "hard_gas_limit_per_operation",
+            UniversalValue::big_num(self.hard_gas_limit_per_operation.clone()),
+        );
+        ret.insert(
+            "hard_gas_limit_per_block",
+            UniversalValue::big_num(self.hard_gas_limit_per_block.clone()),
+        );
+        ret.insert(
+            "proof_of_work_threshold",
+            UniversalValue::i64(self.proof_of_work_threshold),
+        );
+        ret.insert(
+            "tokens_per_roll",
+            UniversalValue::big_num(self.tokens_per_roll.clone()),
+        );
+        ret.insert(
+            "michelson_maximum_type_size",
+            UniversalValue::num(self.michelson_maximum_type_size),
+        );
+        ret.insert(
+            "seed_nonce_revelation_tip",
+            UniversalValue::big_num(self.seed_nonce_revelation_tip.clone()),
+        );
+        ret.insert(
+            "origination_size",
+            UniversalValue::num(self.origination_size),
+        );
+        ret.insert(
+            "block_security_deposit",
+            UniversalValue::big_num(self.block_security_deposit.clone()),
+        );
+        ret.insert(
+            "endorsement_security_deposit",
+            UniversalValue::big_num(self.endorsement_security_deposit.clone()),
+        );
+        ret.insert(
+            "baking_reward_per_endorsement",
+            UniversalValue::big_num_list(self.baking_reward_per_endorsement.clone()),
+        );
+        ret.insert(
+            "endorsement_reward",
+            UniversalValue::big_num_list(self.endorsement_reward.clone()),
+        );
+        ret.insert(
+            "cost_per_byte",
+            UniversalValue::big_num(self.cost_per_byte.clone()),
+        );
+        ret.insert(
+            "hard_storage_limit_per_operation",
+            UniversalValue::big_num(self.hard_storage_limit_per_operation.clone()),
+        );
+        ret.insert(
+            "test_chain_duration",
+            UniversalValue::i64(self.test_chain_duration),
+        );
+        ret.insert("quorum_min", UniversalValue::num(self.quorum_min));
+        ret.insert("quorum_max", UniversalValue::num(self.quorum_max));
+        ret.insert(
+            "min_proposal_quorum",
+            UniversalValue::num(self.min_proposal_quorum),
+        );
+        ret.insert(
+            "initial_endorsers",
+            UniversalValue::num(self.initial_endorsers),
+        );
+        ret.insert(
+            "delay_per_missing_endorsement",
+            UniversalValue::i64(self.delay_per_missing_endorsement),
+        );
+        ret
+    }
+}

--- a/tezos/messages/src/protocol/proto_010/contract.rs
+++ b/tezos/messages/src/protocol/proto_010/contract.rs
@@ -1,0 +1,19 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use getset::Getters;
+use serde::Serialize;
+
+use tezos_encoding::{encoding::HasEncoding, nom::NomReader, types::Zarith};
+
+#[derive(Serialize, Debug, Clone, Getters, HasEncoding, NomReader)]
+pub struct Counter {
+    #[get = "pub"]
+    counter: Zarith,
+}
+
+impl Counter {
+    pub fn to_string_representation(&self) -> String {
+        self.counter.0.to_str_radix(10)
+    }
+}

--- a/tezos/messages/src/protocol/proto_010/mod.rs
+++ b/tezos/messages/src/protocol/proto_010/mod.rs
@@ -1,0 +1,8 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+pub mod constants;
+pub mod contract;
+pub mod rights;
+pub mod votes;
+
+pub const PROTOCOL_HASH: &str = "PtGRANADsDU8R9daYKAgWnQYAJ64omN1o3KMGVCykShA97vQbvV";

--- a/tezos/messages/src/protocol/proto_010/rights.rs
+++ b/tezos/messages/src/protocol/proto_010/rights.rs
@@ -108,8 +108,8 @@ impl ToRpcJsonMap for BakingRights {
 
 #[cfg(test)]
 mod tests {
-    use assert_json_diff::assert_json_eq;
     use anyhow::Error;
+    use assert_json_diff::assert_json_eq;
     use serde_json::json;
 
     use crate::base::signature_public_key_hash::SignaturePublicKeyHash;

--- a/tezos/messages/src/protocol/proto_010/rights.rs
+++ b/tezos/messages/src/protocol/proto_010/rights.rs
@@ -1,0 +1,163 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use std::collections::HashMap;
+
+use serde::Serialize;
+
+use crate::base::rpc_support::{ToRpcJsonMap, UniversalValue};
+use crate::base::signature_public_key_hash::SignaturePublicKeyHash;
+
+/// Endorsing rights structure, final response look like Vec<EndorsingRight>
+#[derive(Serialize, Debug, Clone)]
+pub struct EndorsingRight {
+    /// block level for which endorsing rights are generated
+    pub level: i32,
+
+    /// endorser contract id
+    pub delegate: SignaturePublicKeyHash,
+
+    /// list of endorsement slots
+    pub slots: Vec<u16>,
+
+    /// estimated time of endorsement, is set to None if in past relative to block_id
+    pub estimated_time: Option<i64>,
+}
+
+impl EndorsingRight {
+    /// Simple constructor to construct EndorsingRight
+    pub fn new(
+        level: i32,
+        delegate: SignaturePublicKeyHash,
+        slots: Vec<u16>,
+        estimated_time: Option<i64>,
+    ) -> Self {
+        Self {
+            level,
+            delegate,
+            slots,
+            estimated_time,
+        }
+    }
+}
+
+impl ToRpcJsonMap for EndorsingRight {
+    fn as_map(&self) -> HashMap<&'static str, UniversalValue> {
+        let mut ret: HashMap<&'static str, UniversalValue> = Default::default();
+        ret.insert("level", UniversalValue::num(self.level));
+        ret.insert(
+            "delegate",
+            UniversalValue::string(self.delegate.to_string_representation()),
+        );
+        ret.insert("slots", UniversalValue::num_list(self.slots.iter()));
+        if let Some(ts) = self.estimated_time {
+            ret.insert("estimated_time", UniversalValue::timestamp_rfc3339(ts));
+        }
+        ret
+    }
+}
+
+/// Object containing information about the baking rights
+#[derive(Serialize, Debug, Clone)]
+pub struct BakingRights {
+    /// block level for which baking rights are generated
+    pub level: i32,
+
+    /// baker contract id
+    pub delegate: SignaturePublicKeyHash,
+
+    /// baker priority to bake block
+    pub priority: u16,
+
+    /// estimated time of baking based on baking priority, is set to None if in past relative to block_id
+    pub estimated_time: Option<i64>,
+}
+
+impl BakingRights {
+    /// Simple constructor to construct BakingRights
+    pub fn new(
+        level: i32,
+        delegate: SignaturePublicKeyHash,
+        priority: u16,
+        estimated_time: Option<i64>,
+    ) -> Self {
+        Self {
+            level,
+            delegate,
+            priority,
+            estimated_time,
+        }
+    }
+}
+
+impl ToRpcJsonMap for BakingRights {
+    fn as_map(&self) -> HashMap<&'static str, UniversalValue> {
+        let mut ret: HashMap<&'static str, UniversalValue> = Default::default();
+        ret.insert("level", UniversalValue::num(self.level));
+        ret.insert(
+            "delegate",
+            UniversalValue::string(self.delegate.to_string_representation()),
+        );
+        ret.insert("priority", UniversalValue::num(self.priority));
+        if let Some(ts) = self.estimated_time {
+            ret.insert("estimated_time", UniversalValue::timestamp_rfc3339(ts));
+        }
+        ret
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_json_diff::assert_json_eq;
+    use failure::Error;
+    use serde_json::json;
+
+    use crate::base::signature_public_key_hash::SignaturePublicKeyHash;
+    use crate::protocol::proto_010::rights::{BakingRights, EndorsingRight};
+    use crate::protocol::ToRpcJsonMap;
+
+    #[test]
+    fn test_endorsing_right_with_tz1_to_json() -> Result<(), Error> {
+        let er = EndorsingRight::new(
+            296772,
+            SignaturePublicKeyHash::from_b58_hash("tz1VxS7ff4YnZRs8b4mMP4WaMVpoQjuo1rjf")?,
+            vec![27, 16, 14, 13, 0],
+            Some(1585207011),
+        );
+
+        let json = er.as_map();
+        let expected_json = json!({"level":296772,"delegate":"tz1VxS7ff4YnZRs8b4mMP4WaMVpoQjuo1rjf","slots":[27,16,14,13,0],"estimated_time":"2020-03-26T07:16:51Z"});
+        assert_json_eq!(expected_json, serde_json::to_value(json)?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_endorsing_right_with_tz3_to_json() -> Result<(), Error> {
+        let er = EndorsingRight::new(
+            296771,
+            SignaturePublicKeyHash::from_b58_hash("tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5")?,
+            vec![30, 1],
+            Some(1585207011),
+        );
+
+        let json = er.as_map();
+        let expected_json = json!({"level":296771,"delegate":"tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5","slots":[30,1],"estimated_time":"2020-03-26T07:16:51Z"});
+        assert_json_eq!(expected_json, serde_json::to_value(json)?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_baking_right_to_json() -> Result<(), Error> {
+        let er = BakingRights::new(
+            296781,
+            SignaturePublicKeyHash::from_b58_hash("tz2BFE2MEHhphgcR7demCGQP2k1zG1iMj1oj")?,
+            123,
+            Some(1585207381),
+        );
+
+        let json = er.as_map();
+        let expected_json = json!({"level":296781,"delegate":"tz2BFE2MEHhphgcR7demCGQP2k1zG1iMj1oj","priority":123,"estimated_time":"2020-03-26T07:23:01Z"});
+        assert_json_eq!(expected_json, serde_json::to_value(json)?);
+        Ok(())
+    }
+}

--- a/tezos/messages/src/protocol/proto_010/rights.rs
+++ b/tezos/messages/src/protocol/proto_010/rights.rs
@@ -109,7 +109,7 @@ impl ToRpcJsonMap for BakingRights {
 #[cfg(test)]
 mod tests {
     use assert_json_diff::assert_json_eq;
-    use failure::Error;
+    use anyhow::Error;
     use serde_json::json;
 
     use crate::base::signature_public_key_hash::SignaturePublicKeyHash;

--- a/tezos/messages/src/protocol/proto_010/votes.rs
+++ b/tezos/messages/src/protocol/proto_010/votes.rs
@@ -1,0 +1,24 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use getset::Getters;
+use serde::Serialize;
+
+/// Struct for the delegates and they voting power (in rolls)
+#[derive(Serialize, Debug, Clone, Getters, Eq, Ord, PartialEq, PartialOrd)]
+pub struct VoteListings {
+    /// Public key hash (address, e.g tz1...)
+    #[get = "pub"]
+    pkh: String,
+
+    /// Number of rolls the pkh owns
+    #[get = "pub"]
+    rolls: i32,
+}
+
+impl VoteListings {
+    /// Simple constructor to construct VoteListings
+    pub fn new(pkh: String, rolls: i32) -> Self {
+        Self { pkh, rolls }
+    }
+}


### PR DESCRIPTION
This PR reimplements the rights RPC and disable the routing to the protocol to serve them faster. It utilizes new storages for data needed to do the required computations.

Before merge:

- [x] look into possible leftover TODOs
- [x] cleanup debug messages (println, crit!, ...)
- [x] rustfmt...
- [x] Additionally this test has to pass http://65.21.165.82/tezedge/tezedge/16