### PR TITLE
shell_automaton: fixes and tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2655,7 +2655,7 @@ dependencies = [
 [[package]]
 name = "redux-rs"
 version = "0.1.0"
-source = "git+https://github.com/tezedge/redux-rs.git?tag=tezedge-v1.10.0#8d06d9d47a013d5e1f406f2ac133f3a9ed6bdff3"
+source = "git+https://github.com/tezedge/redux-rs.git?tag=tezedge-v1.10.0-1#4303b957d24fbc932c532ea7f8704ca6b0125f65"
 dependencies = [
  "serde 1.0.130",
 ]
@@ -3098,6 +3098,22 @@ dependencies = [
  "tezos_messages",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "shell_automaton_testing"
+version = "1.10.0"
+dependencies = [
+ "bytes",
+ "crypto",
+ "networking",
+ "redux-rs",
+ "serde 1.0.130",
+ "shell_automaton",
+ "storage",
+ "tezos_encoding",
+ "tezos_identity",
+ "tezos_messages",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "shell",
     "shell-integration",
     "shell_automaton",
+    "shell_automaton/testing",
     "storage",
     "sandbox",
     "light_node",

--- a/async-ipc/tests/test_ipc.rs
+++ b/async-ipc/tests/test_ipc.rs
@@ -13,6 +13,7 @@ mod common;
 
 #[test]
 #[serial]
+#[ignore] // Disabled for now, this crate is deprecated
 fn ipc_fork_and_client_exchange() -> Result<(), anyhow::Error> {
     let sock_path = temp_sock();
     assert!(!sock_path.exists());
@@ -74,6 +75,7 @@ fn ipc_fork_and_client_exchange() -> Result<(), anyhow::Error> {
 
 #[test]
 #[serial]
+#[ignore] // Disabled for now, this crate is deprecated
 fn ipc_accept_timeout() -> Result<(), anyhow::Error> {
     let tokio_runtime = common::create_tokio_runtime();
 

--- a/shell_automaton/Cargo.toml
+++ b/shell_automaton/Cargo.toml
@@ -24,7 +24,7 @@ slog = { version = "2.7", features = ["max_level_trace", "release_max_level_debu
 strum = "0.20"
 strum_macros = "0.20"
 
-redux-rs = { git = "https://github.com/tezedge/redux-rs.git", tag = "tezedge-v1.10.0", features = ["serde"] }
+redux-rs = { git = "https://github.com/tezedge/redux-rs.git", tag = "tezedge-v1.10.0-1", features = ["serde"] }
 
 crypto = { path = "../crypto" }
 storage = { path = "../storage" }

--- a/shell_automaton/src/logger/logger_effects.rs
+++ b/shell_automaton/src/logger/logger_effects.rs
@@ -57,7 +57,7 @@ pub fn logger_effects<S: Service>(
                 "error" => format!("{:?}", content.error));
         }
         Action::PeerHandshakingFinish(content) => {
-            slog::warn!(log, "Peer Handshaking successful"; "address" => content.address.to_string());
+            slog::info!(log, "Peer Handshaking successful"; "address" => content.address.to_string());
         }
         Action::PeerDisconnect(content) => {
             slog::warn!(log, "Disconnecting peer"; "address" => content.address.to_string());

--- a/shell_automaton/src/peer/handshaking/peer_handshaking_state.rs
+++ b/shell_automaton/src/peer/handshaking/peer_handshaking_state.rs
@@ -44,10 +44,6 @@ pub enum PeerHandshakingError {
     #[error("BadPow error: {0}")]
     BadPow(#[from] PowError),
 
-    /// We are trying to connect to ourself.
-    #[error("ConnectingToSelf error")]
-    ConnectingToSelf,
-
     #[error("Timeout error. Phase: {0}")]
     Timeout(PeerHandshakingPhase),
 }

--- a/shell_automaton/src/peer/peer_state.rs
+++ b/shell_automaton/src/peer/peer_state.rs
@@ -129,6 +129,16 @@ impl Peer {
         self.token().is_some()
     }
 
+    /// Whether or not peer is in `PeerStatus::Disconnected` state.
+    pub fn is_disconnected(&self) -> bool {
+        matches!(self.status, PeerStatus::Disconnected)
+    }
+
+    /// Whether or not peer is handshaked (handshaking is finished successfuly).
+    pub fn is_handshaked(&self) -> bool {
+        matches!(self.status, PeerStatus::Handshaked(_))
+    }
+
     pub fn token(&self) -> Option<PeerToken> {
         match &self.status {
             PeerStatus::Potential => None,

--- a/shell_automaton/src/peers/check/timeouts/peers_check_timeouts_effects.rs
+++ b/shell_automaton/src/peers/check/timeouts/peers_check_timeouts_effects.rs
@@ -29,13 +29,13 @@ fn check_timeout(
     Some(match &peer.status {
         PeerStatus::Potential => return None,
         PeerStatus::Connecting(connecting) => {
-            if current_time >= connecting.time() + peer_connecting_timeout {
+            if current_time < connecting.time() + peer_connecting_timeout {
                 return None;
             }
             PeerTimeout::Connecting(connecting.into())
         }
         PeerStatus::Handshaking(handshaking) => {
-            if current_time >= handshaking.since + peer_handshaking_timeout {
+            if current_time < handshaking.since + peer_handshaking_timeout {
                 return None;
             }
             PeerTimeout::Handshaking((&handshaking.status).into())

--- a/shell_automaton/src/peers/dns_lookup/peers_dns_lookup_state.rs
+++ b/shell_automaton/src/peers/dns_lookup/peers_dns_lookup_state.rs
@@ -53,11 +53,11 @@ pub enum DnsLookupError {
     IO,
 }
 
-impl From<dns_lookup::LookupError> for DnsLookupError {
-    fn from(err: dns_lookup::LookupError) -> Self {
+impl From<dns_lookup::LookupErrorKind> for DnsLookupError {
+    fn from(err: dns_lookup::LookupErrorKind) -> Self {
         use dns_lookup::LookupErrorKind::*;
 
-        match err.kind() {
+        match err {
             Again => Self::Again,
             Badflags => Self::Badflags,
             NoName => Self::NoName,

--- a/shell_automaton/src/service/actors_service.rs
+++ b/shell_automaton/src/service/actors_service.rs
@@ -61,8 +61,9 @@ pub struct AutomatonSyncSender {
 
 impl AutomatonSyncSender {
     pub fn send(&self, msg: ActorsMessageFrom) -> Result<(), mpsc::SendError<ActorsMessageFrom>> {
+        self.sender.send(msg)?;
         let _ = self.mio_waker.wake();
-        self.sender.send(msg)
+        Ok(())
     }
 }
 

--- a/shell_automaton/src/service/mio_service.rs
+++ b/shell_automaton/src/service/mio_service.rs
@@ -87,6 +87,15 @@ impl<Stream> MioPeer<Stream> {
     }
 }
 
+impl<Stream: Clone> Clone for MioPeer<Stream> {
+    fn clone(&self) -> Self {
+        Self {
+            address: self.address,
+            stream: self.stream.clone(),
+        }
+    }
+}
+
 pub struct MioPeerRefMut<'a, Stream> {
     /// Pre-allocated buffer that will be used as a temporary container
     /// for doing read syscall.

--- a/shell_automaton/src/service/mod.rs
+++ b/shell_automaton/src/service/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use redux_rs::TimeService;
+pub use redux_rs::TimeService;
 
 pub mod service_async_channel;
 pub mod service_channel;

--- a/shell_automaton/src/service/service_async_channel.rs
+++ b/shell_automaton/src/service/service_async_channel.rs
@@ -40,8 +40,9 @@ async fn responder_send<T>(
     mio_waker: &Arc<mio::Waker>,
     msg: T,
 ) -> Result<(), ResponseSendError<T>> {
+    sender.send(msg).await?;
     let _ = mio_waker.wake();
-    Ok(sender.send(msg).await?)
+    Ok(())
 }
 
 pub struct ServiceWorkerAsyncResponderSender<Resp> {

--- a/shell_automaton/src/service/service_channel.rs
+++ b/shell_automaton/src/service/service_channel.rs
@@ -100,8 +100,9 @@ fn responder_send<T>(
     mio_waker: &Arc<mio::Waker>,
     msg: T,
 ) -> Result<(), ResponseSendError<T>> {
+    sender.send(msg)?;
     let _ = mio_waker.wake();
-    Ok(sender.send(msg)?)
+    Ok(())
 }
 
 pub struct ServiceWorkerResponderSender<Resp> {

--- a/shell_automaton/testing/Cargo.toml
+++ b/shell_automaton/testing/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "shell_automaton_testing"
+version = "1.10.0"
+edition = "2018"
+
+[dependencies]
+bytes = "1.0.1"
+serde = { version = "1.0", features = ["derive", "rc"] }
+redux-rs = { git = "https://github.com/tezedge/redux-rs.git", tag = "tezedge-v1.10.0-1", features = ["serde"] }
+
+shell_automaton = { path = "../" }
+crypto = { path = "../../crypto" }
+storage = { path = "../../storage" }
+networking = { path = "../../networking" }
+tezos_encoding = { path = "../../tezos/encoding" }
+tezos_identity = { path = "../../tezos/identity" }
+tezos_messages = { path = "../../tezos/messages" }

--- a/shell_automaton/testing/src/lib.rs
+++ b/shell_automaton/testing/src/lib.rs
@@ -1,0 +1,5 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+pub mod one_real_node_cluster;
+pub mod service;

--- a/shell_automaton/testing/src/one_real_node_cluster/cluster.rs
+++ b/shell_automaton/testing/src/one_real_node_cluster/cluster.rs
@@ -1,0 +1,360 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use std::time::{Duration, Instant, SystemTime};
+
+use crypto::crypto_box::{CryptoKey, PublicKey};
+use crypto::nonce::Nonce;
+use redux_rs::Store;
+
+use shell_automaton::event::{P2pPeerEvent, P2pServerEvent};
+use shell_automaton::peer::PeerCrypto;
+use shell_automaton::peers::add::multi::PeersAddMultiAction;
+use shell_automaton::{effects, reducer, Action, State};
+use tezos_identity::Identity;
+use tezos_messages::p2p::binary_message::{BinaryChunk, BinaryWrite};
+use tezos_messages::p2p::encoding::ack::{AckMessage, NackInfo};
+use tezos_messages::p2p::encoding::connection::ConnectionMessage;
+use tezos_messages::p2p::encoding::metadata::MetadataMessage;
+
+use crate::service::{
+    ActorsServiceDummy, ConnectedState, DnsServiceMocked, IOCondition, MioPeerMockedId,
+    MioPeerStreamMocked, MioServiceMocked, QuotaServiceDummy, RandomnessServiceMocked,
+    RpcServiceDummy, StorageServiceDummy,
+};
+use crate::service::{Service, TimeService};
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum HandshakeError {
+    NotConnected,
+    NackV0,
+    Nack(NackInfo),
+}
+
+#[derive(Clone)]
+pub struct ServiceMocked {
+    time: Instant,
+    pub randomness: RandomnessServiceMocked,
+    pub dns: DnsServiceMocked,
+    pub mio: MioServiceMocked,
+    pub storage: StorageServiceDummy,
+    pub rpc: RpcServiceDummy,
+    pub actors: ActorsServiceDummy,
+    pub quota: QuotaServiceDummy,
+}
+
+impl ServiceMocked {
+    pub fn new() -> Self {
+        Self {
+            time: Instant::now(),
+            randomness: RandomnessServiceMocked::Dummy,
+            dns: DnsServiceMocked::Constant(Ok(vec![])),
+            mio: MioServiceMocked::new(([0, 0, 0, 0], 9732).into(), u16::MAX as usize),
+            storage: StorageServiceDummy::new(),
+            rpc: RpcServiceDummy::new(),
+            actors: ActorsServiceDummy::new(),
+            quota: QuotaServiceDummy::new(),
+        }
+    }
+
+    pub fn advance_time(&mut self, by: Duration) {
+        self.time += by;
+    }
+}
+
+impl TimeService for ServiceMocked {
+    fn monotonic_time(&mut self) -> Instant {
+        self.time
+    }
+}
+
+impl Service for ServiceMocked {
+    type Randomness = RandomnessServiceMocked;
+    type Dns = DnsServiceMocked;
+    type Mio = MioServiceMocked;
+    type Storage = StorageServiceDummy;
+    type Rpc = RpcServiceDummy;
+    type Actors = ActorsServiceDummy;
+    type Quota = QuotaServiceDummy;
+
+    fn randomness(&mut self) -> &mut Self::Randomness {
+        &mut self.randomness
+    }
+
+    fn dns(&mut self) -> &mut Self::Dns {
+        &mut self.dns
+    }
+
+    fn mio(&mut self) -> &mut Self::Mio {
+        &mut self.mio
+    }
+
+    fn storage(&mut self) -> &mut Self::Storage {
+        &mut self.storage
+    }
+
+    fn rpc(&mut self) -> &mut Self::Rpc {
+        &mut self.rpc
+    }
+
+    fn actors(&mut self) -> &mut Self::Actors {
+        &mut self.actors
+    }
+
+    fn quota(&mut self) -> &mut Self::Quota {
+        &mut self.quota
+    }
+}
+
+#[derive(Clone)]
+pub struct Cluster {
+    store: Store<State, ServiceMocked, Action>,
+}
+
+impl Cluster {
+    pub fn new(initial_state: State, initial_time: SystemTime) -> Self {
+        Self {
+            store: Store::new(
+                reducer,
+                effects,
+                ServiceMocked::new(),
+                initial_time,
+                initial_state,
+            ),
+        }
+    }
+
+    pub fn advance_time(&mut self, by: Duration) {
+        self.store.service.advance_time(by)
+    }
+
+    pub fn state(&self) -> &State {
+        self.store.state()
+    }
+
+    pub fn dispatch(&mut self, action: Action) {
+        self.store.dispatch(action)
+    }
+
+    pub fn dispatch_peer_ready_event(
+        &mut self,
+        peer_id: MioPeerMockedId,
+        is_readable: bool,
+        is_writable: bool,
+        is_closed: bool,
+    ) {
+        self.dispatch(
+            P2pPeerEvent {
+                token: peer_id.to_token(),
+                address: peer_id.to_ipv4(),
+                is_readable,
+                is_writable,
+                is_closed,
+            }
+            .into(),
+        )
+    }
+
+    pub fn peer_init(&mut self, pow_target: f64) -> MioPeerMockedId {
+        self.store.service.mio().peer_init(pow_target)
+    }
+
+    pub fn peer_init_with_identity(&mut self, identity: Identity) -> MioPeerMockedId {
+        self.store.service.mio().peer_init_with_identity(identity)
+    }
+
+    /// Panics if peer with such id is not found.
+    pub fn peer(&mut self, id: MioPeerMockedId) -> &mut MioPeerStreamMocked {
+        &mut self.store.service.mio().peer(id).stream
+    }
+
+    pub fn connect_from_peer(&mut self, peer_id: MioPeerMockedId) {
+        match self.peer(peer_id).conn_state_mut() {
+            conn_state @ ConnectedState::Disconnected => {
+                *conn_state = ConnectedState::OutgoingInit;
+            }
+            conn_state => panic!(
+                "unexpected peer conn_state when requesting to connect from peer to node: {:?}",
+                conn_state
+            ),
+        }
+        self.store.service.mio().backlog_push(peer_id);
+
+        self.dispatch(P2pServerEvent {}.into())
+    }
+
+    pub fn connect_to_peer(&mut self, peer_id: MioPeerMockedId) {
+        match self.peer(peer_id).conn_state() {
+            ConnectedState::Disconnected => {}
+            conn_state => panic!(
+                "unexpected peer conn_state when requesting to connect to peer from node: {:?}",
+                conn_state
+            ),
+        }
+        self.dispatch(
+            // Adding peer as potential peer will cause node to connect
+            // to it if it doesn't have enough peers.
+            PeersAddMultiAction {
+                addresses: vec![peer_id.to_ipv4()],
+            }
+            .into(),
+        )
+    }
+
+    pub fn set_peer_connected(&mut self, peer_id: MioPeerMockedId) {
+        match self.peer(peer_id).conn_state_mut() {
+            conn_state @ ConnectedState::IncomingInit => {
+                *conn_state = ConnectedState::IncomingConnected;
+            }
+            conn_state @ ConnectedState::OutgoingAccepted => {
+                *conn_state = ConnectedState::OutgoingConnected;
+            }
+            conn_state => panic!(
+                "unexpected peer conn_state when setting peer connected: {:?}",
+                conn_state
+            ),
+        }
+
+        self.dispatch_peer_ready_event(peer_id, false, true, false)
+    }
+
+    /// Automatically create and set peer crypto based on stored conn messages.
+    /// [Self::set_sent_conn_message] and [Self::set_received_conn_msg]
+    /// should be called before this function can be used.
+    pub fn auto_set_peer_crypto(
+        &mut self,
+        peer_id: MioPeerMockedId,
+    ) -> Result<&mut Self, HandshakeError> {
+        let peer = self.peer(peer_id);
+        if peer.crypto().is_some() {
+            return Ok(self);
+        }
+        let sent = peer.sent_conn_msg.clone().unwrap();
+        let received = peer.received_conn_msg.clone().unwrap();
+
+        self.set_peer_crypto_with_conn_messages(peer_id, &sent, &received)
+    }
+
+    pub fn set_peer_crypto(
+        &mut self,
+        peer_id: MioPeerMockedId,
+        peer_public_key: &PublicKey,
+        sent_conn_msg: &BinaryChunk,
+        received_conn_msg: &BinaryChunk,
+    ) -> Result<&mut Self, HandshakeError> {
+        let peer = self.peer(peer_id);
+
+        let incoming = match &peer.conn_state() {
+            ConnectedState::IncomingConnected => true,
+            ConnectedState::OutgoingConnected => false,
+            _ => return Err(HandshakeError::NotConnected),
+        };
+
+        *peer.crypto_mut() = Some(
+            PeerCrypto::build(
+                &peer.identity().secret_key,
+                peer_public_key,
+                sent_conn_msg,
+                received_conn_msg,
+                incoming,
+            )
+            .unwrap(),
+        );
+
+        Ok(self)
+    }
+
+    /// Bytes must be without chunk's length.
+    #[inline]
+    pub fn set_peer_crypto_with_bytes(
+        &mut self,
+        peer_id: MioPeerMockedId,
+        peer_public_key: &[u8],
+        sent_conn_msg: &[u8],
+        received_conn_msg: &[u8],
+    ) -> Result<&mut Self, HandshakeError> {
+        self.set_peer_crypto(
+            peer_id,
+            &PublicKey::from_bytes(peer_public_key).unwrap(),
+            &BinaryChunk::from_content(sent_conn_msg).unwrap(),
+            &BinaryChunk::from_content(received_conn_msg).unwrap(),
+        )
+    }
+
+    #[inline]
+    pub fn set_peer_crypto_with_conn_messages(
+        &mut self,
+        peer_id: MioPeerMockedId,
+        sent_conn_msg: &ConnectionMessage,
+        received_conn_msg: &ConnectionMessage,
+    ) -> Result<&mut Self, HandshakeError> {
+        self.set_peer_crypto_with_bytes(
+            peer_id,
+            received_conn_msg.public_key(),
+            &sent_conn_msg.as_bytes().unwrap(),
+            &received_conn_msg.as_bytes().unwrap(),
+        )
+    }
+
+    /// Exchange connection messages and create crypto to encrypt/decrypt messages.
+    pub fn init_crypto_for_peer(
+        &mut self,
+        peer_id: MioPeerMockedId,
+    ) -> Result<&mut Self, HandshakeError> {
+        let network_version = self
+            .state()
+            .config
+            .shell_compatibility_version
+            .to_network_version();
+        let peer = &mut self.peer(peer_id);
+        peer.set_read_cond(IOCondition::NoLimit)
+            .set_write_cond(IOCondition::NoLimit);
+
+        let sent_conn_msg = ConnectionMessage::try_new(
+            peer_id.to_ipv4().port(),
+            &peer.identity().public_key,
+            &peer.identity().proof_of_work_stamp,
+            Nonce::random(),
+            network_version,
+        )
+        .unwrap();
+
+        peer.send_conn_msg(&sent_conn_msg);
+        self.dispatch_peer_ready_event(peer_id, true, true, false);
+
+        let received_conn_msg = self.peer(peer_id).read_conn_msg();
+
+        self.set_peer_crypto_with_conn_messages(peer_id, &sent_conn_msg, &received_conn_msg)
+    }
+
+    /// Do Handshake between node and fake peer.
+    ///
+    /// 1. Exchange [ConnectionMessage] unless we already have crypto set.
+    ///    Using that set crypto to encrypt/decrypt further messages.
+    /// 2. Exchange encrypted [MetadataMessage].
+    /// 3. Exchange encrypted [AckMessage].
+    pub fn do_handshake(&mut self, peer_id: MioPeerMockedId) -> Result<&mut Self, HandshakeError> {
+        if self.peer(peer_id).crypto().is_none() {
+            self.init_crypto_for_peer(peer_id)?;
+        }
+        self.peer(peer_id)
+            .set_read_cond(IOCondition::NoLimit)
+            .send_meta_msg(&MetadataMessage::new(false, false));
+
+        self.dispatch_peer_ready_event(peer_id, true, true, false);
+
+        let peer = self.peer(peer_id);
+        peer.read_meta_msg();
+
+        peer.set_read_cond(IOCondition::NoLimit)
+            .send_ack_msg(&AckMessage::Ack);
+        self.dispatch_peer_ready_event(peer_id, true, true, false);
+
+        let peer = self.peer(peer_id);
+        match peer.read_ack_message() {
+            AckMessage::Ack => Ok(self),
+            AckMessage::NackV0 => Err(HandshakeError::NackV0),
+            AckMessage::Nack(nack_info) => Err(HandshakeError::Nack(nack_info)),
+        }
+    }
+}

--- a/shell_automaton/testing/src/one_real_node_cluster/mod.rs
+++ b/shell_automaton/testing/src/one_real_node_cluster/mod.rs
@@ -1,0 +1,5 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+mod cluster;
+pub use cluster::*;

--- a/shell_automaton/testing/src/service/actors_service.rs
+++ b/shell_automaton/testing/src/service/actors_service.rs
@@ -1,0 +1,28 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use std::sync::mpsc;
+
+pub use shell_automaton::service::actors_service::{
+    ActorsMessageFrom, ActorsMessageTo, ActorsService,
+};
+
+/// Mocked ActorsService.
+///
+/// Does nothing.
+#[derive(Debug, Clone)]
+pub struct ActorsServiceDummy {}
+
+impl ActorsServiceDummy {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl ActorsService for ActorsServiceDummy {
+    fn send(&self, _: ActorsMessageTo) {}
+
+    fn try_recv(&mut self) -> Result<ActorsMessageFrom, mpsc::TryRecvError> {
+        Err(mpsc::TryRecvError::Empty)
+    }
+}

--- a/shell_automaton/testing/src/service/dns_service.rs
+++ b/shell_automaton/testing/src/service/dns_service.rs
@@ -1,0 +1,23 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use std::net::SocketAddr;
+
+use shell_automaton::service::dns_service::{DnsLookupError, DnsService};
+
+#[derive(Debug, Clone)]
+pub enum DnsServiceMocked {
+    Constant(Result<Vec<SocketAddr>, DnsLookupError>),
+}
+
+impl DnsService for DnsServiceMocked {
+    fn resolve_dns_name_to_peer_address(
+        &mut self,
+        _: &str,
+        _: u16,
+    ) -> Result<Vec<SocketAddr>, DnsLookupError> {
+        match self {
+            DnsServiceMocked::Constant(res) => res.clone(),
+        }
+    }
+}

--- a/shell_automaton/testing/src/service/mio_service/chunking/chunk_read_buffer.rs
+++ b/shell_automaton/testing/src/service/mio_service/chunking/chunk_read_buffer.rs
@@ -1,0 +1,155 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use bytes::Buf;
+use serde::{Deserialize, Serialize};
+use std::io::{self, Read};
+
+use tezos_messages::p2p::binary_message::{BinaryChunk, CONTENT_LENGTH_FIELD_BYTES};
+
+pub trait BinaryMessageContent {
+    fn binary_message_content(&self) -> &[u8];
+}
+
+pub struct BinaryChunkRef<'a>(&'a [u8]);
+
+impl<'a> BinaryChunkRef<'a> {
+    #[allow(dead_code)]
+    #[inline]
+    pub fn raw(&self) -> &[u8] {
+        self.0
+    }
+
+    #[inline]
+    pub fn content(&self) -> &[u8] {
+        &self.0[CONTENT_LENGTH_FIELD_BYTES..]
+    }
+}
+
+impl<'a> BinaryMessageContent for BinaryChunkRef<'a> {
+    #[inline]
+    fn binary_message_content(&self) -> &[u8] {
+        self.content()
+    }
+}
+
+impl BinaryMessageContent for BinaryChunk {
+    #[inline]
+    fn binary_message_content(&self) -> &[u8] {
+        self.content()
+    }
+}
+
+/// Chunk read buffer.
+///
+/// Reads first 2 bytes corresponding to the size of the chunk and reads
+/// that amount of bytes until it's done.
+///
+/// When it's [ChunkReadBuffer::is_finished], to get the result we need to call:
+/// - [ChunkReadBuffer::take_if_ready] to take owned [BinaryChunk].
+/// - [ChunkReadBuffer::take_ref_if_ready] to take [BinaryChunkRef].
+///   This way we can reuse `ChunkReadBuffer` for multiple chunks
+///   and avoid extra allocations, since buffer won't be moved/deallocated,
+///   when taking the result, unlike `take_if_ready` method.
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+pub struct ChunkReadBuffer {
+    buf: Vec<u8>,
+    expected_len: usize,
+    index: usize,
+}
+
+impl ChunkReadBuffer {
+    pub fn new() -> Self {
+        Self {
+            buf: vec![],
+            expected_len: 0,
+            index: 0,
+        }
+    }
+
+    /// Check if reading chunk is finished.
+    pub fn is_finished(&self) -> bool {
+        self.index >= self.expected_len.max(CONTENT_LENGTH_FIELD_BYTES)
+    }
+
+    /// Bytes left until whole chunk is read.
+    ///
+    /// Returns `None` if chunk size is not yet known.
+    #[allow(dead_code)]
+    pub fn bytes_left(&self) -> Option<usize> {
+        if self.index >= CONTENT_LENGTH_FIELD_BYTES {
+            Some(self.expected_len - self.index)
+        } else {
+            None
+        }
+    }
+
+    /// Next slice of buffer that we can write to.
+    fn next_slice(&mut self) -> &mut [u8] {
+        let len = self.expected_len.max(CONTENT_LENGTH_FIELD_BYTES);
+
+        if self.buf.len() < len {
+            self.buf.resize(len, 0);
+        }
+
+        &mut self.buf[self.index..len]
+    }
+
+    /// Returns if more might be available to be read.
+    pub fn read_from<R: Read>(&mut self, reader: &mut R) -> Result<(), io::Error> {
+        loop {
+            let size = reader.read(self.next_slice())?;
+
+            self.index += size;
+
+            if self.expected_len == 0 && self.index >= CONTENT_LENGTH_FIELD_BYTES {
+                self.expected_len = CONTENT_LENGTH_FIELD_BYTES + (&self.buf[..]).get_u16() as usize;
+            }
+            if self.is_finished() {
+                return Ok(());
+            } else if size == 0 {
+                return Err(io::Error::new(io::ErrorKind::WouldBlock, "read 0 bytes"));
+            }
+        }
+    }
+
+    /// Take a peek at read chunk, without consuming it or doing any cleanups.
+    #[allow(dead_code)]
+    pub fn peek_if_ready<'a>(&'a self) -> Option<BinaryChunkRef<'a>> {
+        if self.is_finished() {
+            Some(BinaryChunkRef(&self.buf[..self.expected_len]))
+        } else {
+            None
+        }
+    }
+
+    /// Take a reference for buffer and allow it's reuse for reading
+    /// further chunks to avoid extra allocations.
+    pub fn take_ref_if_ready<'a>(&'a mut self) -> Option<BinaryChunkRef<'a>> {
+        if !self.is_finished() {
+            return None;
+        }
+        let chunk = BinaryChunkRef(&self.buf[..self.expected_len]);
+        self.index = 0;
+        self.expected_len = 0;
+
+        Some(chunk)
+    }
+
+    /// Consume buffer and replace it with new empty one.
+    pub fn take_if_ready(&mut self) -> Option<BinaryChunk> {
+        if !self.is_finished() {
+            return None;
+        }
+        let mut buf = std::mem::take(&mut self.buf);
+        buf.truncate(self.expected_len);
+        self.clear();
+
+        Some(BinaryChunk::from_raw(buf).unwrap())
+    }
+
+    pub fn clear(&mut self) {
+        self.index = 0;
+        self.expected_len = 0;
+    }
+}

--- a/shell_automaton/testing/src/service/mio_service/chunking/chunk_writer.rs
+++ b/shell_automaton/testing/src/service/mio_service/chunking/chunk_writer.rs
@@ -1,0 +1,60 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use std::io::{self, Write};
+
+use tezos_messages::p2p::binary_message::BinaryChunk;
+
+use super::extendable_as_writable::ExtendableAsWritable;
+
+/// BinaryChunk Writer.
+#[derive(Debug, Clone)]
+pub struct ChunkWriter {
+    bytes: BinaryChunk,
+    /// Index of the next to write byte inside the chunk.
+    index: usize,
+}
+
+impl ChunkWriter {
+    pub fn new(bytes: BinaryChunk) -> Self {
+        Self { bytes, index: 0 }
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.bytes.content().len() == 0
+    }
+
+    #[inline]
+    pub fn is_finished(&self) -> bool {
+        self.index >= self.bytes.raw().len()
+    }
+
+    #[inline]
+    fn next_bytes(&self) -> &[u8] {
+        &self.bytes.raw()[self.index..]
+    }
+
+    pub fn write_to<W>(&mut self, writer: &mut W) -> Result<(), io::Error>
+    where
+        W: Write,
+    {
+        loop {
+            let size = writer.write(self.next_bytes())?;
+            self.index += size;
+            if self.is_finished() {
+                return Ok(());
+            } else if size == 0 {
+                return Err(io::Error::new(io::ErrorKind::WouldBlock, "written 0 bytes"));
+            }
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn write_to_extendable<T>(&mut self, extendable: &mut T) -> Result<(), io::Error>
+    where
+        T: Extend<u8>,
+    {
+        self.write_to(&mut ExtendableAsWritable::from(extendable))
+    }
+}

--- a/shell_automaton/testing/src/service/mio_service/chunking/encrypted_message_writer.rs
+++ b/shell_automaton/testing/src/service/mio_service/chunking/encrypted_message_writer.rs
@@ -1,0 +1,92 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use std::io::Write;
+
+use tezos_messages::p2p::binary_message::{BinaryChunk, BinaryWrite, CONTENT_LENGTH_MAX};
+
+use super::extendable_as_writable::ExtendableAsWritable;
+use super::{ChunkWriter, WriteMessageError};
+use shell_automaton::peer::PeerCrypto;
+
+// BOX_ZERO_BYTES is subtracted since after encryption, chunk size will
+// increase and we don't want it to overflow CONTENT_LENGTH_MAX.
+const MAX_ENCRYPTED_CHUNK_SIZE: usize = CONTENT_LENGTH_MAX - crypto::crypto_box::BOX_ZERO_BYTES;
+
+#[derive(Debug, Clone)]
+pub struct EncryptedMessageWriter {
+    bytes: Vec<u8>,
+    /// Index of the chunk.
+    chunk_index: usize,
+    chunk_writer: ChunkWriter,
+}
+
+impl EncryptedMessageWriter {
+    fn empty_initial_chunk_writer() -> ChunkWriter {
+        ChunkWriter::new(BinaryChunk::from_content(&[]).unwrap())
+    }
+
+    pub fn try_new<M>(message: &M) -> Result<Self, WriteMessageError>
+    where
+        M: BinaryWrite,
+    {
+        Ok(Self {
+            bytes: message.as_bytes()?,
+            chunk_index: 0,
+            chunk_writer: Self::empty_initial_chunk_writer(),
+        })
+    }
+
+    /// Current chunk that needs to be written.
+    ///
+    /// Returns None if there's nothing more to send.
+    fn current_chunk(&self) -> Option<&[u8]> {
+        self.bytes
+            .chunks(MAX_ENCRYPTED_CHUNK_SIZE)
+            .nth(self.chunk_index)
+            .filter(|x| x.len() > 0)
+    }
+
+    pub fn write_to<W>(
+        &mut self,
+        writer: &mut W,
+        crypto: &mut PeerCrypto,
+    ) -> Result<(), WriteMessageError>
+    where
+        W: Write,
+    {
+        if self.chunk_writer.is_empty() {
+            if let Some(current_chunk) = self.current_chunk() {
+                self.chunk_writer =
+                    ChunkWriter::new(BinaryChunk::from_content(&crypto.encrypt(&current_chunk)?)?);
+            } else {
+                return Ok(());
+            }
+        }
+        loop {
+            self.chunk_writer.write_to(writer)?;
+
+            if self.chunk_writer.is_finished() {
+                self.chunk_index += 1;
+                let chunk = match self.current_chunk() {
+                    Some(chunk) => chunk,
+                    None => return Ok(()),
+                };
+
+                self.chunk_writer =
+                    ChunkWriter::new(BinaryChunk::from_content(&crypto.encrypt(&chunk)?)?);
+            }
+        }
+    }
+
+    pub fn write_to_extendable<T>(
+        &mut self,
+        extendable: &mut T,
+        crypto: &mut PeerCrypto,
+    ) -> Result<(), WriteMessageError>
+    where
+        T: Extend<u8>,
+    {
+        self.write_to(&mut ExtendableAsWritable::from(extendable), crypto)
+    }
+}

--- a/shell_automaton/testing/src/service/mio_service/chunking/extendable_as_writable.rs
+++ b/shell_automaton/testing/src/service/mio_service/chunking/extendable_as_writable.rs
@@ -1,0 +1,31 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use std::io::{self, Read, Write};
+
+pub struct ExtendableAsWritable<'a, T: Extend<u8>> {
+    extendable: &'a mut T,
+}
+
+impl<'a, T: Extend<u8>> Read for ExtendableAsWritable<'a, T> {
+    fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+}
+
+impl<'a, T: Extend<u8>> Write for ExtendableAsWritable<'a, T> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.extendable.extend(buf.iter().cloned());
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a, T: Extend<u8>> From<&'a mut T> for ExtendableAsWritable<'a, T> {
+    fn from(extendable: &'a mut T) -> Self {
+        Self { extendable }
+    }
+}

--- a/shell_automaton/testing/src/service/mio_service/chunking/message_read_buffer.rs
+++ b/shell_automaton/testing/src/service/mio_service/chunking/message_read_buffer.rs
@@ -1,0 +1,125 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use std::io::{self, Read};
+
+use tezos_messages::p2p::{
+    binary_message::{BinaryRead, SizeFromChunk},
+    encoding::peer::PeerMessageResponse,
+};
+
+use super::{ChunkReadBuffer, ReadMessageError};
+use shell_automaton::peer::PeerCrypto;
+
+/// Read buffer for connected peer(`PeerMessage`).
+///
+/// This message can be split into multiple chunks. Encrypted part of
+/// the first chunk includes information (`4 bytes`) about whole message's
+/// size. We need to process chunks until decrypted accumulated message
+/// isn't of that size.
+#[derive(Debug, Clone)]
+pub struct MessageReadBuffer {
+    message_buf: Vec<u8>,
+    message_len: usize,
+    /// Bytes read for current message.
+    read_bytes: usize,
+    chunk_reader: ChunkReadBuffer,
+}
+
+impl MessageReadBuffer {
+    pub fn new() -> Self {
+        Self {
+            message_buf: vec![],
+            message_len: 0,
+            read_bytes: 0,
+            chunk_reader: ChunkReadBuffer::new(),
+        }
+    }
+
+    pub fn is_finished(&self) -> bool {
+        self.message_len > 0 && self.message_buf.len() >= self.message_len
+    }
+
+    /// Returns if more might be available to be read.
+    fn _read_from<R: Read>(
+        &mut self,
+        reader: &mut R,
+        crypto: &mut PeerCrypto,
+    ) -> Result<PeerMessageResponse, ReadMessageError> {
+        loop {
+            self.chunk_reader.read_from(reader)?;
+            // TODO: As an optimization, stop reading
+            // if `message_len < message_buf.len() + chunk_expected_len`.
+            // Technically shouldn't happen, but if it does, then peer
+            // has issue with encoding/chunking.
+
+            if let Some(chunk) = self.chunk_reader.take_ref_if_ready() {
+                let mut decrypted = crypto.decrypt(&chunk.content())?;
+
+                if self.message_len == 0 {
+                    self.message_len = PeerMessageResponse::size_from_chunk(&decrypted)?;
+                }
+                self.message_buf.append(&mut decrypted);
+
+                if self.is_finished() {
+                    return self.take_and_decode();
+                }
+            }
+        }
+    }
+
+    pub fn read_from<R: Read>(
+        &mut self,
+        reader: &mut R,
+        crypto: &mut PeerCrypto,
+    ) -> Result<PeerMessageResponse, ReadMessageError> {
+        let mut counted_reader = ReadCounter::new(reader);
+        let result = self._read_from(&mut counted_reader, crypto);
+        self.read_bytes += counted_reader.result();
+        result
+    }
+
+    fn take_and_decode(&mut self) -> Result<PeerMessageResponse, ReadMessageError> {
+        let result = PeerMessageResponse::from_bytes(&self.message_buf);
+        let read_bytes = self.read_bytes;
+
+        self.clear();
+        let mut resp = result?;
+        resp.set_size_hint(read_bytes);
+        Ok(resp)
+    }
+
+    pub fn clear(&mut self) {
+        self.message_buf.clear();
+        self.message_len = 0;
+        self.read_bytes = 0;
+        self.chunk_reader.clear();
+    }
+}
+
+/// Counts exactly how many bytes were read from the stream.
+struct ReadCounter<'a, R> {
+    reader: &'a mut R,
+    read_bytes: usize,
+}
+
+impl<'a, R> ReadCounter<'a, R> {
+    pub fn new(reader: &'a mut R) -> Self {
+        Self {
+            reader,
+            read_bytes: 0,
+        }
+    }
+
+    pub fn result(self) -> usize {
+        self.read_bytes
+    }
+}
+
+impl<'a, R: Read> Read for ReadCounter<'a, R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let size = self.reader.read(buf)?;
+        self.read_bytes += size;
+        Ok(size)
+    }
+}

--- a/shell_automaton/testing/src/service/mio_service/chunking/mod.rs
+++ b/shell_automaton/testing/src/service/mio_service/chunking/mod.rs
@@ -1,0 +1,89 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use std::io;
+
+use crypto::CryptoError;
+use tezos_encoding::{binary_reader::BinaryReaderError, binary_writer::BinaryWriterError};
+use tezos_messages::p2p::binary_message::BinaryChunkError;
+
+mod chunk_read_buffer;
+pub use chunk_read_buffer::*;
+
+mod message_read_buffer;
+pub use message_read_buffer::*;
+
+pub mod extendable_as_writable;
+
+mod chunk_writer;
+pub use chunk_writer::*;
+
+mod encrypted_message_writer;
+pub use encrypted_message_writer::*;
+
+#[derive(Debug)]
+pub enum ReadMessageError {
+    Pending,
+    IO(io::Error),
+    Crypto(CryptoError),
+    Decode(BinaryReaderError),
+}
+
+impl From<io::Error> for ReadMessageError {
+    fn from(err: io::Error) -> Self {
+        if err.kind() == io::ErrorKind::WouldBlock {
+            Self::Pending
+        } else {
+            Self::IO(err)
+        }
+    }
+}
+
+impl From<BinaryReaderError> for ReadMessageError {
+    fn from(err: BinaryReaderError) -> Self {
+        Self::Decode(err)
+    }
+}
+
+impl From<CryptoError> for ReadMessageError {
+    fn from(err: CryptoError) -> Self {
+        Self::Crypto(err)
+    }
+}
+
+#[derive(Debug)]
+pub enum WriteMessageError {
+    Pending,
+    IO(io::Error),
+    Encode(BinaryWriterError),
+    Crypto(CryptoError),
+    BinaryChunk(BinaryChunkError),
+}
+
+impl From<io::Error> for WriteMessageError {
+    fn from(err: io::Error) -> Self {
+        if err.kind() == io::ErrorKind::WouldBlock {
+            Self::Pending
+        } else {
+            Self::IO(err)
+        }
+    }
+}
+
+impl From<BinaryWriterError> for WriteMessageError {
+    fn from(err: BinaryWriterError) -> Self {
+        Self::Encode(err)
+    }
+}
+
+impl From<CryptoError> for WriteMessageError {
+    fn from(err: CryptoError) -> Self {
+        Self::Crypto(err)
+    }
+}
+
+impl From<BinaryChunkError> for WriteMessageError {
+    fn from(err: BinaryChunkError) -> Self {
+        Self::BinaryChunk(err)
+    }
+}

--- a/shell_automaton/testing/src/service/mio_service/mod.rs
+++ b/shell_automaton/testing/src/service/mio_service/mod.rs
@@ -1,0 +1,154 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use std::collections::VecDeque;
+use std::io;
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use shell_automaton::event::Event;
+use shell_automaton::peer::PeerToken;
+use shell_automaton::service::MioService;
+
+pub(super) mod chunking;
+
+mod peer_mocked;
+pub use peer_mocked::*;
+
+mod peer_mocked_id;
+pub use peer_mocked_id::*;
+use shell_automaton::service::mio_service::{MioPeerRefMut, PeerConnectionIncomingAcceptError};
+use tezos_identity::Identity;
+
+#[derive(Clone)]
+pub struct MioServiceMocked {
+    listening_for_incoming_connections: bool,
+    buffer: Vec<u8>,
+    peers: Vec<MioPeerMocked>,
+    /// Backlog of mocked incoming connections.
+    backlog: VecDeque<MioPeerMockedId>,
+}
+
+impl MioServiceMocked {
+    pub fn new(_: SocketAddr, buffer_size: usize) -> Self {
+        Self {
+            listening_for_incoming_connections: false,
+            buffer: vec![0; buffer_size],
+            peers: vec![],
+            backlog: VecDeque::new(),
+        }
+    }
+
+    pub fn peer_init(&mut self, pow_target: f64) -> MioPeerMockedId {
+        let peer_id = MioPeerMockedId::new_unchecked(self.peers.len());
+        self.peers.push(MioPeerMocked::new(
+            peer_id.to_ipv4(),
+            MioPeerStreamMocked::new(pow_target),
+        ));
+        peer_id
+    }
+
+    pub fn peer_init_with_identity(&mut self, identity: Identity) -> MioPeerMockedId {
+        let peer_id = MioPeerMockedId::new_unchecked(self.peers.len());
+        self.peers.push(MioPeerMocked::new(
+            peer_id.to_ipv4(),
+            MioPeerStreamMocked::with_identity(identity),
+        ));
+        peer_id
+    }
+
+    /// Panics if peer with such id is not found.
+    pub fn peer(&mut self, id: MioPeerMockedId) -> &mut MioPeerMocked {
+        &mut self.peers[id.index()]
+    }
+
+    pub fn backlog_push(&mut self, id: MioPeerMockedId) {
+        self.backlog.push_back(id);
+    }
+}
+
+impl MioService for MioServiceMocked {
+    type PeerStream = MioPeerStreamMocked;
+    type Events = ();
+    type InternalEvent = ();
+
+    fn wait_for_events(&mut self, _: &mut Self::Events, _: Option<Duration>) {
+        unimplemented!()
+    }
+
+    fn transform_event(&mut self, _: &Self::InternalEvent) -> Event {
+        unimplemented!()
+    }
+
+    fn peer_connection_incoming_listen_start(&mut self) -> io::Result<()> {
+        self.listening_for_incoming_connections = true;
+        Ok(())
+    }
+
+    fn peer_connection_incoming_listen_stop(&mut self) {
+        self.listening_for_incoming_connections = false;
+    }
+
+    fn peer_connection_incoming_accept(
+        &mut self,
+    ) -> Result<(PeerToken, MioPeerRefMut<Self::PeerStream>), PeerConnectionIncomingAcceptError>
+    {
+        if self.listening_for_incoming_connections {
+            return Err(PeerConnectionIncomingAcceptError::ServerNotListening);
+        }
+
+        let buffer = &mut self.buffer;
+
+        if let Some(peer_id) = self.backlog.pop_front() {
+            let peer = &mut self.peers[peer_id.index()].stream;
+            return match peer.conn_state() {
+                ConnectedState::OutgoingInit => {
+                    *peer.conn_state_mut() = ConnectedState::OutgoingAccepted;
+                    Ok((
+                        peer_id.to_token(),
+                        MioPeerRefMut::new(buffer, peer_id.to_ipv4(), peer),
+                    ))
+                }
+                _ => panic!("mio peer in invalid state {:?}", peer.conn_state()),
+            };
+        }
+
+        Err(PeerConnectionIncomingAcceptError::WouldBlock)
+    }
+
+    fn peer_connection_init(&mut self, address: SocketAddr) -> io::Result<PeerToken> {
+        let peer_id = MioPeerMockedId::from_ipv4(&address);
+        let conn_state = self.peer(peer_id).stream.conn_state_mut();
+
+        if !matches!(conn_state, ConnectedState::Disconnected) {
+            panic!(
+                "trying to connect to already connected peer: {:?}",
+                conn_state
+            );
+        }
+
+        *conn_state = ConnectedState::IncomingInit;
+
+        Ok(peer_id.to_token())
+    }
+
+    fn peer_disconnect(&mut self, token: PeerToken) {
+        *self.peer(token.into()).stream.conn_state_mut() = ConnectedState::Disconnected;
+    }
+
+    fn peer_get(&mut self, token: PeerToken) -> Option<MioPeerRefMut<Self::PeerStream>> {
+        let buffer = &mut self.buffer;
+        let peer_id = MioPeerMockedId::from_token(&token);
+        let peer = &mut self.peers[peer_id.index()].stream;
+        let peer_ref = MioPeerRefMut::new(buffer, peer_id.to_ipv4(), peer);
+
+        match peer_ref.stream.conn_state() {
+            ConnectedState::Disconnected => None,
+            ConnectedState::IncomingInit => Some(peer_ref),
+            ConnectedState::IncomingConnected => Some(peer_ref),
+            ConnectedState::OutgoingInit => None,
+            ConnectedState::OutgoingAccepted => Some(peer_ref),
+            ConnectedState::OutgoingConnected => Some(peer_ref),
+        }
+    }
+}

--- a/shell_automaton/testing/src/service/mio_service/peer_mocked.rs
+++ b/shell_automaton/testing/src/service/mio_service/peer_mocked.rs
@@ -1,0 +1,342 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use std::collections::VecDeque;
+use std::fmt::Debug;
+use std::io::{self, Read, Write};
+
+use shell_automaton::peer::PeerCrypto;
+use shell_automaton::service::mio_service::MioPeer;
+use tezos_identity::Identity;
+use tezos_messages::p2p::binary_message::{BinaryChunk, BinaryRead, BinaryWrite};
+use tezos_messages::p2p::encoding::prelude::{
+    AckMessage, ConnectionMessage, MetadataMessage, PeerMessage, PeerMessageResponse,
+};
+
+use super::chunking::{ChunkReadBuffer, EncryptedMessageWriter, MessageReadBuffer};
+
+pub type MioPeerMocked = MioPeer<MioPeerStreamMocked>;
+
+#[derive(Debug, Clone, Copy)]
+pub enum ConnectedState {
+    /// Disconnected.
+    Disconnected,
+
+    /// Incoming connection to the mocked peer from real node initiated.
+    IncomingInit,
+    /// Incoming connection to the mocked peer from real node established.
+    IncomingConnected,
+
+    /// Outgoing connection from the mocked peer to real node initiated.
+    OutgoingInit,
+    /// Outgoing connection from the mocked peer to real node accepted.
+    OutgoingAccepted,
+    /// Outgoing connection from the mocked peer to real node established.
+    OutgoingConnected,
+}
+
+impl ConnectedState {
+    pub fn is_connected(&self) -> bool {
+        match self {
+            Self::Disconnected => false,
+            Self::IncomingInit => false,
+            Self::IncomingConnected => true,
+            Self::OutgoingInit => false,
+            Self::OutgoingAccepted => false,
+            Self::OutgoingConnected => true,
+        }
+    }
+
+    pub fn disconnect(&mut self) {
+        *self = Self::Disconnected;
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum IOCondition {
+    NoLimit,
+    Limit(usize),
+    Error(io::ErrorKind),
+}
+
+#[derive(Debug, Clone)]
+pub struct MioPeerStreamMocked {
+    conn_state: ConnectedState,
+    identity: Identity,
+
+    pub sent_conn_msg: Option<ConnectionMessage>,
+    pub received_conn_msg: Option<ConnectionMessage>,
+    crypto: Option<PeerCrypto>,
+
+    read_buf: VecDeque<u8>,
+    write_buf: VecDeque<u8>,
+
+    read_cond: IOCondition,
+    write_cond: IOCondition,
+}
+
+impl MioPeerStreamMocked {
+    pub fn new(pow_target: f64) -> Self {
+        Self::with_identity(Identity::generate(pow_target).unwrap())
+    }
+
+    pub fn with_identity(identity: Identity) -> Self {
+        Self {
+            conn_state: ConnectedState::Disconnected,
+            identity,
+
+            sent_conn_msg: None,
+            received_conn_msg: None,
+            crypto: None,
+
+            read_buf: VecDeque::new(),
+            write_buf: VecDeque::new(),
+
+            read_cond: IOCondition::Limit(0),
+            write_cond: IOCondition::Limit(0),
+        }
+    }
+
+    pub fn identity(&self) -> &Identity {
+        &self.identity
+    }
+
+    pub fn read_buf(&self) -> &VecDeque<u8> {
+        &self.read_buf
+    }
+
+    pub fn write_buf(&self) -> &VecDeque<u8> {
+        &self.write_buf
+    }
+
+    pub fn is_connected(&self) -> bool {
+        self.conn_state.is_connected()
+    }
+
+    pub fn conn_state(&self) -> ConnectedState {
+        self.conn_state
+    }
+
+    pub fn conn_state_mut(&mut self) -> &mut ConnectedState {
+        &mut self.conn_state
+    }
+
+    pub fn crypto(&self) -> Option<&PeerCrypto> {
+        self.crypto.as_ref()
+    }
+
+    pub fn crypto_mut(&mut self) -> &mut Option<PeerCrypto> {
+        &mut self.crypto
+    }
+
+    pub fn disconnect(&mut self) {
+        self.conn_state.disconnect()
+    }
+
+    pub fn set_read_cond(&mut self, cond: IOCondition) -> &mut Self {
+        self.read_cond = cond;
+        self
+    }
+
+    pub fn set_write_cond(&mut self, cond: IOCondition) -> &mut Self {
+        self.write_cond = cond;
+        self
+    }
+
+    pub fn set_sent_conn_message(&mut self, conn_msg: ConnectionMessage) {
+        self.sent_conn_msg = Some(conn_msg);
+    }
+
+    pub fn set_received_conn_msg(&mut self, conn_msg: ConnectionMessage) {
+        self.received_conn_msg = Some(conn_msg);
+    }
+
+    pub fn send_bytes(&mut self, bytes: &[u8]) {
+        self.read_buf.extend(bytes);
+    }
+
+    /// Send connection message to real node.
+    pub fn send_conn_msg(&mut self, conn_msg: &ConnectionMessage) {
+        self.sent_conn_msg = Some(conn_msg.clone());
+        self.send_bytes(
+            BinaryChunk::from_content(&conn_msg.as_bytes().unwrap())
+                .unwrap()
+                .raw(),
+        );
+    }
+
+    pub fn read_conn_msg(&mut self) -> ConnectionMessage {
+        let mut reader = ChunkReadBuffer::new();
+        while !reader.is_finished() {
+            reader
+                .read_from(&mut VecDequeReadable::from(&mut self.write_buf))
+                .unwrap();
+        }
+        let conn_msg =
+            ConnectionMessage::from_bytes(reader.take_if_ready().unwrap().content()).unwrap();
+        self.received_conn_msg = Some(conn_msg.clone());
+        conn_msg
+    }
+
+    pub fn send_meta_msg(&mut self, meta_msg: &MetadataMessage) {
+        let crypto = self
+            .crypto
+            .as_mut()
+            .expect("missing PeerCrypto for encryption");
+        let mut encrypted_msg_writer = EncryptedMessageWriter::try_new(meta_msg).unwrap();
+        encrypted_msg_writer
+            .write_to_extendable(&mut self.read_buf, crypto)
+            .unwrap();
+    }
+
+    pub fn read_meta_msg(&mut self) -> MetadataMessage {
+        let crypto = self
+            .crypto
+            .as_mut()
+            .expect("missing PeerCrypto for encryption");
+        let mut reader = ChunkReadBuffer::new();
+        while !reader.is_finished() {
+            reader
+                .read_from(&mut VecDequeReadable::from(&mut self.write_buf))
+                .unwrap();
+        }
+        let bytes = crypto
+            .decrypt(&reader.take_if_ready().unwrap().content())
+            .unwrap();
+        MetadataMessage::from_bytes(bytes).unwrap()
+    }
+
+    pub fn send_ack_msg(&mut self, ack_msg: &AckMessage) {
+        let crypto = self
+            .crypto
+            .as_mut()
+            .expect("missing PeerCrypto for encryption");
+        let mut encrypted_msg_writer = EncryptedMessageWriter::try_new(ack_msg).unwrap();
+        encrypted_msg_writer
+            .write_to_extendable(&mut self.read_buf, crypto)
+            .unwrap();
+    }
+
+    pub fn read_ack_message(&mut self) -> AckMessage {
+        let crypto = self
+            .crypto
+            .as_mut()
+            .expect("missing PeerCrypto for encryption");
+        let mut reader = ChunkReadBuffer::new();
+        while !reader.is_finished() {
+            reader
+                .read_from(&mut VecDequeReadable::from(&mut self.write_buf))
+                .unwrap();
+        }
+        let bytes = crypto
+            .decrypt(&reader.take_if_ready().unwrap().content())
+            .unwrap();
+        AckMessage::from_bytes(bytes).unwrap()
+    }
+
+    pub fn send_peer_message(&mut self, peer_message: PeerMessage) {
+        let crypto = self
+            .crypto
+            .as_mut()
+            .expect("missing PeerCrypto for encryption");
+        let resp = PeerMessageResponse::from(peer_message);
+        let mut encrypted_msg_writer = EncryptedMessageWriter::try_new(&resp).unwrap();
+        encrypted_msg_writer
+            .write_to_extendable(&mut self.read_buf, crypto)
+            .unwrap();
+    }
+
+    pub fn read_peer_message(&mut self) -> Option<PeerMessage> {
+        let crypto = self
+            .crypto
+            .as_mut()
+            .expect("missing PeerCrypto for encryption");
+        if self.write_buf.len() == 0 {
+            return None;
+        }
+        let mut reader = MessageReadBuffer::new();
+        Some(
+            reader
+                .read_from(&mut VecDequeReadable::from(&mut self.write_buf), crypto)
+                .unwrap()
+                .message,
+        )
+    }
+}
+
+impl Read for MioPeerStreamMocked {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        assert_ne!(
+            buf.len(),
+            0,
+            "empty(len = 0) buffer shouldn't be passed to read method"
+        );
+        let len = match &mut self.read_cond {
+            IOCondition::NoLimit => buf.len(),
+            IOCondition::Limit(limit) => {
+                let min = buf.len().min(*limit);
+                *limit -= min;
+                min
+            }
+            IOCondition::Error(err_kind) => {
+                return Err(io::Error::new(*err_kind, "manual error"));
+            }
+        };
+        // eprintln!("read {}. limit: {:?}", len, &self.read_limit);
+
+        let len = VecDequeReadable::from(&mut self.read_buf).read(&mut buf[..len])?;
+
+        if self.read_buf.len() == 0 {
+            self.set_read_cond(IOCondition::Limit(0));
+        }
+
+        Ok(len)
+    }
+}
+
+impl Write for MioPeerStreamMocked {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let len = match &mut self.write_cond {
+            IOCondition::NoLimit => buf.len(),
+            IOCondition::Limit(limit) => {
+                let min = buf.len().min(*limit);
+                *limit -= min;
+                min
+            }
+            IOCondition::Error(err_kind) => {
+                return Err(io::Error::new(*err_kind, "manual error"));
+            }
+        };
+
+        self.write_buf.extend(&buf[..len]);
+
+        // TODO: somehow reset IOCondition::NoLimit to IOCondition::Limit(0),
+        // maybe after message has been read.
+
+        Ok(len)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+struct VecDequeReadable<'a> {
+    v: &'a mut VecDeque<u8>,
+}
+
+impl<'a> Read for VecDequeReadable<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let len = self.v.len().min(buf.len());
+        for (i, v) in self.v.drain(..len).enumerate() {
+            buf[i] = v;
+        }
+        Ok(len)
+    }
+}
+
+impl<'a> From<&'a mut VecDeque<u8>> for VecDequeReadable<'a> {
+    fn from(v: &'a mut VecDeque<u8>) -> Self {
+        Self { v }
+    }
+}

--- a/shell_automaton/testing/src/service/mio_service/peer_mocked_id.rs
+++ b/shell_automaton/testing/src/service/mio_service/peer_mocked_id.rs
@@ -1,0 +1,61 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use std::net::SocketAddr;
+
+use shell_automaton::peer::PeerToken;
+
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+pub struct MioPeerMockedId {
+    id: usize,
+}
+
+impl MioPeerMockedId {
+    /// Create new unchecked peer id. Caller must ensure that the peer
+    /// with such id exists.
+    pub fn new_unchecked(id: usize) -> Self {
+        Self { id }
+    }
+
+    #[inline]
+    pub fn index(&self) -> usize {
+        self.id
+    }
+
+    pub fn from_ipv4(addr: &SocketAddr) -> Self {
+        match addr {
+            SocketAddr::V4(addr) => {
+                let [a, b, c, d] = addr.ip().octets();
+                let (a, b, c, d) = (a as usize, b as usize, c as usize, d as usize);
+                Self::new_unchecked(a * 256 * 256 * 256 + b * 256 * 256 + c * 256 + d)
+            }
+            SocketAddr::V6(_) => panic!("expected ipv4, found ipv6"),
+        }
+    }
+
+    pub fn to_ipv4(&self) -> SocketAddr {
+        let id = self.id;
+
+        let ip = [
+            ((id / 256 / 256 / 256) % 256) as u8,
+            ((id / 256 / 256) % 256) as u8,
+            ((id / 256) % 256) as u8,
+            (id % 256) as u8,
+        ];
+        (ip, 12345).into()
+    }
+
+    pub fn from_token(token: &PeerToken) -> Self {
+        Self { id: token.index() }
+    }
+
+    pub fn to_token(&self) -> PeerToken {
+        PeerToken::new_unchecked(self.id)
+    }
+}
+
+impl From<PeerToken> for MioPeerMockedId {
+    fn from(token: PeerToken) -> Self {
+        Self { id: token.into() }
+    }
+}

--- a/shell_automaton/testing/src/service/mod.rs
+++ b/shell_automaton/testing/src/service/mod.rs
@@ -1,0 +1,24 @@
+//! Mocked service.
+
+pub use shell_automaton::service::{Service, TimeService};
+
+mod randomness_service;
+pub use randomness_service::*;
+
+mod dns_service;
+pub use dns_service::*;
+
+mod quota_service;
+pub use quota_service::*;
+
+mod storage_service;
+pub use storage_service::*;
+
+mod actors_service;
+pub use actors_service::*;
+
+mod rpc_service;
+pub use rpc_service::*;
+
+mod mio_service;
+pub use mio_service::*;

--- a/shell_automaton/testing/src/service/quota_service.rs
+++ b/shell_automaton/testing/src/service/quota_service.rs
@@ -1,0 +1,15 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+pub use shell_automaton::service::QuotaService;
+
+#[derive(Debug, Clone)]
+pub struct QuotaServiceDummy {}
+
+impl QuotaServiceDummy {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl QuotaService for QuotaServiceDummy {}

--- a/shell_automaton/testing/src/service/randomness_service.rs
+++ b/shell_automaton/testing/src/service/randomness_service.rs
@@ -1,0 +1,36 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use std::net::SocketAddr;
+
+use crypto::nonce::Nonce;
+use shell_automaton::service::RandomnessService;
+
+#[derive(Debug, Clone)]
+pub enum RandomnessServiceMocked {
+    Dummy,
+}
+
+impl RandomnessService for RandomnessServiceMocked {
+    fn get_nonce(&mut self, _: SocketAddr) -> Nonce {
+        match self {
+            Self::Dummy => Nonce::new(&[0; 24]),
+        }
+    }
+
+    fn choose_peer(&mut self, list: &[SocketAddr]) -> Option<SocketAddr> {
+        match self {
+            Self::Dummy => list.get(0).cloned(),
+        }
+    }
+
+    fn choose_potential_peers_for_advertise(&mut self, list: &[SocketAddr]) -> Vec<SocketAddr> {
+        match self {
+            Self::Dummy => list.iter().cloned().take(80).collect(),
+        }
+    }
+
+    fn choose_potential_peers_for_nack(&mut self, list: &[SocketAddr]) -> Vec<SocketAddr> {
+        self.choose_potential_peers_for_advertise(list)
+    }
+}

--- a/shell_automaton/testing/src/service/rpc_service.rs
+++ b/shell_automaton/testing/src/service/rpc_service.rs
@@ -1,0 +1,21 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+pub use shell_automaton::service::rpc_service::{RpcResponse, RpcService};
+use shell_automaton::service::service_async_channel::ResponseTryRecvError;
+
+#[derive(Debug, Clone)]
+pub struct RpcServiceDummy {}
+
+impl RpcServiceDummy {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl RpcService for RpcServiceDummy {
+    #[inline(always)]
+    fn try_recv(&mut self) -> Result<RpcResponse, ResponseTryRecvError> {
+        Err(ResponseTryRecvError::Empty)
+    }
+}

--- a/shell_automaton/testing/src/service/storage_service.rs
+++ b/shell_automaton/testing/src/service/storage_service.rs
@@ -1,0 +1,28 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use shell_automaton::service::service_channel::{RequestSendError, ResponseTryRecvError};
+pub use shell_automaton::service::storage_service::{
+    StorageRequest, StorageResponse, StorageService,
+};
+
+#[derive(Debug, Clone)]
+pub struct StorageServiceDummy {}
+
+impl StorageServiceDummy {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl StorageService for StorageServiceDummy {
+    #[inline(always)]
+    fn request_send(&mut self, _: StorageRequest) -> Result<(), RequestSendError<StorageRequest>> {
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn response_try_recv(&mut self) -> Result<StorageResponse, ResponseTryRecvError> {
+        Err(ResponseTryRecvError::Empty)
+    }
+}

--- a/shell_automaton/testing/tests/test_handshaking_basic.rs
+++ b/shell_automaton/testing/tests/test_handshaking_basic.rs
@@ -1,0 +1,543 @@
+use std::time::{Duration, SystemTime};
+
+use crypto::nonce::Nonce;
+use shell_automaton::peers::check::timeouts::PeersCheckTimeoutsInitAction;
+use shell_automaton::shell_compatibility_version::ShellCompatibilityVersion;
+use shell_automaton::{Config, Quota, State};
+use shell_automaton_testing::one_real_node_cluster::{Cluster, HandshakeError};
+use shell_automaton_testing::service::IOCondition;
+use tezos_identity::Identity;
+use tezos_messages::p2p::encoding::ack::NackMotive;
+use tezos_messages::p2p::encoding::connection::ConnectionMessage;
+use tezos_messages::p2p::encoding::version::NetworkVersion;
+
+fn build_cluster(pow_target: f64) -> Cluster {
+    let initial_time = SystemTime::now();
+
+    let state = State::new(Config {
+        initial_time,
+        port: 9732,
+        disable_mempool: false,
+        private_node: false,
+        pow_target,
+        identity: Identity::generate(pow_target).unwrap(),
+        shell_compatibility_version: ShellCompatibilityVersion::new(
+            "TEZOS_LOCALNET".to_owned(),
+            vec![1],
+            vec![1],
+        ),
+        check_timeouts_interval: Duration::from_millis(500),
+        peer_connecting_timeout: Duration::from_millis(2000),
+        peer_handshaking_timeout: Duration::from_secs(8),
+        peer_max_io_syscalls: 64,
+        peers_potential_max: 2,
+        peers_connected_max: 2,
+        peers_graylist_disable: false,
+        peers_graylist_timeout: Duration::from_secs(15 * 60),
+        record_state_snapshots_with_interval: None,
+        record_actions: false,
+        quota: Quota {
+            restore_duration_millis: 1000,
+            read_quota: 1024,
+            write_quota: 1024,
+        },
+    });
+
+    Cluster::new(state, initial_time)
+}
+
+#[test]
+fn test_can_handshake_outgoing() {
+    let mut cluster = build_cluster(0.0);
+
+    let peer_id = cluster.peer_init(0.0);
+
+    cluster.connect_to_peer(peer_id);
+    cluster.set_peer_connected(peer_id);
+
+    cluster.do_handshake(peer_id).unwrap();
+
+    assert!(cluster
+        .state()
+        .peers
+        .get(&peer_id.to_ipv4())
+        .unwrap()
+        .is_handshaked());
+}
+
+#[test]
+fn test_can_handshake_incoming() {
+    let mut cluster = build_cluster(0.0);
+
+    let peer_id = cluster.peer_init(0.0);
+
+    cluster.connect_from_peer(peer_id);
+    cluster.set_peer_connected(peer_id);
+
+    cluster.do_handshake(peer_id).unwrap();
+
+    assert!(cluster
+        .state()
+        .peers
+        .get(&peer_id.to_ipv4())
+        .unwrap()
+        .is_handshaked());
+}
+
+#[test]
+fn test_handshaking_nack_unknown_chain_name() {
+    let mut cluster = build_cluster(0.0);
+
+    let peer_id = cluster.peer_init(0.0);
+
+    cluster.connect_from_peer(peer_id);
+    cluster.set_peer_connected(peer_id);
+
+    let peer = cluster.peer(peer_id);
+    peer.set_read_cond(IOCondition::NoLimit)
+        .set_write_cond(IOCondition::NoLimit);
+
+    let sent_conn_msg = ConnectionMessage::try_new(
+        peer_id.to_ipv4().port(),
+        &peer.identity().public_key,
+        &peer.identity().proof_of_work_stamp,
+        Nonce::random(),
+        NetworkVersion::new("TEZOS_UNKNOWN".to_owned(), 1, 1),
+    )
+    .unwrap();
+
+    peer.send_conn_msg(&sent_conn_msg);
+    cluster.dispatch_peer_ready_event(peer_id, true, true, false);
+
+    let received_conn_msg = cluster.peer(peer_id).read_conn_msg();
+
+    cluster
+        .set_peer_crypto_with_conn_messages(peer_id, &sent_conn_msg, &received_conn_msg)
+        .unwrap();
+
+    let err = cluster.do_handshake(peer_id).err().expect(
+        "handshaking was successful when it should have failed because of unknown chain name.",
+    );
+    match err {
+        HandshakeError::Nack(info) => assert_eq!(*info.motive(), NackMotive::UnknownChainName),
+        err => panic!("unexpected handshake error: {:?}", err),
+    }
+
+    assert!(cluster
+        .state()
+        .peers
+        .get_blacklisted_ip(&peer_id.to_ipv4().ip())
+        .is_some());
+    assert!(cluster.state().peers.get(&peer_id.to_ipv4()).is_none());
+}
+
+#[test]
+fn test_handshaking_nack_deprecated_distributed_version() {
+    let mut cluster = build_cluster(0.0);
+
+    let peer_id = cluster.peer_init(0.0);
+
+    cluster.connect_from_peer(peer_id);
+    cluster.set_peer_connected(peer_id);
+
+    let peer = cluster.peer(peer_id);
+    peer.set_read_cond(IOCondition::NoLimit)
+        .set_write_cond(IOCondition::NoLimit);
+
+    let sent_conn_msg = ConnectionMessage::try_new(
+        peer_id.to_ipv4().port(),
+        &peer.identity().public_key,
+        &peer.identity().proof_of_work_stamp,
+        Nonce::random(),
+        NetworkVersion::new("TEZOS_LOCALNET".to_owned(), 0, 1),
+    )
+    .unwrap();
+
+    peer.send_conn_msg(&sent_conn_msg);
+    cluster.dispatch_peer_ready_event(peer_id, true, true, false);
+
+    let received_conn_msg = cluster.peer(peer_id).read_conn_msg();
+
+    cluster
+        .set_peer_crypto_with_conn_messages(peer_id, &sent_conn_msg, &received_conn_msg)
+        .unwrap();
+
+    let err = cluster.do_handshake(peer_id).err().expect(
+        "handshaking was successful when it should have failed because of deprecated db version.",
+    );
+    match err {
+        HandshakeError::Nack(info) => {
+            assert_eq!(*info.motive(), NackMotive::DeprecatedDistributedDbVersion)
+        }
+        err => panic!("unexpected handshake error: {:?}", err),
+    }
+
+    assert!(cluster
+        .state()
+        .peers
+        .get_blacklisted_ip(&peer_id.to_ipv4().ip())
+        .is_some());
+    assert!(cluster.state().peers.get(&peer_id.to_ipv4()).is_none());
+}
+
+#[test]
+fn test_handshaking_nack_deprecated_p2p_version() {
+    let mut cluster = build_cluster(0.0);
+
+    let peer_id = cluster.peer_init(0.0);
+
+    cluster.connect_from_peer(peer_id);
+    cluster.set_peer_connected(peer_id);
+
+    let peer = cluster.peer(peer_id);
+    peer.set_read_cond(IOCondition::NoLimit)
+        .set_write_cond(IOCondition::NoLimit);
+
+    let sent_conn_msg = ConnectionMessage::try_new(
+        peer_id.to_ipv4().port(),
+        &peer.identity().public_key,
+        &peer.identity().proof_of_work_stamp,
+        Nonce::random(),
+        NetworkVersion::new("TEZOS_LOCALNET".to_owned(), 1, 0),
+    )
+    .unwrap();
+
+    peer.send_conn_msg(&sent_conn_msg);
+    cluster.dispatch_peer_ready_event(peer_id, true, true, false);
+
+    let received_conn_msg = cluster.peer(peer_id).read_conn_msg();
+
+    cluster
+        .set_peer_crypto_with_conn_messages(peer_id, &sent_conn_msg, &received_conn_msg)
+        .unwrap();
+
+    let err = cluster.do_handshake(peer_id).err().expect(
+        "handshaking was successful when it should have failed because of deprecated p2p version.",
+    );
+    match err {
+        HandshakeError::Nack(info) => assert_eq!(*info.motive(), NackMotive::DeprecatedP2pVersion),
+        err => panic!("unexpected handshake error: {:?}", err),
+    }
+
+    assert!(cluster
+        .state()
+        .peers
+        .get_blacklisted_ip(&peer_id.to_ipv4().ip())
+        .is_some());
+    assert!(cluster.state().peers.get(&peer_id.to_ipv4()).is_none());
+}
+
+#[test]
+fn test_handshaking_nack_already_connected_incoming() {
+    let mut cluster = build_cluster(0.0);
+
+    let peer_id = cluster.peer_init(0.0);
+    let peer_identity = cluster.peer(peer_id).identity().clone();
+
+    cluster.connect_to_peer(peer_id);
+    cluster.set_peer_connected(peer_id);
+
+    cluster.do_handshake(peer_id).unwrap();
+
+    assert!(cluster
+        .state()
+        .peers
+        .get(&peer_id.to_ipv4())
+        .unwrap()
+        .is_handshaked());
+
+    let peer_id = cluster.peer_init_with_identity(peer_identity);
+
+    cluster.connect_from_peer(peer_id);
+    cluster.set_peer_connected(peer_id);
+
+    let err = cluster.do_handshake(peer_id).err().expect("handshaking was successful when it should have failed because peer with same identity is already connected.");
+
+    match err {
+        HandshakeError::Nack(info) => assert_eq!(*info.motive(), NackMotive::AlreadyConnected),
+        err => panic!("unexpected handshake error: {:?}", err),
+    }
+
+    assert!(cluster
+        .state()
+        .peers
+        .get_blacklisted_ip(&peer_id.to_ipv4().ip())
+        .is_none());
+    assert!(cluster.state().peers.get(&peer_id.to_ipv4()).is_none());
+}
+
+#[test]
+fn test_handshaking_nack_already_connected_outgoing() {
+    let mut cluster = build_cluster(0.0);
+
+    let peer_id = cluster.peer_init(0.0);
+    let peer_identity = cluster.peer(peer_id).identity().clone();
+
+    cluster.connect_from_peer(peer_id);
+    cluster.set_peer_connected(peer_id);
+
+    cluster.do_handshake(peer_id).unwrap();
+
+    assert!(cluster
+        .state()
+        .peers
+        .get(&peer_id.to_ipv4())
+        .unwrap()
+        .is_handshaked());
+
+    let peer_id = cluster.peer_init_with_identity(peer_identity);
+
+    cluster.connect_to_peer(peer_id);
+    cluster.set_peer_connected(peer_id);
+
+    let err = cluster.do_handshake(peer_id).err().expect("handshaking was successful when it should have failed because peer with same identity is already connected.");
+    match err {
+        HandshakeError::Nack(info) => assert_eq!(*info.motive(), NackMotive::AlreadyConnected),
+        err => panic!("unexpected handshake error: {:?}", err),
+    }
+
+    assert!(cluster
+        .state()
+        .peers
+        .get_blacklisted_ip(&peer_id.to_ipv4().ip())
+        .is_none());
+    assert!(cluster.state().peers.get(&peer_id.to_ipv4()).is_none());
+}
+
+#[test]
+fn test_handshaking_nack_connecting_to_self_incoming() {
+    let mut cluster = build_cluster(0.0);
+
+    let peer_identity = cluster.state().config.identity.clone();
+    let peer_id = cluster.peer_init_with_identity(peer_identity);
+
+    cluster.connect_from_peer(peer_id);
+    cluster.set_peer_connected(peer_id);
+
+    let err = cluster.do_handshake(peer_id).err().expect("handshaking was successful when it should have failed because peer has the same identity as node.");
+    match err {
+        HandshakeError::Nack(info) => assert_eq!(*info.motive(), NackMotive::AlreadyConnected),
+        err => panic!("unexpected handshake error: {:?}", err),
+    }
+
+    assert!(cluster
+        .state()
+        .peers
+        .get_blacklisted_ip(&peer_id.to_ipv4().ip())
+        .is_none());
+    assert!(cluster.state().peers.get(&peer_id.to_ipv4()).is_none());
+}
+
+#[test]
+fn test_handshaking_nack_connecting_to_self_outgoing() {
+    let mut cluster = build_cluster(0.0);
+
+    let peer_identity = cluster.state().config.identity.clone();
+    let peer_id = cluster.peer_init_with_identity(peer_identity);
+
+    cluster.connect_to_peer(peer_id);
+    cluster.set_peer_connected(peer_id);
+
+    let err = cluster.do_handshake(peer_id).err().expect("handshaking was successful when it should have failed because peer has the same identity as node.");
+    match err {
+        HandshakeError::Nack(info) => assert_eq!(*info.motive(), NackMotive::AlreadyConnected),
+        err => panic!("unexpected handshake error: {:?}", err),
+    }
+
+    assert!(cluster
+        .state()
+        .peers
+        .get_blacklisted_ip(&peer_id.to_ipv4().ip())
+        .is_none());
+    assert!(cluster.state().peers.get(&peer_id.to_ipv4()).is_none());
+}
+
+#[test]
+fn test_handshaking_bad_pow_incoming() {
+    let mut cluster = build_cluster(10.0);
+
+    let peer_identity = loop {
+        // generate identity which doesn't pass 10.0 pow target.
+        let identity = Identity::generate(0.0).unwrap();
+        if identity
+            .proof_of_work_stamp
+            .check(&identity.public_key, 10.0)
+            .is_err()
+        {
+            break identity;
+        }
+    };
+    let peer_id = cluster.peer_init_with_identity(peer_identity);
+
+    cluster.connect_from_peer(peer_id);
+    cluster.set_peer_connected(peer_id);
+
+    let err = cluster
+        .do_handshake(peer_id)
+        .err()
+        .expect("handshaking was successful when it should have failed because peer has bad pow.");
+    match err {
+        HandshakeError::NackV0 => panic!(),
+        HandshakeError::Nack(_) => panic!(),
+        HandshakeError::NotConnected => {}
+    }
+
+    assert!(cluster
+        .state()
+        .peers
+        .get_blacklisted_ip(&peer_id.to_ipv4().ip())
+        .is_some());
+    assert!(cluster.state().peers.get(&peer_id.to_ipv4()).is_none());
+}
+
+#[test]
+fn test_handshaking_bad_pow_outgoing() {
+    let mut cluster = build_cluster(10.0);
+
+    let peer_identity = loop {
+        // generate identity which doesn't pass 10.0 pow target.
+        let identity = Identity::generate(0.0).unwrap();
+        if identity
+            .proof_of_work_stamp
+            .check(&identity.public_key, 10.0)
+            .is_err()
+        {
+            break identity;
+        }
+    };
+    let peer_id = cluster.peer_init_with_identity(peer_identity);
+
+    cluster.connect_to_peer(peer_id);
+    cluster.set_peer_connected(peer_id);
+
+    let err = cluster
+        .do_handshake(peer_id)
+        .err()
+        .expect("handshaking was successful when it should have failed because peer has bad pow.");
+    match err {
+        HandshakeError::NackV0 => panic!(),
+        HandshakeError::Nack(_) => panic!(),
+        HandshakeError::NotConnected => {}
+    }
+
+    assert!(cluster
+        .state()
+        .peers
+        .get_blacklisted_ip(&peer_id.to_ipv4().ip())
+        .is_some());
+    assert!(cluster.state().peers.get(&peer_id.to_ipv4()).is_none());
+}
+
+#[test]
+fn test_connecting_timeout_incoming() {
+    let mut cluster = build_cluster(0.0);
+    let check_timeouts_interval = cluster.state().config.check_timeouts_interval;
+    let configured_timeout = cluster.state().config.peer_connecting_timeout;
+
+    let peer_identity = cluster.state().config.identity.clone();
+    let peer_id = cluster.peer_init_with_identity(peer_identity);
+
+    cluster.connect_from_peer(peer_id);
+
+    for _ in 1..(configured_timeout.as_nanos() / check_timeouts_interval.as_nanos()).max(1) {
+        cluster.advance_time(check_timeouts_interval);
+        cluster.dispatch(PeersCheckTimeoutsInitAction {}.into());
+    }
+    assert!(cluster.state().peers.get(&peer_id.to_ipv4()).is_some());
+
+    cluster.advance_time(check_timeouts_interval);
+    cluster.dispatch(PeersCheckTimeoutsInitAction {}.into());
+
+    assert!(cluster.state().peers.get(&peer_id.to_ipv4()).is_none());
+    assert!(cluster
+        .state()
+        .peers
+        .get_blacklisted_ip(&peer_id.to_ipv4().ip())
+        .is_some());
+}
+
+#[test]
+fn test_connecting_timeout_outgoing() {
+    let mut cluster = build_cluster(0.0);
+    let check_timeouts_interval = cluster.state().config.check_timeouts_interval;
+    let configured_timeout = cluster.state().config.peer_connecting_timeout;
+
+    let peer_identity = cluster.state().config.identity.clone();
+    let peer_id = cluster.peer_init_with_identity(peer_identity);
+
+    cluster.connect_to_peer(peer_id);
+
+    for _ in 1..(configured_timeout.as_nanos() / check_timeouts_interval.as_nanos()).max(1) {
+        cluster.advance_time(check_timeouts_interval);
+        cluster.dispatch(PeersCheckTimeoutsInitAction {}.into());
+    }
+    assert!(cluster.state().peers.get(&peer_id.to_ipv4()).is_some());
+
+    cluster.advance_time(check_timeouts_interval);
+    cluster.dispatch(PeersCheckTimeoutsInitAction {}.into());
+
+    assert!(cluster.state().peers.get(&peer_id.to_ipv4()).is_none());
+    assert!(cluster
+        .state()
+        .peers
+        .get_blacklisted_ip(&peer_id.to_ipv4().ip())
+        .is_some());
+}
+
+#[test]
+fn test_handshaking_timeout_incoming() {
+    let mut cluster = build_cluster(0.0);
+    let check_timeouts_interval = cluster.state().config.check_timeouts_interval;
+    let configured_timeout = cluster.state().config.peer_handshaking_timeout;
+
+    let peer_identity = cluster.state().config.identity.clone();
+    let peer_id = cluster.peer_init_with_identity(peer_identity);
+
+    cluster.connect_from_peer(peer_id);
+    cluster.set_peer_connected(peer_id);
+
+    for _ in 1..(configured_timeout.as_nanos() / check_timeouts_interval.as_nanos()).max(1) {
+        cluster.advance_time(check_timeouts_interval);
+        cluster.dispatch(PeersCheckTimeoutsInitAction {}.into());
+    }
+    assert!(cluster.state().peers.get(&peer_id.to_ipv4()).is_some());
+
+    cluster.advance_time(check_timeouts_interval);
+    cluster.dispatch(PeersCheckTimeoutsInitAction {}.into());
+
+    assert!(cluster.state().peers.get(&peer_id.to_ipv4()).is_none());
+    assert!(cluster
+        .state()
+        .peers
+        .get_blacklisted_ip(&peer_id.to_ipv4().ip())
+        .is_some());
+}
+
+#[test]
+fn test_handshaking_timeout_outgoing() {
+    let mut cluster = build_cluster(0.0);
+    let check_timeouts_interval = cluster.state().config.check_timeouts_interval;
+    let configured_timeout = cluster.state().config.peer_handshaking_timeout;
+
+    let peer_identity = cluster.state().config.identity.clone();
+    let peer_id = cluster.peer_init_with_identity(peer_identity);
+
+    cluster.connect_to_peer(peer_id);
+    cluster.set_peer_connected(peer_id);
+
+    for _ in 1..(configured_timeout.as_nanos() / check_timeouts_interval.as_nanos()).max(1) {
+        cluster.advance_time(check_timeouts_interval);
+        cluster.dispatch(PeersCheckTimeoutsInitAction {}.into());
+    }
+    assert!(cluster.state().peers.get(&peer_id.to_ipv4()).is_some());
+
+    cluster.advance_time(check_timeouts_interval);
+    cluster.dispatch(PeersCheckTimeoutsInitAction {}.into());
+
+    assert!(cluster.state().peers.get(&peer_id.to_ipv4()).is_none());
+    assert!(cluster
+        .state()
+        .peers
+        .get_blacklisted_ip(&peer_id.to_ipv4().ip())
+        .is_some());
+}


### PR DESCRIPTION
- fix(shell_automaton): after nacking a peer, if he doesn't nack us back, we didn't disconnect them
- fix(shell_automaton): when connecting to self, we should send a nack `AlreadyConnected` to avoid blacklisting everyone with same ip
- fix(shell_automaton): when nacking a peer, if we are nacking because he is already connected, we shouldn't blacklist them as it's a normal behavior
- fix(shell_automaton): incorrect inequality used for checking peer timeouts
- test(shell_automaton): add basic tests for handshaking and timeout