### PR TITLE
Implement simulation for max connection number

### DIFF
--- a/shell_automaton/src/peer/connection/incoming/peer_connection_incoming_reducer.rs
+++ b/shell_automaton/src/peer/connection/incoming/peer_connection_incoming_reducer.rs
@@ -35,7 +35,7 @@ pub fn peer_connection_incoming_reducer(state: &mut State, action: &ActionWithId
                     PeerConnectionIncomingState::Pending { token, .. },
                 )) = peer.status
                 {
-                    if peers_connected < state.config.peers_connected_max {
+                    if peers_connected <= state.config.peers_connected_max {
                         peer.status = PeerStatus::Connecting(
                             PeerConnectionIncomingState::Success {
                                 time: action_time,

--- a/shell_automaton/src/peer/connection/incoming/peer_connection_incoming_reducer.rs
+++ b/shell_automaton/src/peer/connection/incoming/peer_connection_incoming_reducer.rs
@@ -29,21 +29,7 @@ pub fn peer_connection_incoming_reducer(state: &mut State, action: &ActionWithId
             }
         }
         Action::PeerConnectionIncomingSuccess(action) => {
-            let peers_connected = state.peers.iter().fold(0, |num, (_, peer)| match &peer.status {
-                PeerStatus::Connecting(state) => match state {
-                    PeerConnectionState::Outgoing(state) => match state {
-                        crate::peer::connection::outgoing::PeerConnectionOutgoingState::Success { .. } => num + 1,
-                        _ => num,
-                    }
-                    PeerConnectionState::Incoming(state) => match state {
-                        PeerConnectionIncomingState::Success { .. } => num + 1,
-                        _ => num,
-                    }
-                },
-                PeerStatus::Handshaking(_) |
-                PeerStatus::Handshaked(_) => num + 1,
-                _ => num,
-            });
+            let peers_connected = state.peers.connected_len();
             if let Some(peer) = state.peers.get_mut(&action.address) {
                 if let PeerStatus::Connecting(PeerConnectionState::Incoming(
                     PeerConnectionIncomingState::Pending { token, .. },

--- a/shell_automaton/src/peer/connection/incoming/peer_connection_incoming_reducer.rs
+++ b/shell_automaton/src/peer/connection/incoming/peer_connection_incoming_reducer.rs
@@ -29,18 +29,35 @@ pub fn peer_connection_incoming_reducer(state: &mut State, action: &ActionWithId
             }
         }
         Action::PeerConnectionIncomingSuccess(action) => {
+            let peers_connected = state.peers.iter().fold(0, |num, (_, peer)| match &peer.status {
+                PeerStatus::Connecting(state) => match state {
+                    PeerConnectionState::Outgoing(state) => match state {
+                        crate::peer::connection::outgoing::PeerConnectionOutgoingState::Success { .. } => num + 1,
+                        _ => num,
+                    }
+                    PeerConnectionState::Incoming(state) => match state {
+                        PeerConnectionIncomingState::Success { .. } => num + 1,
+                        _ => num,
+                    }
+                },
+                PeerStatus::Handshaking(_) |
+                PeerStatus::Handshaked(_) => num + 1,
+                _ => num,
+            });
             if let Some(peer) = state.peers.get_mut(&action.address) {
                 if let PeerStatus::Connecting(PeerConnectionState::Incoming(
                     PeerConnectionIncomingState::Pending { token, .. },
                 )) = peer.status
                 {
-                    peer.status = PeerStatus::Connecting(
-                        PeerConnectionIncomingState::Success {
-                            time: action_time,
-                            token,
-                        }
-                        .into(),
-                    );
+                    if peers_connected < state.config.peers_connected_max {
+                        peer.status = PeerStatus::Connecting(
+                            PeerConnectionIncomingState::Success {
+                                time: action_time,
+                                token,
+                            }
+                            .into(),
+                        );
+                    }
                 }
             }
         }

--- a/shell_automaton/tests/connection_threshold.rs
+++ b/shell_automaton/tests/connection_threshold.rs
@@ -25,8 +25,7 @@ use shell_automaton::{
         PeerToken,
     },
     peers::{add::PeersAddIncomingPeerAction, remove::PeersRemoveAction},
-    reducer,
-    Action, ActionId, ActionWithId, Config, State,
+    reducer, Action, ActionId, ActionWithId, Config, State,
 };
 
 macro_rules! peer_actions {

--- a/shell_automaton/tests/connection_threshold.rs
+++ b/shell_automaton/tests/connection_threshold.rs
@@ -1,0 +1,268 @@
+use std::{
+    io::Write,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+};
+
+use shell_automaton::{
+    config::default_config,
+    peer::{
+        connection::{
+            closed::PeerConnectionClosedAction,
+            incoming::{
+                accept::{
+                    PeerConnectionIncomingAcceptAction, PeerConnectionIncomingAcceptSuccessAction,
+                    PeerConnectionIncomingRejectedAction, PeerConnectionIncomingRejectedReason,
+                },
+                PeerConnectionIncomingSuccessAction,
+            },
+            outgoing::{
+                PeerConnectionOutgoingInitAction, PeerConnectionOutgoingPendingAction,
+                PeerConnectionOutgoingRandomInitAction, PeerConnectionOutgoingSuccessAction,
+            },
+            PeerConnectionState,
+        },
+        disconnection::{PeerDisconnectAction, PeerDisconnectedAction},
+        PeerToken,
+    },
+    peers::{add::PeersAddIncomingPeerAction, remove::PeersRemoveAction},
+    reducer,
+    Action, ActionId, ActionWithId, Config, State,
+};
+
+macro_rules! peer_actions {
+    ($count:expr, { $($rest:tt)* }) => {
+        {
+            let mut actions = Vec::new();
+            peer_actions!(_impl actions, $count, { $($rest)* });
+            actions
+        }
+    };
+
+    (_impl $actions:expr, $count:expr, { $action:ident { address $(, $($fields:tt)*)? }, $($rest:tt)* } ) => {
+        $actions.extend((0..$count as u16).map(|i| peer_actions!(address $action, i, $($($fields)*)?)));
+        peer_actions!(_impl $actions, $count, { $($rest)* });
+    };
+
+    (_impl $actions:expr, $count:expr, { $action:ident { token_address $(, $($fields:tt)*)? }, $($rest:tt)* } ) => {
+        $actions.extend((0..$count as u16).map(|i| peer_actions!(token_address $action, i, $($($fields)*)?)));
+        peer_actions!(_impl $actions, $count, { $($rest)* });
+    };
+
+    (_impl $actions:expr, $count:expr, { $action:ident $({ $($fields:tt)* })?, $($rest:tt)* } ) => {
+        $actions.push($action { $($($fields)*)? } .into());
+        peer_actions!(_impl $actions, $count, { $($rest)* });
+    };
+
+    (_impl $actions:expr, $count:expr, {, }) => {};
+    (_impl $actions:expr, $count:expr, { }) => {};
+
+    (address $action:ident, $i:expr, $($fields:tt)*) => {
+        $action { address: peer_actions!(address $i), $($fields)* }.into()
+    };
+
+    (token_address $action:ident, $i:expr, $($fields:tt)*) => {
+        $action { token: peer_actions!(token $i), address: peer_actions!(address $i), $($fields)* }.into()
+    };
+
+    (address $i:expr) => {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), $i as u16)
+    };
+
+    (token $i:expr) => {
+        PeerToken::new_unchecked($i as usize)
+    };
+}
+
+fn prepare_actions(count: usize) -> Vec<ActionWithId<Action>> {
+    let actions = peer_actions!(count, {
+            PeersAddIncomingPeerAction { token_address },
+            PeersRemoveAction { address },
+            PeerConnectionIncomingAcceptAction,
+            //PeerConnectionIncomingAcceptErrorAction { reason:  },
+            PeerConnectionIncomingRejectedAction { token_address, reason: PeerConnectionIncomingRejectedReason::PeersConnectedMaxBoundReached },
+            PeerConnectionIncomingAcceptSuccessAction { token_address },
+
+            PeerConnectionIncomingSuccessAction { address },
+
+            PeerConnectionOutgoingRandomInitAction,
+            PeerConnectionOutgoingInitAction { address },
+            PeerConnectionOutgoingPendingAction { token_address },
+    //        PeerConnectionOutgoingErrorAction { token_address },
+            PeerConnectionOutgoingSuccessAction { address },
+
+            PeerConnectionClosedAction { address },
+
+            PeerDisconnectAction { address },
+            PeerDisconnectedAction { address },
+        });
+    actions
+        .into_iter()
+        .map(|action| ActionWithId {
+            action,
+            id: ActionId::new_unchecked(0),
+        })
+        .collect()
+}
+
+mod state_explorer;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, strum_macros::AsRefStr)]
+enum PeerState {
+    Potential,
+    IncomingPending,
+    IncomingSuccess,
+    OutgoingIdle,
+    OutgoingPending,
+    OutgoingError,
+    OutgoingSuccess,
+    Connected,
+    Disconnecting,
+    Disconnected,
+    Error,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct Peer {
+    address: SocketAddr,
+    state: PeerState,
+}
+
+impl std::fmt::Display for Peer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}({})", self.address, self.state.as_ref())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ConnectedPeers {
+    peers: Vec<Peer>,
+    max: usize,
+}
+
+impl From<State> for ConnectedPeers {
+    fn from(state: State) -> Self {
+        let mut peers: Vec<_> = state
+            .peers.iter()
+            .map(|(address, peer)| Peer {
+                address: *address,
+                state: match &peer.status {
+                    shell_automaton::peer::PeerStatus::Potential => PeerState::Potential,
+                    shell_automaton::peer::PeerStatus::Connecting(PeerConnectionState::Incoming(state)) => match state {
+                        shell_automaton::peer::connection::incoming::PeerConnectionIncomingState::Pending { .. } => PeerState::IncomingPending,
+                        shell_automaton::peer::connection::incoming::PeerConnectionIncomingState::Success { .. } => PeerState::IncomingSuccess,
+                        shell_automaton::peer::connection::incoming::PeerConnectionIncomingState::Error { .. } => PeerState::Error,
+                    },
+                    shell_automaton::peer::PeerStatus::Connecting(PeerConnectionState::Outgoing(state)) => match state {
+                        shell_automaton::peer::connection::outgoing::PeerConnectionOutgoingState::Idle { .. } => PeerState::OutgoingIdle,
+                        shell_automaton::peer::connection::outgoing::PeerConnectionOutgoingState::Pending { .. } => PeerState::OutgoingPending,
+                        shell_automaton::peer::connection::outgoing::PeerConnectionOutgoingState::Error { .. } => PeerState::OutgoingError,
+                        shell_automaton::peer::connection::outgoing::PeerConnectionOutgoingState::Success { .. } => PeerState::OutgoingSuccess,
+                    },
+                    shell_automaton::peer::PeerStatus::Disconnecting(_) => PeerState::Disconnecting,
+                    shell_automaton::peer::PeerStatus::Disconnected => PeerState::Disconnected,
+                    _ => PeerState::Connected,
+                },
+            })
+            .collect();
+        peers.sort_by_key(|peer| peer.address);
+        ConnectedPeers {
+            peers,
+            max: state.config.peers_connected_max,
+        }
+    }
+}
+
+impl state_explorer::GenState for ConnectedPeers {
+    fn within_bounds(&self) -> bool {
+        let num = self.peers.iter().fold(0, |num, peer| match peer.state {
+            PeerState::IncomingSuccess | PeerState::OutgoingSuccess | PeerState::Connected => {
+                num + 1
+            }
+            _ => num,
+        });
+        // panic if we have more connected peers that allowed
+        assert!(num <= self.max);
+        // limit the number of peers being processed
+        num <= self.max * 2
+    }
+}
+
+pub fn test_config(max_connections: usize) -> Config {
+    Config {
+        peers_connected_max: max_connections,
+        ..default_config()
+    }
+}
+
+/// This test can be executed as follows:
+/// ```bash
+/// PEERS_NUM=6 MAX_CONNECTIONS=4 cargo test --test connection_threshold -- --nocapture --ignored
+/// ```
+///
+/// To generate states diagram in SVG, run the following (with greater numbers will take forever to render graph):
+/// ```bash
+/// $ GRAPH_FILE_NAME=graph.dot PEERS_NUM=3 MAX_CONNECTIONS=2 cargo test --test connection_threshold -- --nocapture --ignored
+/// $ dot -Tsvg graph.dot -o graph.svg
+/// ```
+#[ignore = "Long running simulation for manual execution"]
+#[test]
+fn connection_threshold_simulation() {
+    let max_peers: usize = std::env::var("PEERS_NUM")
+        .map(|s| {
+            s.parse::<usize>()
+                .expect("cannot parse PEERS_NUM as integer")
+        })
+        .unwrap_or(8);
+    let max_connections: usize = std::env::var("MAX_CONNECTIONS")
+        .map(|s| {
+            s.parse::<usize>()
+                .expect("cannot parse MAX_CONNECTIONS as integer")
+        })
+        .unwrap_or(5);
+
+    let actions = prepare_actions(max_peers);
+    let explorer = state_explorer::StateExplorer::<_, _, ConnectedPeers>::new(
+        State::new(test_config(max_connections)),
+        actions,
+        |s, a| {
+            let mut s = s.clone();
+            reducer(&mut s, a);
+            Some(s)
+        },
+    );
+    let graph = explorer.explore();
+    if let Ok(name) = std::env::var("GRAPH_FILE_NAME") {
+        dump_graph(&name, graph);
+    }
+}
+
+fn dump_graph(name: &str, graph: state_explorer::Graph<ActionWithId<Action>, ConnectedPeers>) {
+    std::fs::File::create(name)
+        .and_then(|mut f| {
+            writeln!(f, "digraph ConnectionThreshold {}", '{')?;
+            for (i, (state, transitions)) in graph.states_transitions.into_iter().enumerate() {
+                writeln!(
+                    f,
+                    r#"State_{}[label="{}"]"#,
+                    i,
+                    state.peers.iter().fold(String::new(), |mut s, p| {
+                        use std::fmt::Write;
+                        write!(s, "{}\n", p).unwrap();
+                        s
+                    })
+                )?;
+                for (action, state) in transitions.transitions {
+                    writeln!(
+                        f,
+                        r#"State_{} -> State_{}[label="{}"]"#,
+                        i,
+                        state,
+                        graph.actions[action].action.as_ref()
+                    )?;
+                }
+            }
+            writeln!(f, "{}", '}')?;
+            Ok(())
+        })
+        .expect("cannot write graph");
+}

--- a/shell_automaton/tests/state_explorer.rs
+++ b/shell_automaton/tests/state_explorer.rs
@@ -1,0 +1,185 @@
+#![allow(dead_code)]
+
+use std::collections::{HashMap, HashSet};
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::mem;
+
+pub trait GenState: Clone + PartialEq + Eq + Hash + Debug {
+    /// Predicate that allows limiting the size of state graph.
+    fn within_bounds(&self) -> bool;
+}
+
+struct GenStateData<S> {
+    /// State ID
+    id: usize,
+    /// Instance of specific state
+    state: S,
+    /// Index of the next untested action.
+    next_action: usize,
+    /// Known transitions out of this state, pairs of action index and state index
+    known_exits: Vec<(usize, usize)>,
+}
+
+impl<S> GenStateData<S> {
+    fn new(id: usize, state: S) -> Self {
+        Self {
+            id,
+            state,
+            next_action: 0,
+            known_exits: Vec::new(),
+        }
+    }
+}
+
+struct ExplorerData<S> {
+    real_state: S,
+    next_action_index: usize,
+}
+
+impl<S> ExplorerData<S> {
+    fn new(real_state: S) -> Self {
+        Self {
+            real_state,
+            next_action_index: 0,
+        }
+    }
+
+    fn next_action_index(&mut self) -> usize {
+        let next = self.next_action_index + 1;
+        mem::replace(&mut self.next_action_index, next)
+    }
+}
+
+pub struct Transitions {
+    pub transitions: Vec<(usize, usize)>,
+}
+
+impl Transitions {
+    fn new() -> Self {
+        Self {
+            transitions: Vec::new(),
+        }
+    }
+
+    fn add_transition(&mut self, action_index: usize, state_index: usize) {
+        self.transitions.push((action_index, state_index))
+    }
+}
+
+pub struct Graph<A, G> {
+    pub actions: Vec<A>,
+    pub states_transitions: Vec<(G, Transitions)>,
+}
+
+pub struct StateExplorer<S, A, G> {
+    actions: Vec<A>,
+    states: HashMap<G, usize>,
+    explorer_data: Vec<ExplorerData<S>>,
+    transitions: Vec<Transitions>,
+    reducer: fn(&S, &A) -> Option<S>,
+    undone: HashSet<G>,
+}
+
+impl<S, A, G> StateExplorer<S, A, G>
+where
+    S: Clone + Into<G>,
+    G: GenState,
+{
+    pub fn new(initial: S, actions: Vec<A>, reducer: fn(&S, &A) -> Option<S>) -> Self {
+        let states = HashMap::new();
+        let explorer_data = Vec::new();
+        let graph_data = Vec::new();
+        let undone = HashSet::new();
+        let mut myself = Self {
+            actions,
+            states,
+            explorer_data,
+            transitions: graph_data,
+            reducer,
+            undone,
+        };
+        let gen_state = initial.clone().into();
+        myself.add_state(0, gen_state, initial);
+        myself
+    }
+
+    fn add_state(&mut self, state_index: usize, gen_state: G, state: S) {
+        assert_eq!(state_index, self.states.len());
+        assert_eq!(state_index, self.explorer_data.len());
+        assert_eq!(state_index, self.transitions.len());
+
+        self.undone.insert(gen_state.clone());
+        self.states.insert(gen_state, state_index);
+
+        self.explorer_data.push(ExplorerData::new(state));
+        self.transitions.push(Transitions::new());
+    }
+
+    pub fn explore(mut self) -> Graph<A, G> {
+        let mut iteration = 0;
+        while let Some(mut gen_state) = self.undone.iter().next().cloned() {
+            loop {
+                if iteration % 10000 == 0 {
+                    print!(
+                        "iteration: {}, states: {}, undone states: {}                \r",
+                        iteration,
+                        self.states.len(),
+                        self.undone.len()
+                    )
+                }
+                iteration += 1;
+                let state_index = *self.states.get(&gen_state).unwrap();
+
+                let gen_state_data = &mut self.explorer_data[state_index];
+                let action_index = gen_state_data.next_action_index();
+                if action_index >= self.actions.len() {
+                    self.undone.remove(&gen_state);
+                    break;
+                }
+
+                let action = &self.actions[action_index];
+                if let Some(new_state) = (self.reducer)(&gen_state_data.real_state, action) {
+                    let new_gen_state = new_state.clone().into();
+                    if !new_gen_state.within_bounds() {
+                        eprintln!("the state {:#?} is out of bounds", new_gen_state);
+                        continue;
+                    }
+                    let (new_state_id, add_state) = self
+                        .states
+                        .get(&new_gen_state)
+                        .map(|index| (*index, false))
+                        .unwrap_or_else(|| (self.states.len(), true));
+                    if add_state {
+                        self.add_state(new_state_id, new_gen_state.clone(), new_state);
+                    } else if new_state_id == state_index {
+                        continue;
+                    }
+                    self.transitions[state_index].add_transition(action_index, new_state_id);
+                    gen_state = new_gen_state;
+                }
+            }
+        }
+        print!(
+            "iterations: {}, states: {}                                                                ",
+            iteration,
+            self.states.len(),
+        );
+
+        let mut states = self.states.into_iter().collect::<Vec<_>>();
+        states.sort_by_key(|(_, k)| *k);
+        let states_transitions = states
+            .into_iter()
+            .enumerate()
+            .map(|(i, (s, i2))| {
+                assert_eq!(i, i2);
+                s
+            })
+            .zip(self.transitions.into_iter())
+            .collect::<Vec<_>>();
+        Graph {
+            actions: self.actions,
+            states_transitions,
+        }
+    }
+}


### PR DESCRIPTION
Test that runs connection simulation.

Can be run using 
```
$ PEERS_NUM=6 MAX_CONNECTIONS=4 cargo test --test connection_threshold -- --nocapture --ignored
```
Also states graph can be generated with help of `Graphviz`:
```
$ GRAPH_FILE_NAME=graph.dot PEERS_NUM=3 MAX_CONNECTIONS=2 cargo test --test connection_threshold -- --nocapture --ignored
$ dot -Tsvg graph.dot -o graph.svg
```