### PR TITLE
Add tools for tezedge persistent context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,6 +425,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 
 [[package]]
+name = "byte-unit"
+version = "4.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "956ffc5b0ec7d7a6949e3f21fd63ba5af4cffdc2ba1e0b7bf62b481458c4ae7f"
+dependencies = [
+ "utf8-width",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,9 +579,39 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim 0.8.0",
- "textwrap",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17bf219fcd37199b9a29e00ba65dfb8cd5b2688b7297ec14ff829c40ac50ca9"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.14.2",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b9752c030a14235a0bd5ef3ad60a1dcac8468c30921327fc8af36b20c790b9"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -614,6 +653,17 @@ name = "const-oid"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
+
+[[package]]
+name = "context-tool"
+version = "1.15.0"
+dependencies = [
+ "byte-unit",
+ "clap 3.0.0",
+ "crypto",
+ "termcolor",
+ "tezos_context",
+]
 
 [[package]]
 name = "convert_case"
@@ -671,7 +721,7 @@ checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
 dependencies = [
  "atty",
  "cast",
- "clap",
+ "clap 2.33.3",
  "criterion-plot",
  "csv",
  "itertools 0.10.1",
@@ -914,7 +964,7 @@ dependencies = [
 name = "db-checker"
 version = "1.15.0"
 dependencies = [
- "clap",
+ "clap 2.33.3",
  "edgekv",
 ]
 
@@ -1993,7 +2043,7 @@ name = "light-node"
 version = "1.15.0"
 dependencies = [
  "async_ipc",
- "clap",
+ "clap 2.33.3",
  "crypto",
  "fs_extra",
  "futures",
@@ -2458,6 +2508,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "os_type"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2723,7 +2782,7 @@ dependencies = [
 name = "protocol-runner"
 version = "1.15.0"
 dependencies = [
- "clap",
+ "clap 2.33.3",
  "crypto",
  "ctrlc",
  "jemallocator",
@@ -3144,7 +3203,7 @@ name = "sandbox"
 version = "1.15.0"
 dependencies = [
  "anyhow",
- "clap",
+ "clap 2.33.3",
  "colored",
  "hex",
  "itertools 0.10.1",
@@ -3646,7 +3705,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "bytes",
- "clap",
+ "clap 2.33.3",
  "commitlog",
  "criterion",
  "crypto",
@@ -3805,6 +3864,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "tezedge-actor-system"
@@ -4444,6 +4509,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-width"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cf7d77f457ef8dfa11e4cd5933c5ddb5dc52a94664071951219a97710f0a32b"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "tezos/context",
     "tezos/context-api",
     "tezos/context-ipc-client",
+    "tezos/context-tool",
     "tezos/protocol-ipc-client",
     "tezos/protocol-ipc-messages",
     "tezos/spsc",

--- a/tezos/context-tool/Cargo.toml
+++ b/tezos/context-tool/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "context-tool"
+version = "1.15.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+byte-unit = { version = "4.0", default-features = false }
+clap = { version = "3.0", features = ["derive"] }
+termcolor = "1.1.2"
+
+# local dependencies
+crypto = { path = "../../crypto" }
+tezos_context = { path = "../context" }

--- a/tezos/context-tool/README.md
+++ b/tezos/context-tool/README.md
@@ -1,0 +1,22 @@
+# Tezedge context tool
+
+Binary tool for the persistent context
+
+## Supported commands:
+
+- `build-integrity`: Build a valid `sizes.db` based on a context
+- `is-valid-context`: Check if the context is valid, based on the file `sizes.db`.  
+  It will computes the checksum of the files and verify their sizes.
+- `context-size`: Inspect the context of a commit and display how many bytes occupy its objects
+- `make-snapshot`: Create a snapshot based on a single commit.  
+  This will create a new context with all unused objects removed.
+- `dump-checksums`: Display `sizes.db` in an human readable format 
+
+
+## Example commands:
+
+- `cargo run --bin context-tool -- build-integrity -c PATH_TO_CONTEXT`
+- `cargo run --bin context-tool -- is-valid-context -c PATH_TO_CONTEXT`
+- `cargo run --bin context-tool -- context-size -c PATH_TO_CONTEXT)`
+- `cargo run --bin context-tool -- make-snapshot -c PATH_TO_CONTEXT`
+- `cargo run --bin context-tool -- dump-checksums -c PATH_TO_CONTEXT`

--- a/tezos/context-tool/src/log.rs
+++ b/tezos/context-tool/src/log.rs
@@ -1,0 +1,44 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use std::io::Write;
+use termcolor::{BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
+
+pub fn print(is_stdout: bool, prefix: &str, s: Option<String>) {
+    let bufwtr = if is_stdout {
+        BufferWriter::stdout(ColorChoice::Always)
+    } else {
+        BufferWriter::stderr(ColorChoice::Always)
+    };
+
+    let mut buffer = bufwtr.buffer();
+    buffer
+        .set_color(ColorSpec::new().set_fg(Some(Color::Green)))
+        .unwrap();
+    buffer.write_all(prefix.as_bytes()).unwrap();
+    buffer.set_color(ColorSpec::new().set_fg(None)).unwrap();
+
+    if let Some(s) = s.as_ref() {
+        buffer.write_all(s.as_bytes()).unwrap();
+    };
+
+    buffer.write_all("\n".as_bytes()).unwrap();
+
+    bufwtr.print(&buffer).unwrap();
+}
+
+/// Print logs on stdout with the prefix `[tezedge.tool]`
+macro_rules! log {
+    () => (print(true, "[tezedge.tool]", None));
+    ($($arg:tt)*) => ({
+        print(true, "[tezedge.tool] ", Some(format!("{}", format_args!($($arg)*))))
+    })
+}
+
+/// Print logs on stdout with the prefix `[tezedge.tool]`
+macro_rules! elog {
+    () => (print(false, "[tezedge.tool]", None));
+    ($($arg:tt)*) => ({
+        print(false, "[tezedge.tool] ", Some(format!("{}", format_args!($($arg)*))))
+    })
+}

--- a/tezos/context-tool/src/main.rs
+++ b/tezos/context-tool/src/main.rs
@@ -1,0 +1,394 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use std::{
+    cell::RefCell,
+    path::PathBuf,
+    rc::Rc,
+    sync::{Arc, RwLock},
+};
+
+use crate::log::print;
+use clap::{Parser, Subcommand};
+use crypto::hash::{ContextHash, HashTrait};
+use tezos_context::{
+    kv_store::persistent::{FileSizes, PersistentConfiguration},
+    persistent::file::{File, TAG_SIZES},
+    working_tree::{string_interner::StringId, Commit, ObjectReference},
+    ContextKeyValueStore, IndexApi, ObjectHash, Persistent, ShellContextApi, TezedgeContext,
+    TezedgeIndex,
+};
+
+#[macro_use]
+mod log;
+mod stats;
+
+/// Simple program to greet a person
+#[derive(Parser, Debug)]
+#[clap(about, version, author)]
+struct Args {
+    #[clap(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+enum Commands {
+    /// Build integrity database (file `sizes.db`)
+    BuildIntegrity {
+        /// Path of the persistent context
+        #[clap(short, long)]
+        context_path: String,
+        #[clap(short, long)]
+        /// Path to write the resulting `sizes.db`, default to current directory
+        output_dir: Option<String>,
+    },
+    /// Check if the context match its `sizes.db`
+    IsValidContext {
+        /// Path of the persistent context
+        #[clap(short, long)]
+        context_path: String,
+    },
+    /// Display `sizes.db` file
+    DumpChecksums {
+        /// Path of the persistent context
+        #[clap(short, long)]
+        context_path: String,
+    },
+    /// Display sizes of the different objects for the selected commit
+    ContextSize {
+        /// Path of the persistent context
+        #[clap(short, long)]
+        context_path: String,
+        /// Context hash to inspect, default to last commit
+        #[clap(short, long)]
+        hash: Option<String>,
+    },
+    /// Create a snapshot from a commit.
+    /// This will create a new context with all unused objects removed
+    MakeSnapshot {
+        /// Path of the persistent context
+        #[clap(short, long)]
+        context_path: String,
+        /// Context hash to make the snapshot from, default to last commit
+        #[clap(short, long)]
+        hash: Option<String>,
+        /// Path of the result, default to `/tmp/tezedge_snapshot_XXX`
+        #[clap(short, long)]
+        output: Option<String>,
+    },
+}
+
+fn reload_context_readonly(context_path: String) -> Persistent {
+    log!(" Validating context {:?}...", context_path);
+
+    let now = std::time::Instant::now();
+
+    let sizes_file = File::<{ TAG_SIZES }>::try_new(&context_path, true).unwrap();
+    let sizes = FileSizes::make_list_from_file(&sizes_file).unwrap_or_default();
+    assert!(!sizes.is_empty(), "sizes.db is invalid: {:?}", sizes);
+
+    let mut repo = Persistent::try_new(PersistentConfiguration {
+        db_path: Some(context_path),
+        startup_check: true,
+        read_mode: true,
+    })
+    .unwrap();
+    repo.reload_database().unwrap();
+
+    log!(" Validating context ok {:?}", now.elapsed());
+
+    repo
+}
+
+fn create_snapshot_path(base_path: Option<String>) -> String {
+    match base_path {
+        Some(path_str) => {
+            let path = PathBuf::from(&path_str);
+            if path.exists() {
+                elog!("{:?} already exist", path);
+            }
+            path_str
+        }
+        None => {
+            for index in 0.. {
+                let path_str = format!("/tmp/tezedge_snapshot_{}", index);
+                let path = PathBuf::from(&path_str);
+                if path.exists() {
+                    continue;
+                }
+                return path_str;
+            }
+            unreachable!()
+        }
+    }
+}
+
+fn main() {
+    let args = Args::parse();
+
+    match args.command {
+        Commands::DumpChecksums { context_path } => {
+            let sizes_file = File::<{ TAG_SIZES }>::try_new(&context_path, true).unwrap();
+            let sizes = FileSizes::make_list_from_file(&sizes_file).unwrap_or_default();
+            log!("checksums={:#?}", sizes);
+        }
+        Commands::BuildIntegrity {
+            context_path,
+            output_dir,
+        } => {
+            let output_dir = output_dir.unwrap_or_else(|| "".to_string());
+
+            // Make sure `sizes.db` doesn't already exist
+            match File::<{ TAG_SIZES }>::create_new_file(&output_dir) {
+                Ok(_) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                    panic!(
+                        "The resulting file `sizes.db` already exist at `{:?}`",
+                        output_dir
+                    );
+                }
+                Err(e) => panic!("{:?}", e),
+            };
+
+            let mut ctx = Persistent::try_new(PersistentConfiguration {
+                db_path: Some(context_path),
+                startup_check: true,
+                read_mode: true,
+            })
+            .unwrap();
+            let mut output_file = File::<{ TAG_SIZES }>::try_new(&output_dir, false).unwrap();
+
+            ctx.compute_integrity(&mut output_file).unwrap();
+
+            let sizes = ctx.get_file_sizes();
+            log!("Result={:#?}", sizes);
+        }
+        Commands::IsValidContext { context_path } => {
+            reload_context_readonly(context_path);
+        }
+        Commands::ContextSize {
+            context_path,
+            hash: context_hash,
+        } => {
+            let ctx = reload_context_readonly(context_path);
+
+            let context_hash = if let Some(context_hash) = context_hash.as_ref() {
+                ContextHash::from_b58check(context_hash).unwrap()
+            } else {
+                ctx.get_last_context_hash().unwrap()
+            };
+
+            log!("Computing size for {:?}", context_hash.to_base58_check());
+
+            let index = TezedgeIndex::new(Arc::new(RwLock::new(ctx)), None);
+
+            let now = std::time::Instant::now();
+
+            let context = index.checkout(&context_hash).unwrap().unwrap();
+            let stats = context.tree.traverse_working_tree(true).unwrap();
+
+            let repo = context.index.repository.read().unwrap();
+            let repo_stats = repo.get_read_statistics().unwrap().unwrap();
+
+            let mut stats = stats.unwrap();
+            stats.objects_total_bytes = repo_stats.objects_total_bytes;
+            stats.lowest_offset = repo_stats.lowest_offset;
+            stats.nshapes = repo_stats.unique_shapes.len();
+            stats.shapes_total_bytes = repo_stats.shapes_length * std::mem::size_of::<StringId>();
+
+            log!(
+                "Context size: {:#?}",
+                stats::DebugWorkingTreeStatistics(stats)
+            );
+            log!("Total Time {:?}", now.elapsed());
+        }
+        Commands::MakeSnapshot {
+            context_path,
+            hash: context_hash,
+            output,
+        } => {
+            let start = std::time::Instant::now();
+
+            let snapshot_path = create_snapshot_path(output);
+
+            log!("Start creating snapshot at {:?}", snapshot_path,);
+
+            let ctx = reload_context_readonly(context_path);
+
+            let checkout_context_hash: ContextHash =
+                if let Some(context_hash) = context_hash.as_ref() {
+                    ContextHash::from_b58check(context_hash).unwrap()
+                } else {
+                    ctx.get_last_context_hash().unwrap()
+                };
+
+            log!("Using {:?}", checkout_context_hash);
+
+            let (mut tree, mut storage, string_interner, parent_hash, commit) = {
+                // This block reads the whole tree of the commit, to extract `Storage`, that's
+                // where all the objects (directories and blobs) are stored
+
+                let now = std::time::Instant::now();
+                log!("Loading context in memory...");
+
+                let read_repo: Arc<RwLock<ContextKeyValueStore>> = Arc::new(RwLock::new(ctx));
+                let index = TezedgeIndex::new(Arc::clone(&read_repo), None);
+                let context = index.checkout(&checkout_context_hash).unwrap().unwrap();
+
+                // Take the commit from repository
+                let commit: Commit = index
+                    .fetch_commit_from_context_hash(&checkout_context_hash)
+                    .unwrap()
+                    .unwrap();
+
+                // If the commit has a parent, fetch it
+                // It is necessary for the snapshot to have it in its db
+                let parent_hash: Option<ObjectHash> = match commit.parent_commit_ref {
+                    Some(parent) => {
+                        let repo = read_repo.read().unwrap();
+                        Some(repo.get_hash(parent).unwrap().into_owned())
+                    }
+                    None => None,
+                };
+
+                // Traverse the tree, to store it in the `Storage`
+                context.tree.traverse_working_tree(false).unwrap();
+
+                log!("Loading context in memory ok {:?}", now.elapsed());
+
+                // Extract the `Storage`, `StringInterner` and `WorkingTree` from
+                // the index
+                (
+                    Rc::try_unwrap(context.tree).ok().unwrap(),
+                    context.index.storage.take(),
+                    context.index.string_interner.take().unwrap(),
+                    parent_hash,
+                    commit,
+                )
+            };
+
+            {
+                // This block creates the new database
+
+                let now = std::time::Instant::now();
+                log!("Creating snapshot from context in memory...");
+
+                // Remove all `HashId` and `AbsoluteOffset` from the `Storage`
+                // They will be recomputed
+                storage.forget_references();
+
+                // Create a new `StringInterner` that contains only the strings used
+                // for this commit
+                let string_interner = storage.strip_string_interner(string_interner);
+
+                let storage = Rc::new(RefCell::new(storage));
+                let string_interner = Rc::new(RefCell::new(Some(string_interner)));
+
+                // Create the new writable repository at `snapshot_path`
+                let mut write_repo = Persistent::try_new(PersistentConfiguration {
+                    db_path: Some(snapshot_path.clone()),
+                    startup_check: false,
+                    read_mode: false,
+                })
+                .unwrap();
+                write_repo.enable_hash_dedup();
+
+                // Put the parent hash in the new repository
+                let parent_ref: Option<ObjectReference> =
+                    parent_hash.map(|parent_hash| write_repo.put_hash(parent_hash).unwrap().into());
+
+                let write_repo: Arc<RwLock<ContextKeyValueStore>> =
+                    Arc::new(RwLock::new(write_repo));
+
+                let index =
+                    TezedgeIndex::with_storage(write_repo.clone(), storage, string_interner);
+
+                // Make the `WorkingTree` use our new index
+                tree.index = index.clone();
+
+                {
+                    let now = std::time::Instant::now();
+                    log!(" Computing context hash...");
+
+                    // Compute the hashes of the whole tree and remove the duplicate ones
+                    let mut repo = write_repo.write().unwrap();
+                    tree.get_root_directory_hash(&mut *repo).unwrap();
+                    index.storage.borrow_mut().deduplicate_hashes(&*repo);
+
+                    log!(" Computing context hash ok {:?}", now.elapsed());
+                }
+
+                let context = TezedgeContext::new(index, parent_ref, Some(Rc::new(tree)));
+
+                let commit_context_hash = context
+                    .commit(
+                        commit.author.clone(),
+                        commit.message.clone(),
+                        commit.time as i64,
+                    )
+                    .unwrap();
+
+                // Make sure our new context hash is the same
+                assert_eq!(checkout_context_hash, commit_context_hash);
+
+                log!(
+                    "Creating snapshot from context in memory ok {:?}",
+                    now.elapsed()
+                );
+            }
+
+            {
+                // Fully read the new snapshot and re-compute all the hashes, to
+                // be 100% sure that we have a valid snapshot
+
+                let start = std::time::Instant::now();
+                log!("Loading snapshot & re-compute hashes...");
+
+                let read_ctx = reload_context_readonly(snapshot_path.clone());
+                let read_repo: Arc<RwLock<ContextKeyValueStore>> = Arc::new(RwLock::new(read_ctx));
+
+                let index = TezedgeIndex::new(Arc::clone(&read_repo), None);
+                let mut context = index.checkout(&checkout_context_hash).unwrap().unwrap();
+
+                let commit: Commit = index
+                    .fetch_commit_from_context_hash(&checkout_context_hash)
+                    .unwrap()
+                    .unwrap();
+                context.parent_commit_ref = commit.parent_commit_ref;
+
+                let now = std::time::Instant::now();
+                log!(" Loading in memory...");
+
+                // Fetch all objects into `Storage`
+                context.tree.traverse_working_tree(false).unwrap();
+
+                log!(" Loading in memory ok {:?}", now.elapsed());
+
+                // Remove all `HashId` to re-compute them
+                context.index.storage.borrow_mut().forget_references();
+
+                let now = std::time::Instant::now();
+                log!(" Recomputing hashes...");
+
+                let context_hash = context
+                    .hash(commit.author, commit.message, commit.time as i64)
+                    .unwrap();
+
+                log!(" Recomputing hashes ok {:?}", now.elapsed());
+
+                assert_eq!(checkout_context_hash, context_hash);
+
+                log!(
+                    "Loading snapshot & re-compute hashes ok {:?}",
+                    start.elapsed()
+                );
+            }
+
+            log!(
+                "Snapshot {:?} created in {:?}",
+                snapshot_path,
+                start.elapsed(),
+            );
+        }
+    }
+}

--- a/tezos/context-tool/src/stats.rs
+++ b/tezos/context-tool/src/stats.rs
@@ -1,0 +1,153 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use byte_unit::Byte;
+
+use tezos_context::{working_tree::working_tree::WorkingTreeStatistics, ObjectHash};
+
+pub struct DebugWorkingTreeStatistics(pub WorkingTreeStatistics);
+
+enum Numbers {
+    TotalInlined {
+        total: usize,
+        inlined: usize,
+        not_inlined: usize,
+    },
+    TotalUnique {
+        total: usize,
+        unique: usize,
+    },
+    Unique {
+        unique: usize,
+    },
+}
+
+impl std::fmt::Debug for Numbers {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Numbers::TotalInlined {
+                total,
+                inlined,
+                not_inlined,
+            } => f.write_fmt(format_args!(
+                "{{ total: {:>8}, inlined: {:>8}, not inlined: {:>8} }}",
+                total, inlined, not_inlined,
+            )),
+            Numbers::TotalUnique { total, unique } => {
+                let total_bytes = total * std::mem::size_of::<ObjectHash>();
+                let total_str = Byte::from_bytes(total_bytes as u64)
+                    .get_appropriate_unit(false)
+                    .to_string();
+
+                let unique_bytes = unique * std::mem::size_of::<ObjectHash>();
+                let unique_str = Byte::from_bytes(unique_bytes as u64)
+                    .get_appropriate_unit(false)
+                    .to_string();
+
+                let duplicated = total - unique;
+                let duplicated_bytes = duplicated * std::mem::size_of::<ObjectHash>();
+                let duplicated_str = Byte::from_bytes(duplicated_bytes as u64)
+                    .get_appropriate_unit(false)
+                    .to_string();
+
+                f.write_fmt(format_args!(
+                    "{{ total: {:>8} ({}), unique: {:>8} ({}), duplicate: {:>8} ({}) }}",
+                    total, total_str, unique, unique_str, duplicated, duplicated_str,
+                ))
+            }
+            Numbers::Unique { unique } => f.write_fmt(format_args!("{{ unique: {:>8} }}", unique,)),
+        }
+    }
+}
+
+struct BytesDisplay {
+    bytes: usize,
+}
+
+impl std::fmt::Debug for BytesDisplay {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let bytes_str = Byte::from_bytes(self.bytes as u64)
+            .get_appropriate_unit(false)
+            .to_string();
+
+        f.write_fmt(format_args!("{:>8} ({:>8})", self.bytes, bytes_str,))
+    }
+}
+
+impl std::fmt::Debug for DebugWorkingTreeStatistics {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut blobs_stats = Vec::with_capacity(self.0.blobs_by_length.len());
+        for stats in self.0.blobs_by_length.values() {
+            blobs_stats.push(stats);
+        }
+        blobs_stats.sort_by_key(|stats| stats.size);
+
+        let mut dir_stats = Vec::with_capacity(self.0.directories_by_length.len());
+        for stats in self.0.directories_by_length.values() {
+            dir_stats.push(stats);
+        }
+        dir_stats.sort_by_key(|stats| stats.size);
+
+        let total_bytes = self.0.nhashes * std::mem::size_of::<ObjectHash>()
+            + self.0.strings_total_bytes
+            + self.0.objects_total_bytes
+            + self.0.shapes_total_bytes;
+
+        f.debug_struct("WorkingTreeStatistics")
+            .field("blobs_by_length", &blobs_stats)
+            .field("directories_by_length", &dir_stats)
+            .field("max_depth", &self.0.max_depth)
+            .field(
+                "oldest_reference (absolute offset in data.db file) ",
+                &self.0.lowest_offset,
+            )
+            .field(
+                "number_of_objects (directories + blobs)",
+                &Numbers::TotalInlined {
+                    total: self.0.nobjects,
+                    inlined: self.0.nobjects_inlined,
+                    not_inlined: self.0.nobjects - self.0.nobjects_inlined,
+                },
+            )
+            .field(
+                "number_of_hashes ",
+                &Numbers::TotalUnique {
+                    total: self.0.nhashes,
+                    unique: self.0.unique_hash.len(),
+                },
+            )
+            .field(
+                "number_of_shapes ",
+                &Numbers::Unique {
+                    unique: self.0.nshapes,
+                },
+            )
+            .field("number_of_directories ", &self.0.ndirectories)
+            .field(
+                "hashes_total_bytes (hashes.db file)",
+                &BytesDisplay {
+                    bytes: self.0.nhashes * std::mem::size_of::<ObjectHash>(),
+                },
+            )
+            .field(
+                "strings_total_bytes (small & big strings)",
+                &BytesDisplay {
+                    bytes: self.0.strings_total_bytes,
+                },
+            )
+            .field(
+                "objects_total_bytes (data.db file)",
+                &BytesDisplay {
+                    bytes: self.0.objects_total_bytes,
+                },
+            )
+            .field(
+                "shapes_total_bytes (shape_directories.db file)",
+                &BytesDisplay {
+                    bytes: self.0.shapes_total_bytes,
+                },
+            )
+            .field("total_bytes", &BytesDisplay { bytes: total_bytes })
+            .finish()
+    }
+}

--- a/tezos/context/src/chunks/string.rs
+++ b/tezos/context/src/chunks/string.rs
@@ -106,15 +106,16 @@ impl ChunkedString {
     fn get_next_chunk(&mut self) -> &mut String {
         let chunk_capacity = self.chunk_capacity;
 
-        if self
+        let must_alloc_new_chunk = self
             .list_of_chunks
             .last()
             .map(|chunk| {
                 debug_assert!(chunk.len() <= chunk_capacity);
                 chunk.len() == chunk_capacity
             })
-            .unwrap_or(true)
-        {
+            .unwrap_or(true);
+
+        if must_alloc_new_chunk {
             self.list_of_chunks
                 .push(String::with_capacity(self.chunk_capacity));
         }

--- a/tezos/context/src/chunks/vec.rs
+++ b/tezos/context/src/chunks/vec.rs
@@ -200,15 +200,16 @@ impl<T> ChunkedVec<T> {
     fn get_next_chunk(&mut self) -> &mut Chunk<T> {
         let chunk_capacity = self.chunk_capacity;
 
-        if self
+        let must_alloc_new_chunk = self
             .list_of_chunks
             .last()
             .map(|chunk| {
                 debug_assert!(chunk.len() <= chunk_capacity);
                 chunk.len() == chunk_capacity
             })
-            .unwrap_or(true)
-        {
+            .unwrap_or(true);
+
+        if must_alloc_new_chunk {
             self.list_of_chunks
                 .push(Vec::with_capacity(self.chunk_capacity));
         }
@@ -287,6 +288,10 @@ impl<T> ChunkedVec<T> {
 
     pub fn len(&self) -> usize {
         self.nelems
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
     pub fn deallocate(&mut self) {

--- a/tezos/context/src/initializer.rs
+++ b/tezos/context/src/initializer.rs
@@ -12,7 +12,7 @@ use tezos_context_api::TezosContextTezEdgeStorageConfiguration;
 use thiserror::Error;
 
 use crate::kv_store::in_memory::InMemory;
-use crate::kv_store::persistent::Persistent;
+use crate::kv_store::persistent::{Persistent, PersistentConfiguration};
 use crate::kv_store::readonly_ipc::ReadonlyIpcBackend;
 use crate::persistent::file::OpenFileError;
 use crate::persistent::lock::LockDatabaseError;
@@ -107,9 +107,13 @@ pub fn initialize_tezedge_index(
             )?)),
         },
         ContextKvStoreConfiguration::InMem => Arc::new(RwLock::new(InMemory::try_new()?)),
-        ContextKvStoreConfiguration::OnDisk(ref options) => Arc::new(RwLock::new(
-            Persistent::try_new(Some(options.base_path.as_str()), options.startup_check)?,
-        )),
+        ContextKvStoreConfiguration::OnDisk(ref options) => {
+            Arc::new(RwLock::new(Persistent::try_new(PersistentConfiguration {
+                db_path: Some(options.base_path.clone()),
+                startup_check: options.startup_check,
+                read_mode: false,
+            })?))
+        }
     };
 
     // We reload the database in another thread, to avoid blocking on

--- a/tezos/context/src/kv_store/hashes.rs
+++ b/tezos/context/src/kv_store/hashes.rs
@@ -1,7 +1,10 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::convert::{TryFrom, TryInto};
+use std::{
+    collections::HashMap,
+    convert::{TryFrom, TryInto},
+};
 
 use crate::{
     kv_store::{HashId, VacantObjectHash},
@@ -24,6 +27,9 @@ pub struct HashesContainer {
     is_commiting: bool,
     /// First `HashId` in `Self::working_tree` and `Self::commiting`
     first_index: usize,
+    /// Keep an index on duplicate hashes
+    /// old HashId to new HashId (before and during commit)
+    pub dedup_hashes: Option<HashMap<HashId, HashId>>,
 }
 
 impl HashesContainer {
@@ -33,6 +39,7 @@ impl HashesContainer {
             commiting: IndexMap::with_chunk_capacity(1000),
             is_commiting: false,
             first_index,
+            dedup_hashes: None,
         }
     }
 
@@ -81,6 +88,17 @@ impl HashesContainer {
             return Ok(hash_id);
         }
 
+        if let Some(hash_id) = self
+            .dedup_hashes
+            .as_ref()
+            .and_then(|dedup| dedup.get(&hash_id))
+            .cloned()
+        {
+            return Ok(hash_id);
+        }
+
+        let old_hash_id = hash_id;
+
         // We are commiting, move the `ObjectHash` from `Self::working_tree`
         // into `Self::commiting` and return the new `HashId`.
 
@@ -106,6 +124,10 @@ impl HashesContainer {
 
         // Retrieve the `HashId`
         let hash_id = HashId::try_from(self.first_index + commiting_index)?;
+
+        if let Some(dedup) = self.dedup_hashes.as_mut() {
+            dedup.insert(old_hash_id, hash_id);
+        };
 
         // Return the new `HashId`
         Ok(hash_id)

--- a/tezos/context/src/kv_store/in_memory.rs
+++ b/tezos/context/src/kv_store/in_memory.rs
@@ -25,7 +25,7 @@ use crate::{
         GarbageCollectionError, GarbageCollector,
     },
     hash::ObjectHash,
-    persistent::{DBError, Flushable, KeyValueStoreBackend, Persistable},
+    persistent::{DBError, Flushable, KeyValueStoreBackend, Persistable, ReadStatistics},
     working_tree::{
         shape::{DirectoryShapeId, DirectoryShapes, ShapeStrings},
         storage::{DirEntryId, InodeId, Storage},
@@ -284,7 +284,7 @@ impl KeyValueStoreBackend for InMemory {
         strings: &mut StringInterner,
     ) -> Result<InodeId, DBError> {
         let object_bytes = self.get_value(object_ref.hash_id())?.unwrap_or(&[]);
-        in_memory::deserialize_inode(&object_bytes, storage, strings, self).map_err(Into::into)
+        in_memory::deserialize_inode(object_bytes, storage, strings, self).map_err(Into::into)
     }
 
     fn get_object_bytes<'a>(
@@ -324,6 +324,7 @@ impl KeyValueStoreBackend for InMemory {
                 Some(in_memory::serialize_object),
                 None,
                 true,
+                false,
             )
             .map_err(Box::new)?;
 
@@ -346,6 +347,10 @@ impl KeyValueStoreBackend for InMemory {
     fn make_hash_id_ready_for_commit(&mut self, hash_id: HashId) -> Result<HashId, DBError> {
         // Unused HashId are garbage collected
         Ok(hash_id)
+    }
+
+    fn get_read_statistics(&self) -> Result<Option<ReadStatistics>, DBError> {
+        Ok(None)
     }
 
     #[cfg(test)]

--- a/tezos/context/src/kv_store/mod.rs
+++ b/tezos/context/src/kv_store/mod.rs
@@ -97,7 +97,7 @@ impl<'a> VacantObjectHash<'a> {
         }
     }
 
-    pub(crate) fn write_with<F>(self, fun: F) -> HashId
+    pub fn write_with<F>(self, fun: F) -> HashId
     where
         F: FnOnce(&mut ObjectHash),
     {

--- a/tezos/context/src/kv_store/readonly_ipc.rs
+++ b/tezos/context/src/kv_store/readonly_ipc.rs
@@ -17,7 +17,7 @@ use slog::{error, info};
 use tezos_timing::{RepositoryMemoryUsage, SerializeStats};
 use thiserror::Error;
 
-use crate::persistent::{get_commit_hash, DBError, Flushable, Persistable};
+use crate::persistent::{get_commit_hash, DBError, Flushable, Persistable, ReadStatistics};
 
 use crate::serialize::{in_memory, persistent, ObjectHeader};
 use crate::working_tree::shape::{DirectoryShapeId, ShapeStrings};
@@ -235,6 +235,7 @@ impl KeyValueStoreBackend for ReadonlyIpcBackend {
                 None,
                 None,
                 false,
+                false,
             )
             .map_err(Box::new)?;
 
@@ -262,6 +263,10 @@ impl KeyValueStoreBackend for ReadonlyIpcBackend {
     fn make_hash_id_ready_for_commit(&mut self, hash_id: HashId) -> Result<HashId, DBError> {
         // HashId in the read-only backend are never commited
         Ok(hash_id)
+    }
+
+    fn get_read_statistics(&self) -> Result<Option<ReadStatistics>, DBError> {
+        Ok(None)
     }
 
     #[cfg(test)]

--- a/tezos/context/src/lib.rs
+++ b/tezos/context/src/lib.rs
@@ -149,7 +149,9 @@ use std::num::TryFromIntError;
 use std::sync::PoisonError;
 
 use gc::GarbageCollectionError;
+pub use kv_store::persistent::Persistent;
 use kv_store::HashId;
+
 use persistent::{DBError, KeyValueStoreBackend};
 use tezos_context_api::{ContextKey, ContextKeyOwned, ContextValue, StringTreeObject};
 use thiserror::Error;
@@ -165,7 +167,7 @@ use crate::gc::GarbageCollector;
 use crate::working_tree::working_tree::MerkleError;
 use crypto::hash::{ContextHash, FromBytesError};
 
-mod persistent;
+pub mod persistent;
 
 use crate::persistent::{Flushable, Persistable};
 

--- a/tezos/context/src/serialize/in_memory.rs
+++ b/tezos/context/src/serialize/in_memory.rs
@@ -971,7 +971,7 @@ mod tests {
 
         let mut pointers: [Option<PointerToInode>; 32] = Default::default();
 
-        for index in 0..pointers.len() {
+        for (index, pointer) in pointers.iter_mut().enumerate() {
             let inode_value = Inode::Directory(DirectoryId::empty());
             let inode_value_id = storage.add_inode(inode_value).unwrap();
 
@@ -980,7 +980,7 @@ mod tests {
             repo.write_batch(vec![(hash_id, Arc::new(ObjectHeader::new().into_bytes()))])
                 .unwrap();
 
-            pointers[index] = Some(PointerToInode::new(Some(hash_id), inode_value_id));
+            *pointer = Some(PointerToInode::new(Some(hash_id), inode_value_id));
         }
 
         let inode = Inode::Pointers {

--- a/tezos/context/src/working_tree/storage.rs
+++ b/tezos/context/src/working_tree/storage.rs
@@ -26,7 +26,7 @@ use crate::{
     hash::HashingError,
     kv_store::{index_map::IndexMap, HashId},
     working_tree::ObjectReference,
-    ContextKeyValueStore,
+    ContextKeyValueStore, ObjectHash,
 };
 use crate::{hash::index as index_of_key, serialize::persistent::AbsoluteOffset};
 
@@ -535,6 +535,11 @@ impl PointerToInode {
         } else {
             None
         }
+    }
+
+    pub fn hash_id_opt(&self) -> Option<HashId> {
+        let inner = self.inner.get();
+        HashId::new(inner.hash_id())
     }
 
     pub fn is_commited(&self) -> bool {
@@ -1065,6 +1070,7 @@ impl Storage {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn insert_inode(
         &mut self,
         depth: u32,
@@ -1669,6 +1675,115 @@ impl Storage {
     }
 }
 
+/// Implementation used for `context-tool`
+mod tool {
+    use super::*;
+
+    impl PointerToInode {
+        /// Remove all `HashId` and `AbsoluteOffset` in `Self`
+        /// This is used in order to recompute them
+        ///
+        /// Method used for `context-tool` only.
+        pub fn forget_reference(&self) {
+            let mut inner = self.inner.get();
+            inner.set_hash_id(0);
+            inner.set_is_commited(false);
+            inner.set_offset(0);
+            self.inner.set(inner);
+        }
+    }
+
+    impl Storage {
+        /// Return a new `StringInterner` containing only the strings used by `Self`
+        /// All the strings in `Self` will now refers to strings inside the new `StringInterner`
+        ///
+        /// Method used for `context-tool` only.
+        pub fn strip_string_interner(&mut self, old_strings: StringInterner) -> StringInterner {
+            let mut new_string_interner = StringInterner::default();
+
+            let new_directories: Vec<_> = self
+                .directories
+                .iter()
+                .map(|(string_id, dir_entry_id)| {
+                    let s = old_strings.get_str(*string_id).unwrap();
+                    let new_id = new_string_interner.make_string_id(s.as_ref());
+                    (new_id, *dir_entry_id)
+                })
+                .collect();
+
+            self.directories = ChunkedVec::with_chunk_capacity(DEFAULT_DIRECTORIES_CAPACITY);
+            self.directories.extend_from_slice(&new_directories);
+
+            new_string_interner
+        }
+
+        /// Scan the directories (including inodes) and remove duplicates
+        /// Duplicates will now have the same `HashId`
+        ///
+        /// Method used for `context-tool` only.
+        pub fn deduplicate_hashes(&mut self, repository: &ContextKeyValueStore) {
+            let mut unique: HashMap<ObjectHash, HashId> = HashMap::default();
+
+            for (_, dir_entry_id) in self.directories.iter() {
+                let dir_entry = self.get_dir_entry(*dir_entry_id).unwrap();
+
+                let hash_id: HashId = match dir_entry.hash_id() {
+                    Some(hash_id) => hash_id,
+                    None => continue,
+                };
+
+                let hash: ObjectHash = repository.get_hash(hash_id.into()).unwrap().into_owned();
+                let new_hash_id: HashId = *unique.entry(hash).or_insert(hash_id);
+
+                dir_entry.set_hash_id(new_hash_id);
+            }
+
+            for inode in self.inodes.iter_values() {
+                let pointers = match inode {
+                    Inode::Pointers { pointers, .. } => pointers,
+                    Inode::Directory(_) => continue,
+                };
+
+                for ptr in pointers.iter().filter_map(|p| p.as_ref()) {
+                    let hash_id: HashId = match ptr.hash_id_opt() {
+                        Some(hash_id) => hash_id,
+                        None => continue,
+                    };
+
+                    let hash: ObjectHash =
+                        repository.get_hash(hash_id.into()).unwrap().into_owned();
+                    let new_hash_id: HashId = *unique.entry(hash).or_insert(hash_id);
+
+                    ptr.set_hash_id(Some(new_hash_id));
+                }
+            }
+        }
+
+        /// Remove all `HashId` and `AbsoluteOffset` in `Self`
+        /// This is used in order to recompute them
+        ///
+        /// Method used for `context-tool` only.
+        pub fn forget_references(&mut self) {
+            self.offsets_to_hash_id = Default::default();
+
+            for (_, dir_entry_id) in self.directories.iter() {
+                let dir_entry = self.get_dir_entry(*dir_entry_id).unwrap();
+                dir_entry.set_offset(None);
+                dir_entry.set_hash_id(None);
+                dir_entry.set_commited(false);
+            }
+
+            for inode in self.inodes.iter_values() {
+                if let Inode::Pointers { pointers, .. } = inode {
+                    for ptr in pointers.iter().filter_map(|p| p.as_ref()) {
+                        ptr.forget_reference();
+                    }
+                };
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{
@@ -1690,8 +1805,8 @@ mod tests {
         let blob2_id = storage.add_blob_by_ref(&[2]).unwrap();
         let object2 = Object::Blob(blob2_id);
 
-        let dir_entry1 = DirEntry::new(Blob, object.clone());
-        let dir_entry2 = DirEntry::new(Blob, object2.clone());
+        let dir_entry1 = DirEntry::new(Blob, object);
+        let dir_entry2 = DirEntry::new(Blob, object2);
 
         let dir_id = DirectoryId::empty();
         let dir_id = storage
@@ -1708,8 +1823,8 @@ mod tests {
             storage.get_owned_dir(dir_id, &mut strings, &repo).unwrap(),
             &[
                 ("0".to_string(), dir_entry1.clone()),
-                ("a".to_string(), dir_entry1.clone()),
-                ("b".to_string(), dir_entry2.clone()),
+                ("a".to_string(), dir_entry1),
+                ("b".to_string(), dir_entry2),
             ]
         );
     }

--- a/tezos/context/src/working_tree/string_interner.rs
+++ b/tezos/context/src/working_tree/string_interner.rs
@@ -4,6 +4,7 @@
 //! Implementation of string interning used to implement hash-consing for context path fragments.
 //! This avoids un-necessary duplication of strings, saving memory.
 
+use std::io::Read;
 use std::{borrow::Cow, collections::hash_map::DefaultHasher, convert::TryInto, hash::Hasher};
 
 use static_assertions::const_assert;
@@ -189,13 +190,15 @@ impl BigStrings {
         // [u32 start le bytes | u32 end le bytes]
         // but using `result.push_str` with the string seems to be enough to also update the offsets?
 
+        let mut big_strings_file = big_strings_file.buffered()?;
+
         while offset < end {
-            big_strings_file.read_exact_at(&mut length_bytes, offset.into())?;
+            big_strings_file.read_exact(&mut length_bytes)?;
 
             let length = u32::from_le_bytes(length_bytes) as usize;
             offset += length_bytes.len() as u64;
 
-            big_strings_file.read_exact_at(&mut string_bytes[0..length], offset.into())?;
+            big_strings_file.read_exact(&mut string_bytes[0..length])?;
             offset += length as u64;
 
             let s = std::str::from_utf8(&string_bytes[..length])?;
@@ -279,6 +282,14 @@ impl StringInterner {
         debug_assert_eq!(self.all_strings, other.all_strings);
 
         self.big_strings.extend_from(&other.big_strings);
+    }
+
+    pub fn len(&self) -> usize {
+        self.all_strings.len() + self.big_strings.strings.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
     pub fn make_string_id(&mut self, s: &str) -> StringId {
@@ -391,12 +402,14 @@ impl StringInterner {
         let mut length_byte = [0u8; 1];
         let mut string_bytes = [0u8; 256]; //  30 should be enough here
 
+        let mut strings_file = strings_file.buffered()?;
+
         while offset < end {
-            strings_file.read_exact_at(&mut length_byte, offset.into())?;
+            strings_file.read_exact(&mut length_byte)?;
             offset += length_byte.len() as u64;
 
             let length = u8::from_le_bytes(length_byte) as usize;
-            strings_file.read_exact_at(&mut string_bytes[..length], offset.into())?;
+            strings_file.read_exact(&mut string_bytes[..length])?;
 
             offset += length as u64;
 


### PR DESCRIPTION
Examples:
- `cargo run --bin context-tool -- build-integrity -c PATH_TO_CONTEXT` (create a valid `sizes.db` file)
- `cargo run --bin context-tool -- is-valid-context -c PATH_TO_CONTEXT` (check if context is valid)
- `cargo run --bin context-tool -- context-size -c PATH_TO_CONTEXT` (display detailed context sizes)
- `cargo run --bin context-tool -- make-snapshot -c PATH_TO_CONTEXT` (create a snapshot based on a single commit)