### PR TITLE
Reject zero sized chunk from peer

### DIFF
--- a/shell_automaton/src/peer/chunk/read/peer_chunk_read_effects.rs
+++ b/shell_automaton/src/peer/chunk/read/peer_chunk_read_effects.rs
@@ -41,6 +41,15 @@ pub fn peer_chunk_read_effects<S>(
                             chunk_state, ..
                         } => {
                             return match chunk_state {
+                                PeerChunkReadState::PendingBody { size, .. } if *size == 0 => {
+                                    store.dispatch(
+                                        PeerChunkReadErrorAction {
+                                            address: action.address,
+                                            error: PeerChunkReadError::ZeroSize,
+                                        }
+                                        .into(),
+                                    );
+                                }
                                 PeerChunkReadState::PendingSize { .. }
                                 | PeerChunkReadState::PendingBody { .. } => {
                                     if peer.try_read_loop.can_be_started() {

--- a/shell_automaton/src/peer/chunk/read/peer_chunk_read_state.rs
+++ b/shell_automaton/src/peer/chunk/read/peer_chunk_read_state.rs
@@ -8,6 +8,8 @@ use crypto::{crypto_box::PrecomputedKey, nonce::Nonce, CryptoError};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum PeerChunkReadError {
+    /// Received chunk size = 0.
+    ZeroSize,
     IO(String),
     Crypto(String),
 }

--- a/shell_automaton/testing/tests/test_handshaking_basic.rs
+++ b/shell_automaton/testing/tests/test_handshaking_basic.rs
@@ -541,3 +541,26 @@ fn test_handshaking_timeout_outgoing() {
         .get_blacklisted_ip(&peer_id.to_ipv4().ip())
         .is_some());
 }
+
+#[test]
+fn test_handshaking_connection_message_0_bytes_chunk() {
+    let mut cluster = build_cluster(0.0);
+
+    let peer_id = cluster.peer_init(0.0);
+
+    cluster.connect_to_peer(peer_id);
+    cluster.set_peer_connected(peer_id);
+
+    let peer = cluster.peer(peer_id);
+    peer.set_write_cond(IOCondition::NoLimit);
+    peer.set_read_cond(IOCondition::NoLimit);
+    peer.send_bytes(&[0, 0]);
+    cluster.dispatch_peer_ready_event(peer_id, true, true, false);
+
+    assert!(cluster.state().peers.get(&peer_id.to_ipv4()).is_none());
+    assert!(cluster
+        .state()
+        .peers
+        .get_blacklisted_ip(&peer_id.to_ipv4().ip())
+        .is_some());
+}


### PR DESCRIPTION
Fix `debug_assert!` failing when received chunk size is 0 from peer. https://github.com/tezedge/tezedge/blob/0fa65f197e3ea866a14e08057347ddddd04a7fff/shell_automaton/src/peer/peer_effects.rs#L299

Now when we receive size for a chunk equal to zero, we dispatch an error action:
https://github.com/tezedge/tezedge/blob/e5af19541db19616341c1bd1e668689d78343b0e/shell_automaton/src/peer/chunk/read/peer_chunk_read_effects.rs#L45-L48