### PR TITLE
Remove HashBase58 wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,9 +586,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.0"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17bf219fcd37199b9a29e00ba65dfb8cd5b2688b7297ec14ff829c40ac50ca9"
+checksum = "12e8611f9ae4e068fa3e56931fded356ff745e70987ff76924a6e0ab1c8ef2e3"
 dependencies = [
  "atty",
  "bitflags",
@@ -603,11 +603,11 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.0"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b9752c030a14235a0bd5ef3ad60a1dcac8468c30921327fc8af36b20c790b9"
+checksum = "517358c28fcef6607bf6f76108e02afad7e82297d132a6b846dcc1fc3efcd153"
 dependencies = [
- "heck",
+ "heck 0.4.0",
  "proc-macro-error",
  "proc-macro2 1.0.32",
  "quote 1.0.10",
@@ -659,7 +659,7 @@ name = "context-tool"
 version = "1.15.0"
 dependencies = [
  "byte-unit",
- "clap 3.0.0",
+ "clap 3.0.7",
  "crypto",
  "termcolor",
  "tezos_context",
@@ -1618,6 +1618,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -3765,7 +3771,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro2 1.0.32",
  "quote 1.0.10",
  "syn 1.0.81",

--- a/shell_automaton/src/mempool/mempool_effects.rs
+++ b/shell_automaton/src/mempool/mempool_effects.rs
@@ -80,7 +80,7 @@ where
                 .mempool
                 .local_head_state
                 .as_ref()
-                .map(|h| h.hash.eq(&key.0))
+                .map(|h| h.hash.eq(key))
                 .unwrap_or(false)
             {
                 let operation_hashes = value
@@ -580,8 +580,8 @@ where
                     .ops
                     .iter()
                     .filter_map(|(hash, _)| {
-                        if !peer.seen_operations.contains(&hash.0) {
-                            Some(hash.0.clone())
+                        if !peer.seen_operations.contains(hash) {
+                            Some(hash.clone())
                         } else {
                             None
                         }
@@ -596,9 +596,9 @@ where
                     .pending_operations
                     .iter()
                     .filter(|(hash, op)| {
-                        !peer.seen_operations.contains(&hash.0) && head_state.hash.eq(op.branch())
+                        !peer.seen_operations.contains(hash) && head_state.hash.eq(op.branch())
                     })
-                    .map(|(hash, _)| hash.0.clone())
+                    .map(|(hash, _)| hash.clone())
                     .collect::<Vec<_>>()
             } else {
                 vec![]

--- a/shell_automaton/src/mempool/mempool_state.rs
+++ b/shell_automaton/src/mempool/mempool_state.rs
@@ -9,7 +9,7 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use crypto::hash::{BlockHash, CryptoboxPublicKeyHash, HashBase58, OperationHash};
+use crypto::hash::{BlockHash, CryptoboxPublicKeyHash, OperationHash};
 use tezos_api::ffi::{Applied, Errored, PrevalidatorWrapper};
 use tezos_messages::p2p::encoding::{
     block_header::{BlockHeader, Level},
@@ -25,7 +25,7 @@ pub struct MempoolState {
     //
     pub prevalidator: Option<PrevalidatorWrapper>,
     // performing rpc
-    pub(super) injecting_rpc_ids: HashMap<HashBase58<OperationHash>, RpcId>,
+    pub(super) injecting_rpc_ids: HashMap<OperationHash, RpcId>,
     // performed rpc
     pub(super) injected_rpc_ids: Vec<RpcId>,
     // operation streams requested by baker
@@ -38,7 +38,7 @@ pub struct MempoolState {
     // we sent GetOperations and pending full content of those operations
     pub(super) pending_full_content: HashSet<OperationHash>,
     // operations that passed basic checks, sent to protocol validator
-    pub(super) pending_operations: HashMap<HashBase58<OperationHash>, Operation>,
+    pub(super) pending_operations: HashMap<OperationHash, Operation>,
     // operations that passed basic checks, are not sent because prevalidator is not ready
     pub(super) wait_prevalidator_operations: Vec<Operation>,
     pub validated_operations: ValidatedOperations,
@@ -46,13 +46,12 @@ pub struct MempoolState {
     pub(super) level_to_operation: BTreeMap<i32, Vec<OperationHash>>,
 
     /// Last 120 (TTL) predecessor blocks.
-    pub last_predecessor_blocks: HashMap<HashBase58<BlockHash>, i32>,
+    pub last_predecessor_blocks: HashMap<BlockHash, i32>,
 
     pub operation_stats: OperationsStats,
 
-    pub old_operations_state:
-        VecDeque<(Level, BTreeMap<HashBase58<OperationHash>, MempoolOperation>)>,
-    pub operations_state: BTreeMap<HashBase58<OperationHash>, MempoolOperation>,
+    pub old_operations_state: VecDeque<(Level, BTreeMap<OperationHash, MempoolOperation>)>,
+    pub operations_state: BTreeMap<OperationHash, MempoolOperation>,
 
     /// Hash of the latest applied block
     pub latest_current_head: Option<BlockHash>,
@@ -95,8 +94,8 @@ pub struct OperationStream {
 
 #[derive(Default, Serialize, Deserialize, Debug, Clone)]
 pub struct ValidatedOperations {
-    pub ops: HashMap<HashBase58<OperationHash>, Operation>,
-    pub refused_ops: HashMap<HashBase58<OperationHash>, Operation>,
+    pub ops: HashMap<OperationHash, Operation>,
+    pub refused_ops: HashMap<OperationHash, Operation>,
     // operations that passed all checks and classified
     // can be applied in the current context
     pub applied: Vec<Applied>,
@@ -117,7 +116,7 @@ pub struct PeerState {
     pub(super) known_valid_to_send: Vec<OperationHash>,
 }
 
-pub type OperationsStats = HashMap<HashBase58<OperationHash>, OperationStats>;
+pub type OperationsStats = HashMap<OperationHash, OperationStats>;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct OperationStats {
@@ -129,7 +128,7 @@ pub struct OperationStats {
     /// (time_validation_finished, validation_result, prevalidation_duration)
     pub validation_result: Option<(u64, OperationValidationResult, Option<u64>, Option<u64>)>,
     pub validations: Vec<OperationValidationStats>,
-    pub nodes: HashMap<HashBase58<CryptoboxPublicKeyHash>, OperationNodeStats>,
+    pub nodes: HashMap<CryptoboxPublicKeyHash, OperationNodeStats>,
 }
 
 impl OperationStats {

--- a/shell_automaton/src/mempool/monitored_operation.rs
+++ b/shell_automaton/src/mempool/monitored_operation.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crypto::hash::{HashBase58, OperationHash, ProtocolHash};
+use crypto::hash::{OperationHash, ProtocolHash};
 use tezos_api::ffi::{Applied, Errored};
 use tezos_messages::p2p::encoding::operation::Operation;
 
@@ -22,7 +22,7 @@ pub struct MempoolOperations {
 
 fn convert_applied(
     applied: &[Applied],
-    operations: &HashMap<HashBase58<OperationHash>, Operation>,
+    operations: &HashMap<OperationHash, Operation>,
 ) -> Vec<HashMap<String, Value>> {
     applied
         .iter()
@@ -48,7 +48,7 @@ fn convert_applied(
 
 fn convert_errored(
     errored: &[Errored],
-    operations: &HashMap<HashBase58<OperationHash>, Operation>,
+    operations: &HashMap<OperationHash, Operation>,
     protocol: &ProtocolHash,
 ) -> Vec<Value> {
     let mut result = Vec::with_capacity(errored.len());
@@ -107,7 +107,7 @@ impl MempoolOperations {
         refused: &[Errored],
         branch_delayed: &[Errored],
         branch_refused: &[Errored],
-        operations: &HashMap<HashBase58<OperationHash>, Operation>,
+        operations: &HashMap<OperationHash, Operation>,
         protocol: &ProtocolHash,
     ) -> Self {
         MempoolOperations {
@@ -135,7 +135,7 @@ pub struct MonitoredOperation<'a> {
 impl<'a> MonitoredOperation<'a> {
     pub fn collect_applied(
         applied: &'a [Applied],
-        operations: &'a HashMap<HashBase58<OperationHash>, Operation>,
+        operations: &'a HashMap<OperationHash, Operation>,
         protocol_hash: &'a str,
     ) -> impl Iterator<Item = MonitoredOperation<'a>> + 'a {
         applied.iter().filter_map(move |applied_op| {
@@ -158,7 +158,7 @@ impl<'a> MonitoredOperation<'a> {
 
     pub fn collect_errored(
         errored: &'a [Errored],
-        operations: &'a HashMap<HashBase58<OperationHash>, Operation>,
+        operations: &'a HashMap<OperationHash, Operation>,
         protocol_hash: &'a str,
     ) -> impl Iterator<Item = MonitoredOperation<'a>> + 'a {
         errored.iter().filter_map(move |errored_op| {

--- a/shell_automaton/src/prechecker/prechecker_effects.rs
+++ b/shell_automaton/src/prechecker/prechecker_effects.rs
@@ -406,13 +406,13 @@ where
             match SupportedProtocol::try_from(value.next_protocol_hash()) {
                 Ok(proto) => {
                     store.dispatch(PrecheckerNextBlockProtocolReadyAction {
-                        block_hash: key.0.clone(),
+                        block_hash: key.clone(),
                         supported_protocol: proto.clone(),
                     });
                 }
                 Err(err) => {
                     store.dispatch(PrecheckerNextBlockProtocolErrorAction {
-                        block_hash: key.0.clone(),
+                        block_hash: key.clone(),
                         error: err.into(),
                     });
                 }
@@ -423,7 +423,7 @@ where
             error,
         }) => {
             store.dispatch(PrecheckerNextBlockProtocolErrorAction {
-                block_hash: key.0.clone(),
+                block_hash: key.clone(),
                 error: error.clone().into(),
             });
         }

--- a/shell_automaton/src/prechecker/prechecker_state.rs
+++ b/shell_automaton/src/prechecker/prechecker_state.rs
@@ -10,7 +10,7 @@ use std::{
 use crypto::{
     base58::FromBase58CheckError,
     blake2b::Blake2bError,
-    hash::{BlockHash, FromBytesError, HashBase58, OperationHash, Signature},
+    hash::{BlockHash, FromBytesError, OperationHash, Signature},
 };
 use redux_rs::ActionId;
 use tezos_encoding::{binary_reader::BinaryReaderError, binary_writer::BinaryWriterError};
@@ -86,7 +86,7 @@ impl Default for SupportedProtocolState {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ProtocolVersionCache {
     pub time: Duration,
-    pub protocol_versions: BTreeMap<HashBase58<BlockHash>, (ActionId, SupportedProtocol)>,
+    pub protocol_versions: BTreeMap<BlockHash, (ActionId, SupportedProtocol)>,
 }
 
 impl Default for ProtocolVersionCache {
@@ -240,8 +240,8 @@ impl OperationDecodedContents {
 
     pub(super) fn branch(&self) -> &BlockHash {
         match self {
-            OperationDecodedContents::Proto010(op) => &op.branch.0,
-            OperationDecodedContents::Proto011(op) => &op.branch.0,
+            OperationDecodedContents::Proto010(op) => &op.branch,
+            OperationDecodedContents::Proto011(op) => &op.branch,
         }
     }
 

--- a/shell_automaton/src/prechecker/prechecker_validator.rs
+++ b/shell_automaton/src/prechecker/prechecker_validator.rs
@@ -288,7 +288,7 @@ fn validate_inlined_endorsement(
     start: Instant,
     log: &Logger,
 ) -> Result<Applied, Refused> {
-    if &endorsement.branch.0 != block_hash {
+    if &endorsement.branch != block_hash {
         return Err(Refused::new(
             json,
             EndorsementValidationError::WrongEndorsementPredecessor,
@@ -300,7 +300,7 @@ fn validate_inlined_endorsement(
     } else {
         return Err(Refused::new(json, EndorsementValidationError::InvalidSlot));
     };
-    let signature = &endorsement.signature.0;
+    let signature = &endorsement.signature;
     let mut encoded = endorsement.branch.as_ref().to_vec();
     let binary_endorsement = match endorsement.operations.as_bytes() {
         Ok(bytes) => bytes,

--- a/shell_automaton/src/rights/rights_effects.rs
+++ b/shell_automaton/src/rights/rights_effects.rs
@@ -8,10 +8,7 @@ use std::{
     time::Instant,
 };
 
-use crypto::{
-    blake2b::{self, Blake2bError},
-    hash::HashBase58,
-};
+use crypto::blake2b::{self, Blake2bError};
 use slog::{error, trace, warn, FnValue};
 use storage::{cycle_storage::CycleData, num_from_slice};
 use tezos_messages::base::{
@@ -135,7 +132,7 @@ where
             }
         }
         Action::StorageBlockHeaderOk(kv_block_header::StorageBlockHeaderOkAction {
-            key: HashBase58(key),
+            key,
             value,
         }) => {
             for key in requests
@@ -157,7 +154,7 @@ where
             }
         }
         Action::StorageBlockHeaderError(kv_block_header::StorageBlockHeaderErrorAction {
-            key: HashBase58(key),
+            key,
             error,
         }) => {
             for key in requests
@@ -199,10 +196,7 @@ where
             }
         }
         Action::StorageBlockAdditionalDataOk(
-            kv_block_additional_data::StorageBlockAdditionalDataOkAction {
-                key: HashBase58(key),
-                value,
-            },
+            kv_block_additional_data::StorageBlockAdditionalDataOkAction { key, value },
         ) => {
             let rights_keys: Vec<_> = requests
                 .iter()
@@ -223,10 +217,7 @@ where
             }
         }
         Action::StorageBlockAdditionalDataError(
-            kv_block_additional_data::StorageBlockAdditionalDataErrorAction {
-                key: HashBase58(key),
-                error,
-            },
+            kv_block_additional_data::StorageBlockAdditionalDataErrorAction { key, error },
         ) => {
             for key in requests
                 .iter()
@@ -266,10 +257,7 @@ where
                 store.dispatch(kv_constants::StorageConstantsGetAction::new(key));
             }
         }
-        Action::StorageConstantsOk(kv_constants::StorageConstantsOkAction {
-            key: HashBase58(key),
-            value,
-        }) => {
+        Action::StorageConstantsOk(kv_constants::StorageConstantsOkAction { key, value }) => {
             for key in requests
                 .iter()
                 .filter_map(|(rights_key, request)| {
@@ -306,10 +294,7 @@ where
                 }
             }
         }
-        Action::StorageConstantsError(kv_constants::StorageConstantsErrorAction {
-            key: HashBase58(key),
-            error,
-        }) => {
+        Action::StorageConstantsError(kv_constants::StorageConstantsErrorAction { key, error }) => {
             let rights_keys: Vec<_> = requests
                 .iter()
                 .filter_map(|(rights_key, request)| {
@@ -355,10 +340,7 @@ where
                 store.dispatch(kv_cycle_eras::StorageCycleErasGetAction::new(key));
             }
         }
-        Action::StorageCycleErasOk(kv_cycle_eras::StorageCycleErasOkAction {
-            key: HashBase58(key),
-            value,
-        }) => {
+        Action::StorageCycleErasOk(kv_cycle_eras::StorageCycleErasOkAction { key, value }) => {
             for key in requests
                 .iter()
                 .filter_map(|(rights_key, request)| {
@@ -382,7 +364,7 @@ where
             }
         }
         Action::StorageCycleErasError(kv_cycle_eras::StorageCycleErasErrorAction {
-            key: HashBase58(key),
+            key,
             error,
         }) => {
             for key in requests

--- a/shell_automaton/src/storage/mod.rs
+++ b/shell_automaton/src/storage/mod.rs
@@ -192,7 +192,7 @@ macro_rules! kv_state_machine {
 }
 
 pub mod kv_block_meta {
-    use crypto::hash::{BlockHash, HashBase58};
+    use crypto::hash::BlockHash;
     use storage::block_meta_storage::Meta;
 
     kv_state_machine!(
@@ -200,7 +200,7 @@ pub mod kv_block_meta {
         BlockMetaGet,
         BlockMetaGetSuccess,
         BlockMetaGetError,
-        HashBase58<BlockHash>,
+        BlockHash,
         Meta,
         |_hash, _meta| true,
         StorageBlockMetaGet,
@@ -213,7 +213,7 @@ pub mod kv_block_meta {
 }
 
 pub mod kv_block_additional_data {
-    use crypto::hash::{BlockHash, HashBase58};
+    use crypto::hash::BlockHash;
     use storage::block_meta_storage::BlockAdditionalData;
 
     kv_state_machine!(
@@ -221,7 +221,7 @@ pub mod kv_block_additional_data {
         BlockAdditionalDataGet,
         BlockAdditionalDataGetSuccess,
         BlockAdditionalDataGetError,
-        HashBase58<BlockHash>,
+        BlockHash,
         BlockAdditionalData,
         |_hash, _additinal_data| false,
         StorageBlockAdditionalDataGet,
@@ -234,7 +234,7 @@ pub mod kv_block_additional_data {
 }
 
 pub mod kv_block_header {
-    use crypto::hash::{BlockHash, HashBase58};
+    use crypto::hash::BlockHash;
     use tezos_messages::p2p::encoding::block_header::BlockHeader;
 
     kv_state_machine!(
@@ -242,7 +242,7 @@ pub mod kv_block_header {
         BlockHeaderGet,
         BlockHeaderGetSuccess,
         BlockHeaderGetError,
-        HashBase58<BlockHash>,
+        BlockHash,
         BlockHeader,
         |_hash, _header| false,
         StorageBlockHeaderGet,
@@ -255,14 +255,14 @@ pub mod kv_block_header {
 }
 
 pub mod kv_constants {
-    use crypto::hash::{HashBase58, ProtocolHash};
+    use crypto::hash::ProtocolHash;
 
     kv_state_machine!(
         constants,
         ConstantsGet,
         ConstantsGetSuccess,
         ConstantsGetError,
-        HashBase58<ProtocolHash>,
+        ProtocolHash,
         String,
         |_key, _value| false,
         StorageConstantsGet,
@@ -329,7 +329,7 @@ pub mod kv_cycle_meta {
 }
 
 pub mod kv_cycle_eras {
-    use crypto::hash::{HashBase58, ProtocolHash};
+    use crypto::hash::ProtocolHash;
     use storage::cycle_eras_storage::CycleErasData;
 
     kv_state_machine!(
@@ -337,7 +337,7 @@ pub mod kv_cycle_eras {
         CycleErasGet,
         CycleErasGetSuccess,
         CycleErasGetError,
-        HashBase58<ProtocolHash>,
+        ProtocolHash,
         CycleErasData,
         |_proto, _eras| false,
         StorageCycleErasGet,
@@ -350,7 +350,7 @@ pub mod kv_cycle_eras {
 }
 
 pub mod kv_operations {
-    use crypto::hash::{BlockHash, HashBase58};
+    use crypto::hash::BlockHash;
     use tezos_messages::p2p::encoding::operation::Operation;
 
     kv_state_machine!(
@@ -358,7 +358,7 @@ pub mod kv_operations {
         OperationsGet,
         OperationsGetSuccess,
         OperationsGetError,
-        HashBase58<BlockHash>,
+        BlockHash,
         Vec<Operation>,
         |_hash, _ops| false,
         StorageOperationsGet,

--- a/tezos/encoding/src/enc.rs
+++ b/tezos/encoding/src/enc.rs
@@ -4,7 +4,6 @@
 use std::convert::TryFrom;
 use std::fmt;
 
-use crypto::hash::HashBase58;
 pub use tezos_encoding_derive::BinWriter;
 
 use thiserror::Error;
@@ -261,15 +260,6 @@ encode_hash!(crypto::hash::PublicKeyEd25519);
 encode_hash!(crypto::hash::PublicKeySecp256k1);
 encode_hash!(crypto::hash::PublicKeyP256);
 encode_hash!(crypto::hash::Signature);
-
-impl<H> BinWriter for HashBase58<H>
-where
-    H: BinWriter,
-{
-    fn bin_write(&self, bytes: &mut Vec<u8>) -> BinResult {
-        self.0.bin_write(bytes)
-    }
-}
 
 pub fn sized<T>(
     size: usize,

--- a/tezos/encoding/src/encoding.rs
+++ b/tezos/encoding/src/encoding.rs
@@ -3,7 +3,7 @@
 
 //! Schema used for serialization and deserialization.
 
-use crypto::hash::{HashBase58, HashTrait, HashType};
+use crypto::hash::{HashTrait, HashType};
 use std::collections::HashMap;
 
 pub use tezos_encoding_derive::HasEncoding;
@@ -339,15 +339,6 @@ hash_has_encoding!(PublicKeyEd25519, PUBLIC_KEY_ED25519);
 hash_has_encoding!(PublicKeySecp256k1, PUBLIC_KEY_SECP256K1);
 hash_has_encoding!(PublicKeyP256, PUBLIC_KEY_P256);
 hash_has_encoding!(Signature, SIGNATURE);
-
-impl<H> HasEncoding for HashBase58<H>
-where
-    H: HasEncoding,
-{
-    fn encoding() -> &'static Encoding {
-        H::encoding()
-    }
-}
 
 /// Creates impl HasEncoding for given struct backed by lazy_static ref instance with encoding.
 #[macro_export]

--- a/tezos/encoding/src/nom.rs
+++ b/tezos/encoding/src/nom.rs
@@ -1,7 +1,7 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use crypto::hash::{HashBase58, HashTrait};
+use crypto::hash::HashTrait;
 use nom::{
     bitvec::{bitvec, order::Msb0, view::BitView},
     branch::*,
@@ -259,15 +259,6 @@ hash_nom_reader!(PublicKeyEd25519);
 hash_nom_reader!(PublicKeySecp256k1);
 hash_nom_reader!(PublicKeyP256);
 hash_nom_reader!(Signature);
-
-impl<H> NomReader for HashBase58<H>
-where
-    H: NomReader,
-{
-    fn nom_read(bytes: &[u8]) -> NomResult<Self> {
-        nom::combinator::map(H::nom_read, Self)(bytes)
-    }
-}
 
 impl NomReader for Zarith {
     fn nom_read(bytes: &[u8]) -> NomResult<Self> {

--- a/tezos/messages/src/protocol/proto_001/operation.rs
+++ b/tezos/messages/src/protocol/proto_001/operation.rs
@@ -6,7 +6,10 @@
 
 use std::convert::TryFrom;
 
-use crypto::hash::{HashBase58, HashTrait};
+use crypto::hash::{
+    BlockHash, ContextHash, ContractTz1Hash, HashTrait, OperationListListHash, ProtocolHash,
+    Signature,
+};
 use tezos_encoding::binary_reader::BinaryReaderError;
 use tezos_encoding::types::Mutez;
 use tezos_encoding::{enc::BinWriter, encoding::HasEncoding, nom::NomReader};
@@ -18,13 +21,6 @@ use crate::p2p::encoding::{
     limits::BLOCK_HEADER_FITNESS_MAX_SIZE,
     operation::Operation as P2POperation,
 };
-
-type BlockHash = HashBase58<crypto::hash::BlockHash>;
-type Signature = HashBase58<crypto::hash::Signature>;
-type ContextHash = HashBase58<crypto::hash::ContextHash>;
-type OperationListListHash = HashBase58<crypto::hash::OperationListListHash>;
-type ContractTz1Hash = HashBase58<crypto::hash::ContractTz1Hash>;
-type ProtocolHash = HashBase58<crypto::hash::ProtocolHash>;
 
 /// Operation contents.
 /// See [https://tezos.gitlab.io/shell/p2p_api.html?highlight=p2p%20encodings#operation-alpha-specific].
@@ -77,7 +73,7 @@ impl TryFrom<P2POperation> for Operation {
             signature,
         } = OperationContents::from_bytes(operation.data())?;
         Ok(Operation {
-            branch: HashBase58(branch),
+            branch,
             contents,
             signature,
         })

--- a/tezos/messages/src/protocol/proto_009/operation.rs
+++ b/tezos/messages/src/protocol/proto_009/operation.rs
@@ -18,14 +18,11 @@ pub use super::super::proto_008_2::operation::{
 
 use std::convert::TryFrom;
 
-use crypto::hash::{HashBase58, HashTrait};
+use crypto::hash::{BlockHash, HashTrait, Signature};
 use tezos_encoding::binary_reader::BinaryReaderError;
 use tezos_encoding::{encoding::HasEncoding, nom::NomReader};
 
 use crate::p2p::encoding::operation::Operation as P2POperation;
-
-type BlockHash = HashBase58<crypto::hash::BlockHash>;
-type Signature = HashBase58<crypto::hash::Signature>;
 
 /// Operation contents.
 /// See [https://tezos.gitlab.io/shell/p2p_api.html?highlight=p2p%20encodings#operation-alpha-specific].
@@ -78,7 +75,7 @@ impl TryFrom<P2POperation> for Operation {
             signature,
         } = OperationContents::from_bytes(operation.data())?;
         Ok(Operation {
-            branch: HashBase58(branch),
+            branch,
             contents,
             signature,
         })

--- a/tezos/messages/src/protocol/proto_010/operation.rs
+++ b/tezos/messages/src/protocol/proto_010/operation.rs
@@ -17,7 +17,7 @@ pub use super::super::proto_009::operation::{
 
 use std::convert::TryFrom;
 
-use crypto::hash::{HashBase58, HashTrait};
+use crypto::hash::{BlockHash, ContextHash, HashTrait, OperationListListHash, Signature};
 use tezos_encoding::binary_reader::BinaryReaderError;
 use tezos_encoding::{encoding::HasEncoding, nom::NomReader};
 
@@ -26,11 +26,6 @@ use crate::p2p::encoding::{
     limits::BLOCK_HEADER_FITNESS_MAX_SIZE,
     operation::Operation as P2POperation,
 };
-
-type BlockHash = HashBase58<crypto::hash::BlockHash>;
-type Signature = HashBase58<crypto::hash::Signature>;
-type ContextHash = HashBase58<crypto::hash::ContextHash>;
-type OperationListListHash = HashBase58<crypto::hash::OperationListListHash>;
 
 /// Operation contents.
 /// See [https://tezos.gitlab.io/shell/p2p_api.html?highlight=p2p%20encodings#operation-alpha-specific].
@@ -83,7 +78,7 @@ impl TryFrom<P2POperation> for Operation {
             signature,
         } = OperationContents::from_bytes(operation.data())?;
         Ok(Operation {
-            branch: HashBase58(branch),
+            branch,
             contents,
             signature,
         })

--- a/tezos/messages/src/protocol/proto_011/operation.rs
+++ b/tezos/messages/src/protocol/proto_011/operation.rs
@@ -16,7 +16,7 @@ pub use super::super::proto_010::operation::{
 
 use std::convert::TryFrom;
 
-use crypto::hash::{HashBase58, HashTrait};
+use crypto::hash::{BlockHash, ContextHash, HashTrait, OperationListListHash, Signature};
 use tezos_encoding::{
     binary_reader::BinaryReaderError, encoding::HasEncoding, nom::NomReader, types::Mutez,
 };
@@ -29,11 +29,6 @@ use crate::{
         operation::Operation as P2POperation,
     },
 };
-
-type BlockHash = HashBase58<crypto::hash::BlockHash>;
-type Signature = HashBase58<crypto::hash::Signature>;
-type ContextHash = HashBase58<crypto::hash::ContextHash>;
-type OperationListListHash = HashBase58<crypto::hash::OperationListListHash>;
 
 /// Operation contents.
 /// See [https://tezos.gitlab.io/shell/p2p_api.html?highlight=p2p%20encodings#operation-alpha-specific].
@@ -86,7 +81,7 @@ impl TryFrom<P2POperation> for Operation {
             signature,
         } = OperationContents::from_bytes(operation.data())?;
         Ok(Operation {
-            branch: HashBase58(branch),
+            branch,
             contents,
             signature,
         })


### PR DESCRIPTION
Now that hashes are encoded as strings in JSON we don't need that wrapper anymore.