### PR TITLE
Lazily read and deserialize inodes

### DIFF
--- a/tezos/context/src/kv_store/hashes.rs
+++ b/tezos/context/src/kv_store/hashes.rs
@@ -46,8 +46,16 @@ impl HashesContainer {
 
     pub fn commited(&mut self) {
         self.first_index += self.commiting.len();
-        self.working_tree.clear();
-        self.commiting.clear();
+        if self.working_tree.capacity() > 1000 {
+            self.working_tree = IndexMap::with_chunk_capacity(1000);
+        } else {
+            self.working_tree.clear();
+        }
+        if self.commiting.capacity() > 1000 {
+            self.commiting = IndexMap::with_chunk_capacity(1000);
+        } else {
+            self.commiting.clear();
+        }
         self.is_commiting = false;
     }
 

--- a/tezos/context/src/kv_store/in_memory.rs
+++ b/tezos/context/src/kv_store/in_memory.rs
@@ -28,7 +28,7 @@ use crate::{
     persistent::{DBError, Flushable, KeyValueStoreBackend, Persistable},
     working_tree::{
         shape::{DirectoryShapeId, DirectoryShapes, ShapeStrings},
-        storage::{DirEntryId, Storage},
+        storage::{DirEntryId, InodeId, Storage},
         string_interner::{StringId, StringInterner},
         working_tree::{PostCommitData, WorkingTree},
         Object, ObjectReference,
@@ -271,6 +271,16 @@ impl KeyValueStoreBackend for InMemory {
     ) -> Result<Object, DBError> {
         let object_bytes = self.get_value(object_ref.hash_id())?.unwrap_or(&[]);
         in_memory::deserialize_object(object_bytes, storage, strings, self).map_err(Into::into)
+    }
+
+    fn get_inode(
+        &self,
+        object_ref: ObjectReference,
+        storage: &mut Storage,
+        strings: &mut StringInterner,
+    ) -> Result<InodeId, DBError> {
+        let object_bytes = self.get_value(object_ref.hash_id())?.unwrap_or(&[]);
+        in_memory::deserialize_inode(&object_bytes, storage, strings, self).map_err(Into::into)
     }
 
     fn get_object_bytes<'a>(

--- a/tezos/context/src/persistent/mod.rs
+++ b/tezos/context/src/persistent/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     serialize::DeserializationError,
     working_tree::{
         shape::{DirectoryShapeError, DirectoryShapeId, ShapeStrings},
-        storage::{DirEntryId, Storage},
+        storage::{DirEntryId, InodeId, Storage},
         string_interner::{StringId, StringInterner},
         working_tree::{MerkleError, WorkingTree},
         Object, ObjectReference,
@@ -90,6 +90,13 @@ pub trait KeyValueStoreBackend {
         storage: &mut Storage,
         strings: &mut StringInterner,
     ) -> Result<Object, DBError>;
+    /// Return the inode associated to this `object_ref`.
+    fn get_inode(
+        &self,
+        object_ref: ObjectReference,
+        storage: &mut Storage,
+        strings: &mut StringInterner,
+    ) -> Result<InodeId, DBError>;
     /// Return the object bytes associated to this `object_ref`.
     ///
     /// The object bytes will be inserted at the beginning of `buffer`.

--- a/tezos/context/src/serialize/mod.rs
+++ b/tezos/context/src/serialize/mod.rs
@@ -82,7 +82,7 @@ impl ObjectHeader {
         self.length()
     }
 
-    pub fn get_persistent(&self) -> bool {
+    pub fn get_is_persistent(&self) -> bool {
         self.is_persistent()
     }
 }
@@ -216,6 +216,8 @@ pub enum SerializationError {
         #[from]
         error: HashingError,
     },
+    #[error("InodeId is missing")]
+    MissingInodeId,
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
There are 2 cases where the inodes are still fully read from disk:
- `WorkingTree::list`
- `fold`