### PR TITLE
Replace no-longer used `TEZOS_STORAGE` env var with `TEZOS_CONTEXT`

### DIFF
--- a/apps/deploy_monitoring/docker-compose.tezedge_and_explorer.yml
+++ b/apps/deploy_monitoring/docker-compose.tezedge_and_explorer.yml
@@ -25,7 +25,7 @@ services:
     volumes:
       - "${TEZEDGE_VOLUME_PATH}:/tmp/tezedge"
     environment:
-      - TEZOS_STORAGE=index-log-size=5_000_000
+      - TEZOS_CONTEXT=index-log-size=5_000_000
     ports:
       - "4927:4927"       # node WS port (required only for tezedge)
       - "9732:9732"       # node P2P port

--- a/apps/node_monitoring/docker-compose.tezedge_and_explorer.yml
+++ b/apps/node_monitoring/docker-compose.tezedge_and_explorer.yml
@@ -27,7 +27,7 @@ services:
     volumes:
       - "${TEZEDGE_VOLUME_PATH}:/tmp/tezedge"
     environment:
-      - TEZOS_STORAGE=index-log-size=5_000_000
+      - TEZOS_CONTEXT=index-log-size=5_000_000
 
   explorer:
     image: tezedge/tezedge-explorer:v1.9.1


### PR DESCRIPTION
This is used to set Irmin's index log size limit.