### PR TITLE
Fix `HashId` with inodes

### DIFF
--- a/tezos/context/src/hash/mod.rs
+++ b/tezos/context/src/hash/mod.rs
@@ -715,7 +715,7 @@ mod tests {
                             dir_id,
                             &key,
                             DirEntry::new_commited(DirEntryKind::Blob, Some(hash_id), None)
-                                .with_offset(0.into()),
+                                .with_offset(1.into()),
                             &mut strings,
                         )
                         .unwrap();
@@ -728,7 +728,7 @@ mod tests {
                             dir_id,
                             &key,
                             DirEntry::new_commited(DirEntryKind::Blob, Some(hash_id), None)
-                                .with_offset(0.into()),
+                                .with_offset(1.into()),
                             &mut strings,
                         )
                         .unwrap();

--- a/tezos/context/src/hash/mod.rs
+++ b/tezos/context/src/hash/mod.rs
@@ -187,7 +187,7 @@ fn hash_long_inode(
 
                     hasher.update(&[index]);
 
-                    let hash_id = match pointer.hash_id() {
+                    let hash_id = match pointer.hash_id(storage, store)? {
                         Some(hash_id) => hash_id,
                         None => {
                             let inode_id = pointer.inode_id();

--- a/tezos/context/src/serialize/in_memory.rs
+++ b/tezos/context/src/serialize/in_memory.rs
@@ -49,6 +49,7 @@ fn serialize_shaped_directory(
     dir: &[(StringId, DirEntryId)],
     output: &mut Vec<u8>,
     storage: &Storage,
+    repository: &mut ContextKeyValueStore,
     stats: &mut SerializeStats,
 ) -> Result<(), SerializationError> {
     let mut nblobs_inlined: usize = 0;
@@ -69,7 +70,7 @@ fn serialize_shaped_directory(
     for (_, dir_entry_id) in dir {
         let dir_entry = storage.get_dir_entry(*dir_entry_id)?;
 
-        let hash_id: u64 = dir_entry.hash_id().map(|h| h.as_u64()).unwrap_or(0);
+        let hash_id = dir_entry.hash_id();
         let kind = dir_entry.dir_entry_kind();
 
         let blob_inline = dir_entry.get_inlined_blob(storage);
@@ -88,7 +89,7 @@ fn serialize_shaped_directory(
 
             output.write_all(&blob_inline)?;
         } else {
-            serialize_hash_id(hash_id, output, stats)?;
+            serialize_hash_id(hash_id, output, repository, stats)?;
         }
     }
 
@@ -110,7 +111,7 @@ fn serialize_directory(
     let mut blobs_length: usize = 0;
 
     if let Some(shape_id) = repository.make_shape(dir)? {
-        return serialize_shaped_directory(shape_id, dir, output, storage, stats);
+        return serialize_shaped_directory(shape_id, dir, output, storage, repository, stats);
     };
 
     let header: [u8; 1] = ObjectHeader::new()
@@ -124,7 +125,7 @@ fn serialize_directory(
 
         let dir_entry = storage.get_dir_entry(*dir_entry_id)?;
 
-        let hash_id: u64 = dir_entry.hash_id().map(|h| h.as_u64()).unwrap_or(0);
+        let hash_id = dir_entry.hash_id();
         let kind = dir_entry.dir_entry_kind();
 
         let blob_inline = dir_entry.get_inlined_blob(storage);
@@ -162,7 +163,7 @@ fn serialize_directory(
 
             output.write_all(&blob_inline)?;
         } else {
-            serialize_hash_id(hash_id, output, stats)?;
+            serialize_hash_id(hash_id, output, repository, stats)?;
         }
     }
 
@@ -232,15 +233,11 @@ pub fn serialize_object(
                 .into_bytes();
             output.write_all(&header)?;
 
-            let parent_hash_id = commit
-                .parent_commit_ref
-                .and_then(|p| p.hash_id_opt())
-                .map(|h| h.as_u64())
-                .unwrap_or(0);
-            serialize_hash_id(parent_hash_id, output, stats)?;
+            let parent_hash_id = commit.parent_commit_ref.and_then(|p| p.hash_id_opt());
+            serialize_hash_id(parent_hash_id, output, repository, stats)?;
 
-            let root_hash_id = commit.root_ref.hash_id().as_u64();
-            serialize_hash_id(root_hash_id, output, stats)?;
+            let root_hash_id = commit.root_ref.hash_id();
+            serialize_hash_id(root_hash_id, output, repository, stats)?;
 
             output.write_all(&commit.time.to_ne_bytes())?;
 
@@ -304,9 +301,8 @@ fn serialize_inode(
 
             for pointer in pointers.iter().filter_map(|p| p.as_ref()) {
                 let hash_id = pointer.hash_id().ok_or(MissingHashId)?;
-                let hash_id = hash_id.as_u64();
 
-                serialize_hash_id(hash_id, output, stats)?;
+                serialize_hash_id(hash_id, output, repository, stats)?;
             }
 
             batch.push((hash_id, Arc::from(output.as_slice())));

--- a/tezos/context/src/serialize/in_memory.rs
+++ b/tezos/context/src/serialize/in_memory.rs
@@ -300,7 +300,7 @@ fn serialize_inode(
             debug_assert_eq!(output.len(), INODE_POINTERS_NBYTES_TO_HASHES);
 
             for pointer in pointers.iter().filter_map(|p| p.as_ref()) {
-                let hash_id = pointer.hash_id().ok_or(MissingHashId)?;
+                let hash_id = pointer.hash_id(storage, repository)?.ok_or(MissingHashId)?;
 
                 serialize_hash_id(hash_id, output, repository, stats)?;
             }
@@ -309,7 +309,7 @@ fn serialize_inode(
 
             // Recursively serialize all children
             for pointer in pointers.iter().filter_map(|p| p.as_ref()) {
-                let hash_id = pointer.hash_id().ok_or(MissingHashId)?;
+                let hash_id = pointer.hash_id(storage, repository)?.ok_or(MissingHashId)?;
 
                 if pointer.is_commited() {
                     // We only want to serialize new inodes.
@@ -1031,7 +1031,7 @@ mod tests {
 
             for (index, pointer) in pointers.iter().enumerate() {
                 let pointer = pointer.as_ref().unwrap();
-                let hash_id = pointer.hash_id().unwrap();
+                let hash_id = pointer.hash_id(&storage, &repo).unwrap().unwrap();
                 assert_eq!(hash_id.as_u64() as usize, index + 1);
 
                 let inode = storage.get_inode(pointer.inode_id()).unwrap();

--- a/tezos/context/src/serialize/mod.rs
+++ b/tezos/context/src/serialize/mod.rs
@@ -11,6 +11,7 @@ use tezos_timing::SerializeStats;
 use thiserror::Error;
 
 use crate::{
+    hash::HashingError,
     kv_store::HashId,
     persistent::DBError,
     working_tree::{
@@ -210,6 +211,11 @@ pub enum SerializationError {
     },
     #[error("Missing Offset")]
     MissingOffset,
+    #[error("Hashing Error: {error}")]
+    HashingError {
+        #[from]
+        error: HashingError,
+    },
 }
 
 #[derive(Debug, Error)]

--- a/tezos/context/src/serialize/persistent.rs
+++ b/tezos/context/src/serialize/persistent.rs
@@ -1219,7 +1219,7 @@ mod tests {
             .dir_insert(
                 dir_id,
                 "a",
-                DirEntry::new_commited(DirEntryKind::Blob, None, None).with_offset(0.into()),
+                DirEntry::new_commited(DirEntryKind::Blob, None, None).with_offset(1.into()),
                 &mut strings,
             )
             .unwrap();
@@ -1227,7 +1227,7 @@ mod tests {
             .dir_insert(
                 dir_id,
                 "bab",
-                DirEntry::new_commited(DirEntryKind::Blob, None, None).with_offset(0.into()),
+                DirEntry::new_commited(DirEntryKind::Blob, None, None).with_offset(1.into()),
                 &mut strings,
             )
             .unwrap();
@@ -1235,7 +1235,7 @@ mod tests {
             .dir_insert(
                 dir_id,
                 "0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                DirEntry::new_commited(DirEntryKind::Blob, None, None).with_offset(0.into()),
+                DirEntry::new_commited(DirEntryKind::Blob, None, None).with_offset(1.into()),
                 &mut strings,
             )
             .unwrap();
@@ -1654,7 +1654,7 @@ mod tests {
             .dir_insert(
                 dir_id,
                 "a",
-                DirEntry::new_commited(DirEntryKind::Blob, None, None).with_offset(0.into()),
+                DirEntry::new_commited(DirEntryKind::Blob, None, None).with_offset(1.into()),
                 &mut strings,
             )
             .unwrap();
@@ -1671,7 +1671,7 @@ mod tests {
             &mut batch,
             &mut older_objects,
             &mut repo,
-            Some(0.into()),
+            Some(1.into()),
         )
         .unwrap();
 

--- a/tezos/context/src/serialize/persistent.rs
+++ b/tezos/context/src/serialize/persistent.rs
@@ -186,6 +186,7 @@ fn serialize_shaped_directory(
     offset: AbsoluteOffset,
     output: &mut Vec<u8>,
     storage: &Storage,
+    repository: &mut ContextKeyValueStore,
     stats: &mut SerializeStats,
 ) -> Result<(), SerializationError> {
     use SerializationError::*;
@@ -198,7 +199,7 @@ fn serialize_shaped_directory(
     // Replaced by ObjectHeader
     output.write_all(&[0, 0])?;
 
-    serialize_hash_id(object_hash_id.as_u64(), output, stats)?;
+    serialize_hash_id(object_hash_id, output, repository, stats)?;
 
     let shape_id = shape_id.as_u32();
     output.write_all(&shape_id.to_le_bytes())?;
@@ -311,6 +312,7 @@ fn serialize_directory_or_shape(
             offset,
             output,
             storage,
+            repository,
             stats,
         )
     } else {
@@ -334,7 +336,7 @@ fn serialize_directory(
     offset: AbsoluteOffset,
     output: &mut Vec<u8>,
     storage: &Storage,
-    _repository: &mut ContextKeyValueStore,
+    repository: &mut ContextKeyValueStore,
     stats: &mut SerializeStats,
     strings: &StringInterner,
 ) -> Result<(), SerializationError> {
@@ -349,7 +351,7 @@ fn serialize_directory(
     // Replaced by ObjectHeader
     output.write_all(&[0, 0])?;
 
-    serialize_hash_id(object_hash_id.as_u64(), output, stats)?;
+    serialize_hash_id(object_hash_id, output, repository, stats)?;
 
     for (key_id, dir_entry_id) in dir {
         let key = strings.get_str(*key_id)?;
@@ -471,7 +473,7 @@ pub fn serialize_object(
             // Replaced by ObjectHeader
             output.write_all(&[0, 0])?;
 
-            serialize_hash_id(object_hash_id.as_u64(), output, stats)?;
+            serialize_hash_id(object_hash_id, output, repository, stats)?;
             output.write_all(blob.as_ref())?;
 
             write_object_header(output, start, ObjectTag::Blob);
@@ -482,7 +484,7 @@ pub fn serialize_object(
             // Replaced by ObjectHeader
             output.write_all(&[0, 0])?;
 
-            serialize_hash_id(object_hash_id.as_u64(), output, stats)?;
+            serialize_hash_id(object_hash_id, output, repository, stats)?;
 
             let author_length = match commit.author.len() {
                 length if length <= 0xFF => ObjectLength::OneByte,
@@ -509,13 +511,13 @@ pub fn serialize_object(
             output.write_all(&header)?;
 
             if let Some(parent) = commit.parent_commit_ref {
-                serialize_hash_id(parent.hash_id().as_u64(), output, stats)?;
+                serialize_hash_id(parent.hash_id(), output, repository, stats)?;
                 serialize_offset(output, parent_relative_offset, parent_offset_length, stats)?;
             };
 
-            let root_hash_id = commit.root_ref.hash_id().as_u64();
+            let root_hash_id = commit.root_ref.hash_id();
 
-            serialize_hash_id(root_hash_id, output, stats)?;
+            serialize_hash_id(root_hash_id, output, repository, stats)?;
             serialize_offset(output, root_relative_offset, root_offset_length, stats)?;
 
             output.write_all(&commit.time.to_le_bytes())?;
@@ -675,7 +677,7 @@ fn serialize_inode(
             // Replaced by ObjectHeader
             output.write_all(&[0, 0])?;
 
-            serialize_hash_id(object_hash_id.as_u64(), output, stats)?;
+            serialize_hash_id(object_hash_id, output, repository, stats)?;
 
             output.write_all(&depth.to_le_bytes())?;
             output.write_all(&nchildren.to_le_bytes())?;
@@ -1684,35 +1686,36 @@ mod tests {
 
     #[test]
     fn test_hash_id() {
+        let mut repo = Persistent::try_new(None).expect("failed to create context");
         let mut output = Vec::with_capacity(10);
         let mut stats = Default::default();
 
-        let number = 10101;
+        let number = HashId::new(10101).unwrap();
 
-        serialize_hash_id(number, &mut output, &mut stats).unwrap();
+        serialize_hash_id(number, &mut output, &mut repo, &mut stats).unwrap();
         let (hash_id, size) = deserialize_hash_id(&output).unwrap();
         assert_eq!(output.len(), 4);
-        assert_eq!(hash_id.unwrap().as_u64(), number);
+        assert_eq!(hash_id.unwrap(), number);
         assert_eq!(size, 4);
 
         output.clear();
 
-        let number = (u32::MAX as u64) + 10;
+        let number = HashId::new((u32::MAX as u64) + 10).unwrap();
 
-        serialize_hash_id(number, &mut output, &mut stats).unwrap();
+        serialize_hash_id(number, &mut output, &mut repo, &mut stats).unwrap();
         let (hash_id, size) = deserialize_hash_id(&output).unwrap();
         assert_eq!(output.len(), 6);
-        assert_eq!(hash_id.unwrap().as_u64(), number);
+        assert_eq!(hash_id.unwrap(), number);
         assert_eq!(size, 6);
 
         output.clear();
 
-        let number = u32::MAX as u64;
+        let number = HashId::new(u32::MAX as u64).unwrap();
 
-        serialize_hash_id(number, &mut output, &mut stats).unwrap();
+        serialize_hash_id(number, &mut output, &mut repo, &mut stats).unwrap();
         let (hash_id, size) = deserialize_hash_id(&output).unwrap();
         assert_eq!(output.len(), 6);
-        assert_eq!(hash_id.unwrap().as_u64(), number);
+        assert_eq!(hash_id.unwrap(), number);
         assert_eq!(size, 6);
     }
 

--- a/tezos/context/src/working_tree/mod.rs
+++ b/tezos/context/src/working_tree/mod.rs
@@ -50,8 +50,7 @@ pub struct DirEntryInner {
     object_hash_id: B48,
     object_available: bool,
     object_id: B61,
-    file_offset_available: bool,
-    file_offset: B63,
+    file_offset: B64,
 }
 
 /// Wrapper over the children objects of a directory, containing
@@ -148,29 +147,28 @@ impl DirEntry {
     }
 
     pub fn set_offset(&self, offset: AbsoluteOffset) {
-        let inner = self
-            .inner
-            .get()
-            .with_file_offset(offset.as_u64())
-            .with_file_offset_available(true);
+        debug_assert_ne!(offset.as_u64(), 0);
+
+        let inner = self.inner.get().with_file_offset(offset.as_u64());
+
         self.inner.set(inner);
     }
 
     pub fn with_offset(self, offset: AbsoluteOffset) -> Self {
-        let inner = self
-            .inner
-            .get()
-            .with_file_offset(offset.as_u64())
-            .with_file_offset_available(true);
+        debug_assert_ne!(offset.as_u64(), 0);
+
+        let inner = self.inner.get().with_file_offset(offset.as_u64());
+
         self.inner.set(inner);
         self
     }
 
     pub fn get_offset(&self) -> Option<AbsoluteOffset> {
         let inner = self.inner.get();
+        let offset: u64 = inner.file_offset();
 
-        if inner.file_offset_available() {
-            Some(inner.file_offset().into())
+        if offset != 0 {
+            Some(offset.into())
         } else {
             None
         }

--- a/tezos/context/src/working_tree/mod.rs
+++ b/tezos/context/src/working_tree/mod.rs
@@ -218,7 +218,7 @@ impl DirEntry {
     /// Returns the `HashId` of this dir_entry, it will compute the hash if necessary.
     ///
     /// If this dir_entry is an inlined blob, this will return `None`.
-    fn object_hash_id_impl(
+    fn object_hash_id(
         &self,
         store: &mut ContextKeyValueStore,
         storage: &Storage,
@@ -250,41 +250,16 @@ impl DirEntry {
                         strings,
                     )?
                 };
+
+                if let Some(hash_id) = hash_id {
+                    let mut inner = self.inner.get();
+                    inner.set_object_hash_id(hash_id.as_u64());
+                    self.inner.set(inner);
+                };
+
                 Ok(hash_id)
             }
         }
-    }
-
-    /// Returns the `HashId` of this dir_entry, it will compute the hash if necessary.
-    ///
-    /// If this dir_entry is an inlined blob, this will return `None`.
-    pub fn object_hash_id(
-        &self,
-        store: &mut ContextKeyValueStore,
-        storage: &Storage,
-        strings: &StringInterner,
-    ) -> Result<Option<HashId>, HashingError> {
-        let hash_id = match self.object_hash_id_impl(store, storage, strings)? {
-            Some(hash_id) => hash_id,
-            None => return Ok(None),
-        };
-
-        let new_hash_id = store.make_hash_id_ready_for_commit(hash_id)?;
-
-        if new_hash_id.as_u64() & 0xFFFFFFFFFFFF != new_hash_id.as_u64() {
-            // more than 48 bits
-            let a = hash_id.as_u64();
-            let b = new_hash_id.as_u64();
-            println!(
-                "HASH_ID={:?}/{:x?}/{:064b} NEW_HASH_ID={:?}/{:x?}/{:064b}",
-                a, a, a, b, b, b
-            );
-        }
-
-        let mut inner = self.inner.get();
-        inner.set_object_hash_id(new_hash_id.as_u64());
-        self.inner.set(inner);
-        Ok(Some(new_hash_id))
     }
 
     pub fn get_inlined_blob<'a>(&self, storage: &'a Storage) -> Option<Blob<'a>> {

--- a/tezos/context/src/working_tree/storage.rs
+++ b/tezos/context/src/working_tree/storage.rs
@@ -23,7 +23,10 @@ use thiserror::Error;
 
 use crate::{
     chunks::ChunkedVec,
+    hash::HashingError,
     kv_store::{index_map::IndexMap, HashId},
+    working_tree::ObjectReference,
+    ContextKeyValueStore,
 };
 use crate::{hash::index as index_of_key, serialize::persistent::AbsoluteOffset};
 
@@ -398,7 +401,8 @@ pub struct PointerToInodeInner {
     hash_id: B48,
     is_commited: bool,
     inode_id: B31,
-    offset: B64,
+    is_offset_available: bool,
+    offset: B63,
 }
 
 #[derive(Clone, Debug)]
@@ -414,6 +418,7 @@ impl PointerToInode {
                     .with_hash_id(hash_id.map(|h| h.as_u64()).unwrap_or(0))
                     .with_is_commited(false)
                     .with_inode_id(inode_id.0)
+                    .with_is_offset_available(false)
                     .with_offset(0),
             ),
         }
@@ -430,7 +435,8 @@ impl PointerToInode {
                     .with_hash_id(hash_id.map(|h| h.as_u64()).unwrap_or(0))
                     .with_is_commited(true)
                     .with_inode_id(inode_id.0)
-                    .with_offset(offset.map(|o| o.as_u64()).unwrap_or(0)), //.with_offset(0),
+                    .with_is_offset_available(offset.is_some())
+                    .with_offset(offset.map(|o| o.as_u64()).unwrap_or(0)),
             ),
         }
     }
@@ -438,6 +444,7 @@ impl PointerToInode {
     pub fn with_offset(self, offset: u64) -> Self {
         let mut inner = self.inner.get();
         inner.set_offset(offset);
+        inner.set_is_offset_available(true);
         self.inner.set(inner);
 
         self
@@ -450,11 +457,34 @@ impl PointerToInode {
         InodeId(inode_id)
     }
 
-    pub fn hash_id(&self) -> Option<HashId> {
-        let inner = self.inner.get();
-        let hash_id = inner.hash_id();
+    pub fn hash_id(
+        &self,
+        storage: &Storage,
+        repository: &ContextKeyValueStore,
+    ) -> Result<Option<HashId>, HashingError> {
+        let mut inner = self.inner.get();
 
-        HashId::new(hash_id)
+        if let Some(hash_id) = HashId::new(inner.hash_id()) {
+            return Ok(Some(hash_id));
+        };
+
+        let offset = match self.get_offset() {
+            Some(offset) => offset,
+            None => return Ok(None),
+        };
+
+        let hash_id = match storage.offsets_to_hash_id.get(&offset) {
+            Some(hash_id) => *hash_id,
+            None => {
+                let object_ref = ObjectReference::new(None, Some(offset));
+                repository.get_hash_id(object_ref)?
+            }
+        };
+
+        inner.set_hash_id(hash_id.as_u64());
+        self.inner.set(inner);
+
+        Ok(Some(hash_id))
     }
 
     pub fn set_hash_id(&self, hash_id: Option<HashId>) {
@@ -467,13 +497,18 @@ impl PointerToInode {
     pub fn set_offset(&self, offset: AbsoluteOffset) {
         let mut inner = self.inner.get();
         inner.set_offset(offset.as_u64());
+        inner.set_is_offset_available(true);
 
         self.inner.set(inner);
     }
 
-    pub fn offset(&self) -> AbsoluteOffset {
+    pub fn get_offset(&self) -> Option<AbsoluteOffset> {
         let inner = self.inner.get();
-        inner.offset().into()
+        if inner.is_offset_available() {
+            Some(inner.offset().into())
+        } else {
+            None
+        }
     }
 
     pub fn is_commited(&self) -> bool {


### PR DESCRIPTION
- Fix HashId created before commit on inodes.
  They are recomputed with the correct index (index on disk) and by removing the working tree bit
- Do not recompute hashes from deserialized inodes