### PR TITLE
Set index-log-size default (to same as Octez v11) in all docker-compose files

### DIFF
--- a/apps/deploy_monitoring/docker-compose.deploy.florencenet.latest.yml
+++ b/apps/deploy_monitoring/docker-compose.deploy.florencenet.latest.yml
@@ -32,6 +32,8 @@ services:
 
   tezedge-node:
     image: tezedge/tezedge:latest-frame-pointers-enabled
+    environment:
+      - TEZOS_CONTEXT=index-log-size=2_500_000
     command: ["--network", "${TEZOS_NETWORK}", "--p2p-port=9732", "--rpc-port=18732", "--websocket-address=0.0.0.0:4927", "--log", "terminal", "file", "--log-file", "/tmp/tezedge/tezedge.log", "--tezos-context-storage", "both", "--context-stats-db-path", "context-stats-db", "--peer-thresh-low", "60", "--peer-thresh-high", "80"]
     logging:
       # Produce syslogs instead of terminal logs

--- a/apps/deploy_monitoring/docker-compose.deploy.latest-release.yml
+++ b/apps/deploy_monitoring/docker-compose.deploy.latest-release.yml
@@ -32,6 +32,8 @@ services:
 
   tezedge-node:
     image: tezedge/tezedge:v1.11.0-frame-pointers-enabled
+    environment:
+      - TEZOS_CONTEXT=index-log-size=2_500_000
     command: ["--network", "${TEZOS_NETWORK}", "--p2p-port=9732", "--rpc-port=18732", "--websocket-address=0.0.0.0:4927", "--log", "terminal", "file", "--log-file", "/tmp/tezedge/tezedge.log", "--tezos-context-storage", "irmin", "--peer-thresh-low", "60", "--peer-thresh-high", "80"]
     logging:
       # Produce syslogs instead of terminal logs

--- a/apps/deploy_monitoring/docker-compose.deploy.latest.yml
+++ b/apps/deploy_monitoring/docker-compose.deploy.latest.yml
@@ -32,6 +32,8 @@ services:
 
   tezedge-node:
     image: tezedge/tezedge:latest-frame-pointers-enabled
+    environment:
+      - TEZOS_CONTEXT=index-log-size=2_500_000
     command: ["--network", "${TEZOS_NETWORK}", "--p2p-port=9732", "--rpc-port=18732", "--websocket-address=0.0.0.0:4927", "--log", "terminal", "file", "--log-file", "/tmp/tezedge/tezedge.log", "--tezos-context-storage", "irmin", "--peer-thresh-low", "60", "--peer-thresh-high", "80"]
     logging:
       # Produce syslogs instead of terminal logs

--- a/apps/deploy_monitoring/docker-compose.deploy.mainnet.latest-release.yml
+++ b/apps/deploy_monitoring/docker-compose.deploy.mainnet.latest-release.yml
@@ -32,6 +32,8 @@ services:
 
   tezedge-node:
     image: tezedge/tezedge:v1.11.0-frame-pointers-enabled
+    environment:
+      - TEZOS_CONTEXT=index-log-size=2_500_000
     command: ["--network", "${TEZOS_NETWORK}", "--p2p-port=9732", "--rpc-port=18732", "--websocket-address=0.0.0.0:4927", "--log", "terminal", "file", "--log-file", "/tmp/tezedge/tezedge.log", "--tezos-context-storage", "both", "--context-stats-db-path", "context-stats-db", "--peer-thresh-low", "60", "--peer-thresh-high", "80"]
     logging:
       # Produce syslogs instead of terminal logs

--- a/apps/deploy_monitoring/docker-compose.localhost.yml
+++ b/apps/deploy_monitoring/docker-compose.localhost.yml
@@ -32,6 +32,8 @@ services:
 
   tezedge-node:
     image: tezedge/tezedge:latest-frame-pointers-enabled
+    environment:
+      - TEZOS_CONTEXT=index-log-size=2_500_000
     command: ["--network", "${TEZOS_NETWORK}", "--p2p-port=9732", "--rpc-port=18732", "--websocket-address=0.0.0.0:4927", "--log", "terminal", "file", "--log-file", "/tmp/tezedge/tezedge.log"]
     logging:
       # Produce syslogs instead of terminal logs

--- a/apps/deploy_monitoring/docker-compose.tezedge_and_explorer.yml
+++ b/apps/deploy_monitoring/docker-compose.tezedge_and_explorer.yml
@@ -3,6 +3,8 @@ version: "3"
 services:
   tezedge-node:
     image: tezedge/tezedge:v1.11.0
