### PR TITLE
Fix: shell automaton and actor system peers out of sync

### DIFF
--- a/light_node/src/configuration.rs
+++ b/light_node/src/configuration.rs
@@ -388,7 +388,7 @@ pub fn tezos_app() -> App<'static, 'static> {
         .arg(Arg::with_name("disable-peer-graylist")
             .long("disable-peer-graylist")
             .global(true)
-            .help("Disable peer blacklisting"))
+            .help("Disable peer graylisting"))
         .arg(Arg::with_name("mempool-downloaded-operation-max-ttl-in-secs")
             .long("mempool-downloaded-operation-max-ttl-in-secs")
             .takes_value(true)

--- a/shell/src/state/bootstrap_state.rs
+++ b/shell/src/state/bootstrap_state.rs
@@ -184,7 +184,6 @@ impl BootstrapState {
                        "reason" => reason,
                        "peer_ip" => peer_id.address.to_string());
 
-            self.clean_peer_data(&peer_id.address);
             disconnect_peer(&peer_id, &self.data_requester);
         }
     }
@@ -213,7 +212,7 @@ impl BootstrapState {
         let mut rng = rand::thread_rng();
         let data_requester = &*self.data_requester;
 
-        self.peers.retain(|_, peer_state| {
+        for (_, peer_state) in self.peers.iter_mut() {
             // clear peer state
             peer_state.empty_bootstrap_state = Some(Instant::now());
             peer_state.is_bootstrapped = false;
@@ -234,8 +233,7 @@ impl BootstrapState {
                             "peer_id" => peer_state.peer_id.public_key_hash.to_base58_check(), "peer_ip" => peer_state.peer_id.address.to_string());
                 disconnect_peer(&peer_state.peer_id, data_requester);
             }
-            retain_peer
-        });
+        }
     }
 
     pub fn blocks_scheduled_count(&self) -> usize {


### PR DESCRIPTION
Actor decides to remove a peer from it's state without state machine's approval, which causes actor to not have any peers and state machine to not connect to new peers since it doesn't disconnect them.