### PR TITLE
Serialize `Hashid` on 6 bytes

### DIFF
--- a/tezos/context/src/kv_store/persistent.rs
+++ b/tezos/context/src/kv_store/persistent.rs
@@ -315,16 +315,16 @@ fn deserialize_hashes(
     let mut offset = commit_index_file.start();
     let end = commit_index_file.offset().as_u64();
 
-    let mut hash_id_bytes = [0u8; 4];
+    let mut hash_id_bytes = [0u8; 8];
     let mut hash_offset_bytes = [0u8; 8];
     let mut commit_hash: ObjectHash = Default::default();
 
     while offset < end {
         // commit index file is a sequence of entries that look like:
-        // [hash_id u32 ne bytes | offset u64 ne bytes | hash <HASH_LEN> bytes]
-        commit_index_file.read_exact_at(&mut hash_id_bytes, offset.into())?;
-        offset += hash_id_bytes.len() as u64;
-        let hash_id = u32::from_le_bytes(hash_id_bytes);
+        // [hash_id 6 le bytes | offset u64 le bytes | hash <HASH_LEN> bytes]
+        commit_index_file.read_exact_at(&mut hash_id_bytes[..6], offset.into())?;
+        offset += (hash_id_bytes[..6]).len() as u64;
+        let hash_id = u64::from_le_bytes(hash_id_bytes);
 
         commit_index_file.read_exact_at(&mut hash_offset_bytes, offset.into())?;
         offset += hash_offset_bytes.len() as u64;
@@ -353,9 +353,9 @@ fn serialize_context_hash(
     let mut output = Vec::<u8>::with_capacity(100);
 
     let offset: u64 = offset.as_u64();
-    let hash_id: u32 = hash_id.as_u32();
+    let hash_id: u64 = hash_id.as_u64();
 
-    output.write_all(&hash_id.to_le_bytes())?;
+    output.write_all(&hash_id.to_le_bytes()[..6])?;
     output.write_all(&offset.to_le_bytes())?;
     output.write_all(hash)?;
 
@@ -557,5 +557,55 @@ impl KeyValueStoreBackend for Persistent {
         self.commit_to_disk(output)?;
         self.hashes.in_memory.set_is_commiting();
         Ok(Some(self.data_file.offset()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Make sure that the commit index is correctly serialized & deserialized
+    #[test]
+    fn test_commit_index() {
+        let hashes_file = File::try_new("test_commit_index", FileType::Hashes).unwrap();
+        let mut commit_index_file =
+            File::try_new("test_commit_index", FileType::CommitIndex).unwrap();
+
+        let bytes =
+            serialize_context_hash(HashId::new(101).unwrap(), 102.into(), &vec![3; 32]).unwrap();
+        commit_index_file.append(bytes).unwrap();
+
+        let bytes = serialize_context_hash(
+            HashId::new(u32::MAX as u64).unwrap(),
+            103.into(),
+            &vec![4; 32],
+        )
+        .unwrap();
+        commit_index_file.append(bytes).unwrap();
+
+        let bytes = serialize_context_hash(
+            HashId::new(u32::MAX as u64 + 10).unwrap(),
+            104.into(),
+            &vec![5; 32],
+        )
+        .unwrap();
+        commit_index_file.append(bytes).unwrap();
+
+        let res = deserialize_hashes(hashes_file, &commit_index_file).unwrap();
+
+        let mut values: Vec<_> = res.1.values().collect();
+        values.sort_by_key(|k| k.offset().as_u64());
+
+        assert_eq!(
+            &values,
+            &[
+                &ObjectReference::new(HashId::new(101), Some(102.into())),
+                &ObjectReference::new(HashId::new(u32::MAX as u64), Some(103.into())),
+                &ObjectReference::new(HashId::new(u32::MAX as u64 + 10), Some(104.into())),
+            ]
+        );
+
+        std::fs::remove_file("test_commit_index/hashes.db").ok();
+        std::fs::remove_file("test_commit_index/commit_index.db").ok();
     }
 }

--- a/tezos/context/src/serialize/in_memory.rs
+++ b/tezos/context/src/serialize/in_memory.rs
@@ -69,7 +69,7 @@ fn serialize_shaped_directory(
     for (_, dir_entry_id) in dir {
         let dir_entry = storage.get_dir_entry(*dir_entry_id)?;
 
-        let hash_id: u32 = dir_entry.hash_id().map(|h| h.as_u32()).unwrap_or(0);
+        let hash_id: u64 = dir_entry.hash_id().map(|h| h.as_u64()).unwrap_or(0);
         let kind = dir_entry.dir_entry_kind();
 
         let blob_inline = dir_entry.get_inlined_blob(storage);
@@ -124,7 +124,7 @@ fn serialize_directory(
 
         let dir_entry = storage.get_dir_entry(*dir_entry_id)?;
 
-        let hash_id: u32 = dir_entry.hash_id().map(|h| h.as_u32()).unwrap_or(0);
+        let hash_id: u64 = dir_entry.hash_id().map(|h| h.as_u64()).unwrap_or(0);
         let kind = dir_entry.dir_entry_kind();
 
         let blob_inline = dir_entry.get_inlined_blob(storage);
@@ -235,11 +235,11 @@ pub fn serialize_object(
             let parent_hash_id = commit
                 .parent_commit_ref
                 .and_then(|p| p.hash_id_opt())
-                .map(|h| h.as_u32())
+                .map(|h| h.as_u64())
                 .unwrap_or(0);
             serialize_hash_id(parent_hash_id, output, stats)?;
 
-            let root_hash_id = commit.root_ref.hash_id().as_u32();
+            let root_hash_id = commit.root_ref.hash_id().as_u64();
             serialize_hash_id(root_hash_id, output, stats)?;
 
             output.write_all(&commit.time.to_ne_bytes())?;
@@ -304,7 +304,7 @@ fn serialize_inode(
 
             for pointer in pointers.iter().filter_map(|p| p.as_ref()) {
                 let hash_id = pointer.hash_id().ok_or(MissingHashId)?;
-                let hash_id = hash_id.as_u32();
+                let hash_id = hash_id.as_u64();
 
                 serialize_hash_id(hash_id, output, stats)?;
             }
@@ -856,7 +856,7 @@ mod tests {
         }
 
         let iter = iter_hash_ids(&data);
-        assert_eq!(iter.map(|h| h.as_u32()).collect::<Vec<_>>(), &[3, 1, 2]);
+        assert_eq!(iter.map(|h| h.as_u64()).collect::<Vec<_>>(), &[3, 1, 2]);
 
         // Test Object::Directory (Shaped)
 
@@ -913,7 +913,7 @@ mod tests {
         }
 
         let iter = iter_hash_ids(&data);
-        assert_eq!(iter.map(|h| h.as_u32()).collect::<Vec<_>>(), &[3, 1, 2]);
+        assert_eq!(iter.map(|h| h.as_u64()).collect::<Vec<_>>(), &[3, 1, 2]);
 
         // Test Object::Blob
 
@@ -976,7 +976,7 @@ mod tests {
         }
 
         let iter = iter_hash_ids(&data);
-        assert_eq!(iter.map(|h| h.as_u32()).collect::<Vec<_>>(), &[12345]);
+        assert_eq!(iter.map(|h| h.as_u64()).collect::<Vec<_>>(), &[12345]);
 
         // Test Inode::Directory
 
@@ -986,7 +986,7 @@ mod tests {
             let inode_value = Inode::Directory(DirectoryId::empty());
             let inode_value_id = storage.add_inode(inode_value).unwrap();
 
-            let hash_id = HashId::new((index + 1) as u32).unwrap();
+            let hash_id = HashId::new((index + 1) as u64).unwrap();
 
             repo.write_batch(vec![(hash_id, Arc::new(ObjectHeader::new().into_bytes()))])
                 .unwrap();
@@ -1036,7 +1036,7 @@ mod tests {
             for (index, pointer) in pointers.iter().enumerate() {
                 let pointer = pointer.as_ref().unwrap();
                 let hash_id = pointer.hash_id().unwrap();
-                assert_eq!(hash_id.as_u32() as usize, index + 1);
+                assert_eq!(hash_id.as_u64() as usize, index + 1);
 
                 let inode = storage.get_inode(pointer.inode_id()).unwrap();
                 match inode {
@@ -1050,7 +1050,7 @@ mod tests {
 
         let iter = iter_hash_ids(&batch[0].1);
         assert_eq!(
-            iter.map(|h| h.as_u32()).collect::<Vec<_>>(),
+            iter.map(|h| h.as_u64()).collect::<Vec<_>>(),
             (1..33).collect::<Vec<_>>()
         );
 
@@ -1111,7 +1111,7 @@ mod tests {
         }
 
         let iter = iter_hash_ids(&batch[0].1);
-        assert_eq!(iter.map(|h| h.as_u32()).collect::<Vec<_>>(), &[3, 1, 2]);
+        assert_eq!(iter.map(|h| h.as_u64()).collect::<Vec<_>>(), &[3, 1, 2]);
     }
 
     #[test]

--- a/tezos/context/src/working_tree/storage.rs
+++ b/tezos/context/src/working_tree/storage.rs
@@ -375,7 +375,7 @@ pub struct InodeId(u32);
 #[bitfield]
 #[derive(Clone, Copy, Debug)]
 pub struct PointerToInodeInner {
-    hash_id: B32,
+    hash_id: B48,
     is_commited: bool,
     inode_id: B31,
     offset: B64,
@@ -391,7 +391,7 @@ impl PointerToInode {
         Self {
             inner: Cell::new(
                 PointerToInodeInner::new()
-                    .with_hash_id(hash_id.map(|h| h.as_u32()).unwrap_or(0))
+                    .with_hash_id(hash_id.map(|h| h.as_u64()).unwrap_or(0))
                     .with_is_commited(false)
                     .with_inode_id(inode_id.0)
                     .with_offset(0),
@@ -407,7 +407,7 @@ impl PointerToInode {
         Self {
             inner: Cell::new(
                 PointerToInodeInner::new()
-                    .with_hash_id(hash_id.map(|h| h.as_u32()).unwrap_or(0))
+                    .with_hash_id(hash_id.map(|h| h.as_u64()).unwrap_or(0))
                     .with_is_commited(true)
                     .with_inode_id(inode_id.0)
                     .with_offset(offset.map(|o| o.as_u64()).unwrap_or(0)), //.with_offset(0),
@@ -439,7 +439,7 @@ impl PointerToInode {
 
     pub fn set_hash_id(&self, hash_id: Option<HashId>) {
         let mut inner = self.inner.get();
-        inner.set_hash_id(hash_id.map(|h| h.as_u32()).unwrap_or(0));
+        inner.set_hash_id(hash_id.map(|h| h.as_u64()).unwrap_or(0));
 
         self.inner.set(inner);
     }
@@ -462,7 +462,7 @@ impl PointerToInode {
     }
 }
 
-assert_eq_size!([u8; 17], Option<PointerToInode>);
+assert_eq_size!([u8; 19], Option<PointerToInode>);
 
 /// Inode representation used for hashing directories with > DIRECTORY_INODE_THRESHOLD entries.
 #[allow(clippy::large_enum_variant)]
@@ -481,7 +481,7 @@ pub enum Inode {
     },
 }
 
-assert_eq_size!([u8; 560], Inode);
+assert_eq_size!([u8; 624], Inode);
 
 /// A range inside `Storage::temp_dir`
 type TempDirRange = Range<usize>;

--- a/tezos/timing/src/lib.rs
+++ b/tezos/timing/src/lib.rs
@@ -122,7 +122,7 @@ pub struct SerializeStats {
     pub blobs_length: usize,
     pub hash_ids_length: usize,
     pub keys_length: usize,
-    pub highest_hash_id: u32,
+    pub highest_hash_id: u64,
     pub ndirectories: usize,
     pub nblobs: usize,
     pub nblobs_inlined: usize,


### PR DESCRIPTION
This change `HashId` serialization size from 4 bytes to 6 bytes.
`HashId` will still be serialized on 4 bytes when the underlying `u64` fits in 32 bytes