+    environment:
+      - TEZOS_CONTEXT=index-log-size=5_000_000
     command: [
         "--network", "${TEZOS_NETWORK}",
         "--p2p-port=9732",
@@ -24,8 +26,6 @@ services:
         syslog-format: "rfc5424micro"
     volumes:
       - "${TEZEDGE_VOLUME_PATH}:/tmp/tezedge"
-    environment:
-      - TEZOS_CONTEXT=index-log-size=5_000_000
     ports:
       - "4927:4927"       # node WS port (required only for tezedge)
       - "9732:9732"       # node P2P port

--- a/apps/node_monitoring/docker-compose.deploy.florencenet.latest.yml
+++ b/apps/node_monitoring/docker-compose.deploy.florencenet.latest.yml
@@ -34,6 +34,8 @@ services:
     image: tezedge/tezedge:latest-frame-pointers-enabled
     pid: host
     network_mode: host
+    environment:
+      - TEZOS_CONTEXT=index-log-size=2_500_000
     command: ["--network", "${TEZOS_NETWORK-florencenet}", "--p2p-port=9732", "--rpc-port=18732", "--websocket-address=0.0.0.0:4927", "--log", "terminal", "file", "--log-file", "/tmp/tezedge/tezedge.log", "--tezos-context-storage", "both", "--context-stats-db-path", "context-stats-db", "--peer-thresh-low", "15", "--peer-thresh-high", "30", "--record-shell-automaton-state-snapshots", "--record-shell-automaton-actions"]
     logging:
       # Produce syslogs instead of terminal logs

--- a/apps/node_monitoring/docker-compose.deploy.mainnet.latest-release.yml
+++ b/apps/node_monitoring/docker-compose.deploy.mainnet.latest-release.yml
@@ -34,6 +34,8 @@ services:
     image: tezedge/tezedge:v1.11.0-frame-pointers-enabled
     pid: host
     network_mode: host
+    environment:
+      - TEZOS_CONTEXT=index-log-size=2_500_000
     command: ["--network", "${TEZOS_NETWORK-mainnet}", "--p2p-port=9732", "--rpc-port=18732", "--websocket-address=0.0.0.0:4927", "--log", "terminal", "file", "--log-file", "/tmp/tezedge/tezedge.log", "--tezos-context-storage", "irmin", "--context-stats-db-path", "context-stats-db", "--peer-thresh-low", "15", "--peer-thresh-high", "30", "--record-shell-automaton-state-snapshots", "--record-shell-automaton-actions"]
     logging:
       # Produce syslogs instead of terminal logs

--- a/apps/node_monitoring/docker-compose.deploy.mainnet.latest.yml
+++ b/apps/node_monitoring/docker-compose.deploy.mainnet.latest.yml
@@ -34,6 +34,8 @@ services:
     image: tezedge/tezedge:v1.11.0-frame-pointers-enabled
     pid: host
     network_mode: host
+    environment:
+      - TEZOS_CONTEXT=index-log-size=2_500_000
     command: ["--network", "${TEZOS_NETWORK-mainnet}", "--p2p-port=9732", "--rpc-port=18732", "--websocket-address=0.0.0.0:4927", "--log", "terminal", "file", "--log-file", "/tmp/tezedge/tezedge.log", "--tezos-context-storage", "irmin", "--context-stats-db-path", "context-stats-db", "--peer-thresh-low", "15", "--peer-thresh-high", "30", "--record-shell-automaton-state-snapshots", "--record-shell-automaton-actions"]
     logging:
       # Produce syslogs instead of terminal logs

--- a/apps/node_monitoring/docker-compose.deploy.mainnet.snapshot.latest.yml
+++ b/apps/node_monitoring/docker-compose.deploy.mainnet.snapshot.latest.yml
@@ -34,6 +34,8 @@ services:
     image: tezedge/tezedge:v1.11.0-frame-pointers-enabled
     pid: host
     network_mode: host
+    environment:
+      - TEZOS_CONTEXT=index-log-size=2_500_000
     command: ["--network", "${TEZOS_NETWORK-mainnet}", "--p2p-port=9732", "--rpc-port=18732", "--websocket-address=0.0.0.0:4927", "--log", "terminal", "file", "--log-file", "/tmp/tezedge/tezedge.log", "--tezos-context-storage", "irmin", "--context-stats-db-path", "context-stats-db", "--peer-thresh-low", "60", "--peer-thresh-high", "80"]
     logging:
       # Produce syslogs instead of terminal logs

--- a/apps/node_monitoring/docker-compose.tezedge_and_explorer.yml
+++ b/apps/node_monitoring/docker-compose.tezedge_and_explorer.yml
@@ -3,6 +3,8 @@ version: "3"
 services:
   tezedge-node:
     image: tezedge/tezedge:v1.11.0
+    environment:
+      - TEZOS_CONTEXT=index-log-size=5_000_000
     command: [
         "--network", "${TEZOS_NETWORK}",
         "--p2p-port=9732",
@@ -26,8 +28,6 @@ services:
         syslog-format: "rfc5424micro"
     volumes:
       - "${TEZEDGE_VOLUME_PATH}:/tmp/tezedge"
-    environment:
-      - TEZOS_CONTEXT=index-log-size=5_000_000
 
   explorer:
     image: tezedge/tezedge-explorer:v1.9.1

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -32,6 +32,8 @@ services:
         syslog-format: "rfc5424micro"
     volumes:
       - "tezedge-debug-data:/tmp/tezedge"
+    environment:
+      - TEZOS_CONTEXT=index-log-size=2_500_000
 
   explorer:
     image: tezedge/tezedge-explorer:v1.9.1

--- a/docker-compose.storage.irmin.yml
+++ b/docker-compose.storage.irmin.yml
@@ -11,6 +11,8 @@ services:
     tty: true
     volumes:
       - "tezedge-with-irmin-storage-data:/tmp/tezedge"
+    environment:
+      - TEZOS_CONTEXT=index-log-size=2_500_000
 
   tezedge-explorer-with-irmin-storage:
     image: tezedge/tezedge-explorer:v1.9.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
     networks:
       - default
     tty: true
+    environment:
+      - TEZOS_CONTEXT=index-log-size=2_500_000
 
   explorer:
     image: tezedge/tezedge-explorer:v1.9.1


### PR DESCRIPTION
Matches https://gitlab.com/tezos/tezos/-/commit/43c9915810b7f4cc7a3669b90b0a0d1d93af8098

Newer protocols create bindings at a higher rate, reaching the index log size limit more often, this change raises the limit to 5x the current limit.

Once our libtezos has been upgraded to v11 this will not be required.

This will increase memory usage of the protocol runner (bigger index to keep in memory), but it will not have as big of an impact as before because we don't have 10+ protocol runners running in parallel now.