### PR TITLE
Load context from disk and apply blocks in memory + Reduce memory

### DIFF
--- a/tezos/context/src/chunks/vec.rs
+++ b/tezos/context/src/chunks/vec.rs
@@ -331,6 +331,12 @@ where
 
         println!("INTO_SORTED_MAP {:?} {:?}", now.elapsed(), map);
 
+        let now = std::time::Instant::now();
+
+        map.shrink_to_fit();
+
+        println!("INTO_SORTED_MAP SHRINK_TO_FIT {:?} {:?}", now.elapsed(), map);
+
         map
     }
 }

--- a/tezos/context/src/chunks/vec.rs
+++ b/tezos/context/src/chunks/vec.rs
@@ -310,7 +310,7 @@ impl<T> ChunkedVec<T> {
         self.nelems = 0;
     }
 
-    pub fn take_first(&mut self) -> Option<Vec<T>> {
+    pub fn pop_first_chunk(&mut self) -> Option<Vec<T>> {
         if self.list_of_chunks.is_empty() {
             None
         } else {
@@ -341,14 +341,10 @@ impl<T> ChunkedVec<T> {
 
 impl<K, V> ChunkedVec<(K, V)>
 where
-    K: Ord + Copy + Debug,
+    K: Ord + Copy,
 {
     pub fn into_sorted_map(&mut self) -> SortedMap<K, V> {
         let mut map = SortedMap::default();
-
-        let now = std::time::Instant::now();
-
-        println!("INTO_SORTED_MAP START {:?} ITEMS", self.len());
 
         while !self.list_of_chunks.is_empty() {
             let chunk = self.list_of_chunks.remove(0);
@@ -357,18 +353,7 @@ where
             }
         }
 
-        println!("INTO_SORTED_MAP {:?} {:?}", now.elapsed(), map);
-
-        let now = std::time::Instant::now();
-
         map.shrink_to_fit();
-
-        println!(
-            "INTO_SORTED_MAP SHRINK_TO_FIT {:?} {:?}",
-            now.elapsed(),
-            map
-        );
-
         map
     }
 }

--- a/tezos/context/src/chunks/vec.rs
+++ b/tezos/context/src/chunks/vec.rs
@@ -317,6 +317,12 @@ impl<T> ChunkedVec<T> {
             Some(self.list_of_chunks.remove(0))
         }
     }
+
+    pub fn pop(&mut self) -> Option<T> {
+        let last = self.list_of_chunks.last_mut()?.pop()?;
+        self.nelems -= 1;
+        Some(last)
+    }
 }
 
 impl<K, V> ChunkedVec<(K, V)>

--- a/tezos/context/src/chunks/vec.rs
+++ b/tezos/context/src/chunks/vec.rs
@@ -7,7 +7,7 @@ use std::{
     ops::{Index, IndexMut, Range},
 };
 
-use crate::gc::sorted_map::SortedMap;
+use crate::gc::SortedMap;
 
 use super::{Chunk, DEFAULT_LIST_LENGTH};
 

--- a/tezos/context/src/chunks/vec.rs
+++ b/tezos/context/src/chunks/vec.rs
@@ -3,8 +3,11 @@
 
 use std::{
     borrow::Cow,
+    fmt::Debug,
     ops::{Index, IndexMut, Range},
 };
+
+use crate::gc::sorted_map::SortedMap;
 
 use super::{Chunk, DEFAULT_LIST_LENGTH};
 
@@ -305,6 +308,30 @@ impl<T> ChunkedVec<T> {
             first_chunk.clear();
         };
         self.nelems = 0;
+    }
+}
+
+impl<K, V> ChunkedVec<(K, V)>
+where
+    K: Ord + Copy + Debug,
+{
+    pub fn into_sorted_map(&mut self) -> SortedMap<K, V> {
+        let mut map = SortedMap::default();
+
+        let now = std::time::Instant::now();
+
+        println!("INTO_SORTED_MAP START {:?} ITEMS", self.len());
+
+        while !self.list_of_chunks.is_empty() {
+            let chunk = self.list_of_chunks.remove(0);
+            for (k, v) in chunk.into_iter() {
+                map.insert(k, v);
+            }
+        }
+
+        println!("INTO_SORTED_MAP {:?} {:?}", now.elapsed(), map);
+
+        map
     }
 }
 

--- a/tezos/context/src/chunks/vec.rs
+++ b/tezos/context/src/chunks/vec.rs
@@ -309,6 +309,14 @@ impl<T> ChunkedVec<T> {
         };
         self.nelems = 0;
     }
+
+    pub fn take_first(&mut self) -> Option<Vec<T>> {
+        if self.list_of_chunks.is_empty() {
+            None
+        } else {
+            Some(self.list_of_chunks.remove(0))
+        }
+    }
 }
 
 impl<K, V> ChunkedVec<(K, V)>
@@ -335,7 +343,11 @@ where
 
         map.shrink_to_fit();
 
-        println!("INTO_SORTED_MAP SHRINK_TO_FIT {:?} {:?}", now.elapsed(), map);
+        println!(
+            "INTO_SORTED_MAP SHRINK_TO_FIT {:?} {:?}",
+            now.elapsed(),
+            map
+        );
 
         map
     }

--- a/tezos/context/src/ffi.rs
+++ b/tezos/context/src/ffi.rs
@@ -283,14 +283,16 @@ ocaml_export! {
         let cycle_position: Option<i64> = cycle_position.to_rust(rt);
         let context_hash: Option<ContextHash> = context_hash.to_rust(rt);
 
-        let result = if let Some(0) = cycle_position {
-            if context_hash.is_some() {
-                index.cycle_started().map_err(|err| format!("BlockApplied->CycleStarted: {:?}", err))
-            } else {
-                Ok(())
-            }
-        } else {
-            Ok(())
+        // We call `IndexApi::cycle_started` only when `context_hash` is `Some(_)`:
+        // For a single commit, `tezedge_index_block_applied` is called twice from OCaml
+        // Once before the commit, and one more time after the commit.
+        // Before the commit, it is called with a `None` `context_hash`, and after
+        // the commit, it is called with a `Some(_)` `context_hash`
+        let result = match (cycle_position, context_hash) {
+            (Some(0), Some(_)) => index
+                .cycle_started()
+                .map_err(|err| format!("BlockApplied->CycleStarted: {:?}", err)),
+            _ => Ok(())
         };
 
         result.to_ocaml(rt)

--- a/tezos/context/src/ffi.rs
+++ b/tezos/context/src/ffi.rs
@@ -274,16 +274,21 @@ ocaml_export! {
     fn tezedge_index_block_applied(
         rt,
         index: OCamlRef<DynBox<TezedgeIndexFFI>>,
-        _context_hash: OCamlRef<Option<OCamlContextHash>>,
+        context_hash: OCamlRef<Option<OCamlContextHash>>,
         cycle_position: OCamlRef<Option<OCamlInt>>,
     ) -> OCaml<Result<(), String>> {
         let ocaml_index = rt.get(index);
         let index: &TezedgeIndexFFI = ocaml_index.borrow();
         let mut index = index.0.borrow().clone();
         let cycle_position: Option<i64> = cycle_position.to_rust(rt);
+        let context_hash: Option<ContextHash> = context_hash.to_rust(rt);
 
         let result = if let Some(0) = cycle_position {
-            index.cycle_started().map_err(|err| format!("BlockApplied->CycleStarted: {:?}", err))
+            if context_hash.is_some() {
+                index.cycle_started().map_err(|err| format!("BlockApplied->CycleStarted: {:?}", err))
+            } else {
+                Ok(())
+            }
         } else {
             Ok(())
         };

--- a/tezos/context/src/gc/mod.rs
+++ b/tezos/context/src/gc/mod.rs
@@ -11,6 +11,7 @@ use thiserror::Error;
 
 use crypto::hash::FromBytesError;
 
+use crate::chunks::ChunkedVec;
 use crate::persistent::DBError;
 use crate::{hash::HashingError, kv_store::HashId};
 
@@ -22,7 +23,7 @@ pub trait GarbageCollector {
 
     fn block_applied(
         &mut self,
-        referenced_older_objects: Vec<HashId>,
+        referenced_older_objects: ChunkedVec<HashId>,
     ) -> Result<(), GarbageCollectionError>;
 }
 
@@ -35,7 +36,7 @@ impl<T: NotGarbageCollected> GarbageCollector for T {
 
     fn block_applied(
         &mut self,
-        _referenced_older_objects: Vec<HashId>,
+        _referenced_older_objects: ChunkedVec<HashId>,
     ) -> Result<(), GarbageCollectionError> {
         Ok(())
     }

--- a/tezos/context/src/gc/mod.rs
+++ b/tezos/context/src/gc/mod.rs
@@ -14,6 +14,7 @@ use crypto::hash::FromBytesError;
 use crate::persistent::DBError;
 use crate::{hash::HashingError, kv_store::HashId};
 
+pub(crate) mod sorted_map;
 pub(crate) mod worker;
 
 pub trait GarbageCollector {

--- a/tezos/context/src/gc/mod.rs
+++ b/tezos/context/src/gc/mod.rs
@@ -15,8 +15,12 @@ use crate::chunks::ChunkedVec;
 use crate::persistent::DBError;
 use crate::{hash::HashingError, kv_store::HashId};
 
-pub(crate) mod sorted_map;
+mod sorted_map;
 pub(crate) mod worker;
+
+// TODO: Use const default when the feature is stabilized, it will be in 1.59.0:
+// https://github.com/rust-lang/rust/pull/90207
+pub type SortedMap<K, V> = sorted_map::SortedMap<K, V, { sorted_map::DEFAULT_CHUNK_SIZE }>;
 
 pub trait GarbageCollector {
     fn new_cycle_started(&mut self) -> Result<(), GarbageCollectionError>;

--- a/tezos/context/src/gc/sorted_map.rs
+++ b/tezos/context/src/gc/sorted_map.rs
@@ -190,12 +190,16 @@ where
         }
     }
 
+    pub fn contains_key(&self, key: &K) -> bool {
+        self.get(key).is_some()
+    }
+
     pub fn to_vec(mut self) -> Vec<K> {
-        let vec = Vec::with_capacity(self.len());
+        let mut vec = Vec::with_capacity(self.len());
 
         while let Some(chunk) = self.list.get(0) {
-            for (key, _) in chunk.inner {
-                vec.push(key);
+            for (key, _) in &chunk.inner {
+                vec.push(*key);
             }
             self.list.remove(0);
         }

--- a/tezos/context/src/gc/sorted_map.rs
+++ b/tezos/context/src/gc/sorted_map.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 #[cfg(not(test))]
-const MAX_CHUNK_SIZE: usize = 1_000_000;
+const MAX_CHUNK_SIZE: usize = 10_000;
 
 #[cfg(test)]
 const MAX_CHUNK_SIZE: usize = 4;
@@ -52,8 +52,9 @@ where
 
 impl<K, V> std::fmt::Debug for SortedMap<K, V>
 where
-    K: Ord + std::fmt::Debug,
-    V: std::fmt::Debug,
+    K: Ord,
+    // K: Ord + std::fmt::Debug,
+    // V: std::fmt::Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut len = 0;

--- a/tezos/context/src/gc/sorted_map.rs
+++ b/tezos/context/src/gc/sorted_map.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 #[cfg(not(test))]
-const MAX_CHUNK_SIZE: usize = 10_000;
+const MAX_CHUNK_SIZE: usize = 1_000;
 
 #[cfg(test)]
 const MAX_CHUNK_SIZE: usize = 4;

--- a/tezos/context/src/gc/sorted_map.rs
+++ b/tezos/context/src/gc/sorted_map.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, slice::SliceIndex};
+use std::fmt::Debug;
 
 #[cfg(not(test))]
 const MAX_CHUNK_SIZE: usize = 1_000_000;
@@ -194,7 +194,7 @@ where
         self.get(key).is_some()
     }
 
-    pub fn to_vec(mut self) -> Vec<K> {
+    pub fn keys_to_vec(mut self) -> Vec<K> {
         let mut vec = Vec::with_capacity(self.len());
 
         while let Some(chunk) = self.list.get(0) {

--- a/tezos/context/src/gc/sorted_map.rs
+++ b/tezos/context/src/gc/sorted_map.rs
@@ -1,3 +1,6 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
 use std::{fmt::Debug, sync::Arc};
 
 use static_assertions::assert_eq_size;

--- a/tezos/context/src/gc/sorted_map.rs
+++ b/tezos/context/src/gc/sorted_map.rs
@@ -1,4 +1,8 @@
-use std::fmt::Debug;
+use std::{fmt::Debug, sync::Arc};
+
+use static_assertions::assert_eq_size;
+
+use crate::kv_store::HashId;
 
 #[cfg(not(test))]
 const MAX_CHUNK_SIZE: usize = 1_000;
@@ -16,6 +20,11 @@ where
     min: K,
     max: K,
 }
+
+assert_eq_size!([u8; 40], Chunk<HashId, Arc<[u8]>>);
+assert_eq_size!([u8; 24], (HashId, Arc<[u8]>));
+
+//10413651+ 11259171+ 10596201+ 10308720+ 14033165+ 35634221+ 54858073
 
 pub struct SortedMap<K, V>
 where

--- a/tezos/context/src/gc/sorted_map.rs
+++ b/tezos/context/src/gc/sorted_map.rs
@@ -81,9 +81,7 @@ where
     K: Ord + Copy,
 {
     fn shrink_to_fit(&mut self) {
-        if self.len() + 100 < self.inner.capacity() {
-            self.inner.shrink_to_fit();
-        }
+        self.inner.shrink_to_fit();
     }
 
     fn len(&self) -> usize {

--- a/tezos/context/src/gc/sorted_map.rs
+++ b/tezos/context/src/gc/sorted_map.rs
@@ -1,0 +1,397 @@
+use std::fmt::Debug;
+
+#[cfg(not(test))]
+const MAX_CHUNK_SIZE: usize = 1_000_000;
+
+#[cfg(test)]
+const MAX_CHUNK_SIZE: usize = 4;
+
+const SPLIT_AT: usize = (MAX_CHUNK_SIZE / 2) + (MAX_CHUNK_SIZE / 4);
+
+struct Chunk<K, V>
+where
+    K: Ord,
+{
+    inner: Vec<(K, V)>,
+    min: K,
+    max: K,
+}
+
+#[derive(Default)]
+struct SortedMap<K, V>
+where
+    K: Ord,
+{
+    list: Vec<Chunk<K, V>>,
+}
+
+impl<K, V> std::fmt::Debug for Chunk<K, V>
+where
+    K: Ord + std::fmt::Debug,
+    V: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Chunk")
+            .field("inner", &self.inner)
+            .field("inner_cap", &self.inner.capacity())
+            .field("min", &self.min)
+            .field("max", &self.max)
+            .finish()
+    }
+}
+
+impl<K, V> std::fmt::Debug for SortedMap<K, V>
+where
+    K: Ord + std::fmt::Debug,
+    V: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut len = 0;
+        let mut cap = 0;
+
+        for chunk in &self.list {
+            len += chunk.inner.len();
+            cap += chunk.inner.capacity();
+        }
+
+        f.debug_struct("SortedMap")
+            .field("nchunks", &self.list.len())
+            .field("list_len", &len)
+            .field("list_cap", &cap)
+            .finish()
+
+        // f.debug_struct("SortedMap")
+        //     .field("list", &self.list)
+        //     .finish()
+    }
+}
+
+impl<K, V> Chunk<K, V>
+where
+    K: Ord + Copy,
+{
+    fn shrink_to_fit(&mut self) {
+        if self.len() + 100 < self.inner.capacity() {
+            self.inner.shrink_to_fit();
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    fn new_with_element(key: K, value: V) -> Self {
+        let mut inner = Vec::with_capacity(MAX_CHUNK_SIZE / 2);
+
+        let min = key;
+        let max = key;
+
+        inner.push((key, value));
+
+        Self { inner, min, max }
+    }
+
+    fn set_min_max(&mut self) {
+        if let Some(first) = self.inner.first() {
+            self.min = first.0;
+        };
+        if let Some(last) = self.inner.last() {
+            self.max = last.0;
+        };
+    }
+
+    fn get(&self, key: &K) -> Option<&V> {
+        let index = self.inner.binary_search_by_key(key, |&(k, _)| k).ok()?;
+        self.inner.get(index).map(|(_, v)| v)
+    }
+
+    fn append(&mut self, other: &mut Self) {
+        self.inner.append(&mut other.inner);
+        self.max = self.inner.last().unwrap().0;
+    }
+
+    fn remove(&mut self, key: &K) {
+        let index = match self.inner.binary_search_by_key(key, |&(k, _)| k) {
+            Ok(index) => index,
+            Err(_) => return,
+        };
+
+        self.inner.remove(index);
+    }
+
+    fn insert(&mut self, key: K, value: V) -> Option<Self> {
+        let insert_at = match self.inner.binary_search_by_key(&key, |&(k, _)| k) {
+            Ok(index) => {
+                self.inner[index].1 = value;
+                return None;
+            }
+            Err(index) => index,
+        };
+
+        let mut next_chunk = None;
+
+        if self.len() == MAX_CHUNK_SIZE {
+            let new_chunk = if insert_at >= SPLIT_AT {
+                let mut new_chunk = self.inner.split_off(SPLIT_AT);
+                new_chunk.insert(insert_at - SPLIT_AT, (key, value));
+                new_chunk
+            } else {
+                let new_chunk = self.inner.split_off(SPLIT_AT - 1);
+                self.inner.insert(insert_at, (key, value));
+                new_chunk
+            };
+
+            let new_min = new_chunk[0].0;
+            let new_max = new_chunk.last().unwrap().0;
+
+            self.max = self.inner.last().unwrap().0;
+
+            next_chunk = Some(Chunk {
+                inner: new_chunk,
+                min: new_min,
+                max: new_max,
+            });
+        } else {
+            self.inner.insert(insert_at, (key, value));
+
+            if key < self.min {
+                self.min = key;
+            }
+
+            if key > self.max {
+                self.max = key;
+            }
+        }
+
+        next_chunk
+    }
+}
+
+impl<K, V> SortedMap<K, V>
+where
+    // K: Ord + Copy,
+    K: Ord + Copy + Debug,
+{
+    fn shrink_to_fit(&mut self) {
+        for chunk in self.list.iter_mut() {
+            chunk.shrink_to_fit();
+        }
+    }
+
+    fn get(&self, key: &K) -> Option<&V> {
+        let index = self.binary_search(key).ok()?;
+        let chunk = self.list.get(index)?;
+
+        chunk.get(key)
+    }
+
+    fn remove(&mut self, key: &K) {
+        let index = match self.binary_search(key) {
+            Ok(index) => index,
+            Err(_) => return,
+        };
+
+        let chunk = &mut self.list[index];
+        chunk.remove(key);
+
+        if chunk.is_empty() {
+            self.list.remove(index);
+        } else {
+            chunk.set_min_max();
+        }
+    }
+
+    fn insert(&mut self, key: K, value: V) {
+        match self.binary_search(&key) {
+            Ok(index) => {
+                let chunk = &mut self.list[index];
+
+                let mut new_chunk = match chunk.insert(key, value) {
+                    Some(new_chunk) => new_chunk,
+                    None => return,
+                };
+
+                let can_merge_with_next = self
+                    .list
+                    .get(index + 1)
+                    .map(|c| c.len() + new_chunk.len() < MAX_CHUNK_SIZE)
+                    .unwrap_or(false);
+
+                if can_merge_with_next {
+                    new_chunk.append(self.list.get_mut(index + 1).unwrap());
+                    self.list[index + 1] = new_chunk
+                } else {
+                    self.list.insert(index + 1, new_chunk);
+                }
+            }
+            Err(index) => {
+                if let Some(prev) = index.checked_sub(1) {
+                    let next_size = self.list.get(index).map(|c| c.len());
+
+                    let prev_chunk = &mut self.list[prev];
+
+                    let next_is_less_busy = next_size
+                        .map(|next_size| next_size < prev_chunk.len())
+                        .unwrap_or(false);
+
+                    if !next_is_less_busy && prev_chunk.len() < MAX_CHUNK_SIZE {
+                        let new = prev_chunk.insert(key, value);
+                        debug_assert!(new.is_none());
+                        return;
+                    }
+                };
+
+                if self.list.len() == index {
+                    self.list.push(Chunk::new_with_element(key, value));
+                    return;
+                }
+
+                let chunk = &mut self.list[index];
+
+                if chunk.len() < MAX_CHUNK_SIZE {
+                    let new = chunk.insert(key, value);
+                    debug_assert!(new.is_none());
+                    return;
+                }
+
+                let chunk = Chunk::new_with_element(key, value);
+                self.list.insert(index, chunk);
+            }
+        }
+    }
+
+    fn binary_search(&self, key: &K) -> Result<usize, usize> {
+        let key = *key;
+
+        self.list.binary_search_by(|chunk| {
+            if chunk.min > key {
+                std::cmp::Ordering::Greater
+            } else if chunk.max < key {
+                std::cmp::Ordering::Less
+            } else {
+                std::cmp::Ordering::Equal
+            }
+        })
+    }
+
+    #[cfg(test)]
+    fn assert_correct(&self) {
+        let mut prev_chunk = Option::<(K, K)>::None;
+
+        for chunk in &self.list {
+            if let Some(prev_chunk) = prev_chunk {
+                assert!(prev_chunk.0 < chunk.min);
+                assert!(prev_chunk.1 < chunk.max);
+            };
+
+            assert!(chunk.min <= chunk.max);
+            assert_eq!(chunk.min, chunk.inner[0].0);
+            assert_eq!(chunk.max, chunk.inner.last().unwrap().0);
+
+            let mut prev = None;
+            for item in &chunk.inner {
+                if let Some(prev) = prev {
+                    assert!(prev < item.0);
+                }
+                prev = Some(item.0);
+            }
+
+            prev_chunk = Some((chunk.min, chunk.max));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sorted_map() {
+        let mut map = SortedMap::default();
+
+        map.insert(101, 101);
+        map.insert(110, 110);
+        map.insert(100, 100);
+        map.insert(100, 100);
+        map.insert(102, 102);
+
+        assert_eq!(map.list.len(), 1);
+
+        map.insert(104, 104);
+        assert_eq!(map.list.len(), 2);
+
+        map.insert(114, 114);
+        map.insert(200, 200);
+        assert_eq!(map.list.len(), 2);
+        map.insert(201, 201);
+        assert_eq!(map.list.len(), 3);
+        map.insert(120, 120);
+        map.insert(119, 119);
+        map.insert(115, 115);
+        map.insert(116, 116);
+
+        map.insert(117, 117);
+        map.insert(117, 1117);
+
+        assert_eq!(map.list.len(), 4);
+
+        map.insert(99, 99);
+        assert_eq!(map.list.len(), 4);
+        map.insert(98, 98);
+        assert_eq!(map.list.len(), 5);
+
+        println!("MAP={:#?}", map);
+
+        map.assert_correct();
+
+        map.remove(&200);
+        map.remove(&120);
+        assert_eq!(map.list.len(), 5);
+        map.assert_correct();
+        map.remove(&201);
+        assert_eq!(map.list.len(), 4);
+
+        map.remove(&98);
+        map.assert_correct();
+        assert_eq!(map.list.len(), 3);
+
+        map.remove(&104);
+        map.remove(&110);
+        map.assert_correct();
+        assert_eq!(map.list.len(), 3);
+        map.remove(&114);
+        assert_eq!(map.list.len(), 2);
+
+        println!("MAP={:#?}", map);
+
+        map.assert_correct();
+    }
+
+    #[test]
+    fn test_sorted_map_big() {
+        let mut map = SortedMap::default();
+
+        for index in 0..100_000 {
+            map.insert(index, index);
+        }
+        map.assert_correct();
+
+        assert_eq!(map.list.len(), 25_000);
+    }
+
+    #[test]
+    fn test_sorted_map_big_revert() {
+        let mut map = SortedMap::default();
+
+        for index in 0..100_000 {
+            map.insert(100_000 - index, index);
+        }
+        map.assert_correct();
+
+        assert_eq!(map.list.len(), 25_000);
+    }
+}

--- a/tezos/context/src/gc/sorted_map.rs
+++ b/tezos/context/src/gc/sorted_map.rs
@@ -36,7 +36,7 @@ use crate::kv_store::HashId;
 
 /// This affects both performance and memory usage
 /// 1_000 seems to be a good value.
-const DEFAULT_CHUNK_SIZE: usize = 1_000;
+pub const DEFAULT_CHUNK_SIZE: usize = 1_000;
 
 const fn const_split_at(chunk_size: usize) -> usize {
     (chunk_size / 2) + (chunk_size / 4)
@@ -55,7 +55,9 @@ assert_eq_size!([u8; 40], Chunk<HashId, Arc<[u8]>, 1>);
 assert_eq_size!([u8; 24], (HashId, Arc<[u8]>));
 assert_eq_size!([u8; 48], [(HashId, Arc<[u8]>); 2]);
 
-pub struct SortedMap<K, V, const CHUNK_SIZE: usize = DEFAULT_CHUNK_SIZE>
+// TODO: Use const default when the feature is stabilized, it will be in 1.59.0:
+// https://github.com/rust-lang/rust/pull/90207
+pub struct SortedMap<K, V, const CHUNK_SIZE: usize>
 where
     K: Ord,
 {
@@ -502,7 +504,7 @@ mod tests {
             fn remove(&mut self, key: &K) -> Option<V>;
         }
 
-        impl_container!(SortedMap<K, V>);
+        impl_container!(SortedMap<K, V, DEFAULT_CHUNK_SIZE>);
         impl_container!(BTreeMap<K, V>);
         impl_container!(HashMap<K, V>);
 

--- a/tezos/context/src/gc/worker.rs
+++ b/tezos/context/src/gc/worker.rs
@@ -37,7 +37,7 @@ pub(crate) enum Command {
         new_ids: ChunkedVec<HashId>,
     },
     MarkReused {
-        reused: Vec<HashId>,
+        reused: ChunkedVec<HashId>,
     },
     Close,
 }
@@ -280,7 +280,7 @@ impl GCThread {
         GC_PENDING_HASHIDS.store(self.pending.len(), Ordering::Release);
     }
 
-    fn mark_reused(&mut self, mut reused: Vec<HashId>) {
+    fn mark_reused(&mut self, mut reused: ChunkedVec<HashId>) {
         GC_PENDING_HASHIDS.store(self.pending.len(), Ordering::Release);
 
         let mut none = 0;

--- a/tezos/context/src/gc/worker.rs
+++ b/tezos/context/src/gc/worker.rs
@@ -315,6 +315,6 @@ impl GCThread {
         for store in self.cycles.list.iter_mut() {
             store.shrink_to_fit();
         }
-        println!("SORTED_MAPS SHRINK IN {:?}", now.elapsed());
+        println!("SHRINK IN {:?}", now.elapsed());
     }
 }

--- a/tezos/context/src/gc/worker.rs
+++ b/tezos/context/src/gc/worker.rs
@@ -33,7 +33,7 @@ pub(crate) struct GCThread {
 
 pub(crate) enum Command {
     StartNewCycle {
-        values_in_cycle: SortedMap<HashId, Arc<[u8]>>,
+        values_in_cycle: ChunkedVec<(HashId, Arc<[u8]>)>,
         new_ids: ChunkedVec<HashId>,
     },
     MarkReused {
@@ -192,12 +192,14 @@ impl GCThread {
 
     fn start_new_cycle(
         &mut self,
-        new_cycle: SortedMap<HashId, Arc<[u8]>>,
+        mut new_cycle: ChunkedVec<(HashId, Arc<[u8]>)>,
         new_ids: ChunkedVec<HashId>,
     ) {
         GC_PENDING_HASHIDS.store(self.pending.len(), Ordering::Release);
 
         let mut hashid_without_value = Vec::with_capacity(1024);
+
+        let new_cycle = new_cycle.into_sorted_map();
 
         // let mut without_value = 0;
 

--- a/tezos/context/src/gc/worker.rs
+++ b/tezos/context/src/gc/worker.rs
@@ -310,5 +310,11 @@ impl GCThread {
         );
 
         self.send_pending();
+
+        let now = std::time::Instant::now();
+        for store in self.cycles.list.iter_mut() {
+            store.shrink_to_fit();
+        }
+        println!("SORTED_MAPS SHRINK IN {:?}", now.elapsed());
     }
 }

--- a/tezos/context/src/gc/worker.rs
+++ b/tezos/context/src/gc/worker.rs
@@ -146,6 +146,9 @@ impl GCThread {
             self.recv.len(),
             msg
         );
+
+        let mut total = 0;
+
         for (index, c) in self.cycles.list.iter().enumerate() {
             // let n_none = c
             //     .values()
@@ -159,8 +162,14 @@ impl GCThread {
             // );
 
             println!("CYCLE[{:?}]_LENGTH={:?}", index, c.len(),);
+
+            total += c.len();
         }
-        println!("PENDING={:?}", self.pending.len());
+        println!(
+            "PENDING={:?} TOTAL_IN_CYCLES={:?}",
+            self.pending.len(),
+            total
+        );
     }
 
     fn start_new_cycle(

--- a/tezos/context/src/gc/worker.rs
+++ b/tezos/context/src/gc/worker.rs
@@ -15,7 +15,7 @@ use crate::{chunks::ChunkedVec, kv_store::HashId, serialize::in_memory::iter_has
 
 use tezos_spsc::Producer;
 
-use super::sorted_map::SortedMap;
+use super::SortedMap;
 
 pub(crate) const PRESERVE_CYCLE_COUNT: usize = 7;
 

--- a/tezos/context/src/gc/worker.rs
+++ b/tezos/context/src/gc/worker.rs
@@ -95,7 +95,7 @@ impl Cycles {
             eprintln!("GC: Failed to insert value in Cycles")
         }
 
-        Some(value)
+        value
     }
 
     fn roll(&mut self, new_cycle: BTreeMap<HashId, Arc<[u8]>>) -> Vec<HashId> {

--- a/tezos/context/src/gc/worker.rs
+++ b/tezos/context/src/gc/worker.rs
@@ -135,12 +135,18 @@ impl GCThread {
         new_ids: ChunkedVec<HashId>,
     ) {
         GC_PENDING_HASHIDS.store(self.pending.len(), Ordering::Release);
+
+        let mut without_value = 0;
+
         for hash_id in new_ids.iter() {
             new_cycle.entry(*hash_id).or_insert_with(|| {
-                println!("GC_WORKER: Got HashId without value");
+                without_value += 1;
                 None
             });
         }
+
+        println!("GC_WORKER: Got HashId without value: {:?}", without_value);
+
         let unused = self.cycles.roll(new_cycle);
         self.send_unused(unused);
     }

--- a/tezos/context/src/gc/worker.rs
+++ b/tezos/context/src/gc/worker.rs
@@ -78,7 +78,7 @@ impl Cycles {
     }
 
     fn roll(&mut self, new_cycle: BTreeMap<HashId, Option<Arc<[u8]>>>) -> Vec<HashId> {
-        let unused = self.list.pop_front().unwrap_or_else(BTreeMap::new);
+        let unused = self.list.pop_front().unwrap_or_default();
         self.list.push_back(new_cycle);
 
         let mut vec = Vec::with_capacity(unused.len());
@@ -92,6 +92,7 @@ impl Cycles {
 impl GCThread {
     pub(crate) fn run(mut self) {
         loop {
+            self.debug();
             match self.recv.recv() {
                 Ok(Command::StartNewCycle {
                     values_in_cycle,
@@ -109,6 +110,14 @@ impl GCThread {
             }
         }
         eprintln!("GC exited");
+    }
+
+    fn debug(&self) {
+        println!("CYCLES_LENGTH = {:?}", self.cycles.list.len());
+        for (index, c) in self.cycles.list.iter().enumerate() {
+            println!("CYCLE[{:?}]_LENGTH = {:?}", index, c.len());
+        }
+        println!("PENDING={:?}", self.pending.len());
     }
 
     fn start_new_cycle(

--- a/tezos/context/src/gc/worker.rs
+++ b/tezos/context/src/gc/worker.rs
@@ -140,18 +140,25 @@ impl GCThread {
             Err(_) => "ERR".to_owned(),
         };
 
-        println!("CYCLES_LENGTH = {:?} MSG={:?}", self.cycles.list.len(), msg);
+        println!(
+            "CYCLES_LENGTH={:?} NMSG={:?} MSG={:?}",
+            self.cycles.list.len(),
+            self.recv.len(),
+            msg
+        );
         for (index, c) in self.cycles.list.iter().enumerate() {
-            let n_none = c
-                .values()
-                .fold(0, |acc, n| if n.is_none() { acc + 1 } else { acc });
+            // let n_none = c
+            //     .values()
+            //     .fold(0, |acc, n| if n.is_none() { acc + 1 } else { acc });
 
-            println!(
-                "CYCLE[{:?}]_LENGTH = {:?} NONE={:?}",
-                index,
-                c.len(),
-                n_none
-            );
+            // println!(
+            //     "CYCLE[{:?}]_LENGTH = {:?} NONE={:?}",
+            //     index,
+            //     c.len(),
+            //     n_none
+            // );
+
+            println!("CYCLE[{:?}]_LENGTH={:?}", index, c.len(),);
         }
         println!("PENDING={:?}", self.pending.len());
     }

--- a/tezos/context/src/gc/worker.rs
+++ b/tezos/context/src/gc/worker.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 use std::{
-    collections::{BTreeMap, VecDeque},
+    collections::VecDeque,
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc,
@@ -17,7 +17,7 @@ use tezos_spsc::Producer;
 
 use super::sorted_map::SortedMap;
 
-pub(crate) const PRESERVE_CYCLE_COUNT: usize = 8;
+pub(crate) const PRESERVE_CYCLE_COUNT: usize = 7;
 
 /// Used for statistics
 ///
@@ -108,7 +108,7 @@ impl Cycles {
             store.shrink_to_fit();
         }
 
-        unused.to_vec()
+        unused.keys_to_vec()
         // let mut vec = Vec::with_capacity(unused.len());
         // for id in unused.keys() {
         //     vec.push(*id);
@@ -179,7 +179,7 @@ impl GCThread {
             //     n_none
             // );
 
-            println!("CYCLE[{:?}]_LENGTH={:?}", index, c.len(),);
+            println!("CYCLE[{:?}]_LENGTH={:?}", index, c);
 
             total += c.len();
         }
@@ -192,7 +192,7 @@ impl GCThread {
 
     fn start_new_cycle(
         &mut self,
-        mut new_cycle: SortedMap<HashId, Arc<[u8]>>,
+        new_cycle: SortedMap<HashId, Arc<[u8]>>,
         new_ids: ChunkedVec<HashId>,
     ) {
         GC_PENDING_HASHIDS.store(self.pending.len(), Ordering::Release);

--- a/tezos/context/src/initializer.rs
+++ b/tezos/context/src/initializer.rs
@@ -64,7 +64,9 @@ fn spawn_reload_database(
     let (sender, recv) = std::sync::mpsc::channel();
 
     let result = thread.spawn(move || {
+        let start_time = std::time::Instant::now();
         log!("Reloading context");
+
         let mut repository = match repository.write() {
             Ok(repository) => repository,
             Err(e) => {
@@ -81,7 +83,7 @@ fn spawn_reload_database(
         if let Err(e) = repository.reload_database() {
             elog!("Failed to reload repository: {:?}", e);
         }
-        log!("Context reloaded");
+        log!("Context reloaded in {:?}", start_time.elapsed());
     });
 
     // Wait for the spawned thread to lock the repository.

--- a/tezos/context/src/kv_store/in_memory.rs
+++ b/tezos/context/src/kv_store/in_memory.rs
@@ -23,6 +23,7 @@ use tezos_timing::{RepositoryMemoryUsage, SerializeStats};
 use crate::{
     chunks::ChunkedVec,
     gc::{
+        sorted_map::SortedMap,
         worker::{Command, Cycles, GCThread, GC_PENDING_HASHIDS, PRESERVE_CYCLE_COUNT},
         GarbageCollectionError, GarbageCollector,
     },
@@ -174,7 +175,7 @@ impl HashValueStore {
 }
 
 pub struct InMemory {
-    current_cycle: BTreeMap<HashId, Arc<[u8]>>,
+    current_cycle: SortedMap<HashId, Arc<[u8]>>,
     pub hashes: HashValueStore,
     sender: Option<Sender<Command>>,
     pub context_hashes: Map<u64, HashId>,

--- a/tezos/context/src/kv_store/in_memory.rs
+++ b/tezos/context/src/kv_store/in_memory.rs
@@ -383,6 +383,7 @@ impl InMemory {
                         recv,
                         free_ids: prod,
                         pending: Vec::new(),
+                        debug: false,
                     }
                     .run()
                 })?;
@@ -558,7 +559,7 @@ impl InMemory {
         &mut self,
         mut batch: ChunkedVec<(HashId, Arc<[u8]>)>,
     ) -> Result<(), DBError> {
-        while let Some(chunk) = batch.take_first() {
+        while let Some(chunk) = batch.pop_first_chunk() {
             for (hash_id, value) in chunk.into_iter() {
                 self.hashes.insert_value_at(hash_id, Arc::clone(&value))?;
                 self.current_cycle.push((hash_id, value));

--- a/tezos/context/src/kv_store/in_memory.rs
+++ b/tezos/context/src/kv_store/in_memory.rs
@@ -415,7 +415,7 @@ impl InMemory {
             let mut ondisk = Persistent::try_new(PersistentConfiguration {
                 db_path: Some("/tmp/tezedge/context".to_string()),
                 // db_path: Some("/home/sebastien/tmp/replay/context".to_string()),
-                startup_check: true,
+                startup_check: false,
                 read_mode: true,
             })
             .unwrap();

--- a/tezos/context/src/kv_store/in_memory.rs
+++ b/tezos/context/src/kv_store/in_memory.rs
@@ -351,7 +351,7 @@ impl KeyValueStoreBackend for InMemory {
         batch: &[(HashId, Arc<[u8]>)],
         _output: &[u8],
     ) -> Result<Option<AbsoluteOffset>, DBError> {
-        let mut vec = ChunkedVec::with_chunk_capacity(batch.len());
+        let mut vec = ChunkedVec::with_chunk_capacity(batch.len().max(1000));
         for item in batch {
             vec.push(item.clone());
         }

--- a/tezos/context/src/kv_store/in_memory.rs
+++ b/tezos/context/src/kv_store/in_memory.rs
@@ -161,8 +161,8 @@ impl HashValueStore {
     }
 
     fn take_new_ids(&mut self) -> Vec<HashId> {
-        let new_ids = self.new_ids.clone();
-        self.new_ids.clear();
+        let new_ids = std::mem::take(&mut self.new_ids);
+        self.new_ids = Vec::with_capacity(128 * 1024);
         new_ids
     }
 }

--- a/tezos/context/src/kv_store/in_memory.rs
+++ b/tezos/context/src/kv_store/in_memory.rs
@@ -351,7 +351,11 @@ impl KeyValueStoreBackend for InMemory {
         batch: &[(HashId, Arc<[u8]>)],
         _output: &[u8],
     ) -> Result<Option<AbsoluteOffset>, DBError> {
-        self.write_batch(batch.to_vec())?;
+        let mut vec = ChunkedVec::with_chunk_capacity(batch.len());
+        for item in batch {
+            vec.push(item.clone());
+        }
+        self.write_batch(vec)?;
         Ok(None)
     }
 }

--- a/tezos/context/src/kv_store/in_memory.rs
+++ b/tezos/context/src/kv_store/in_memory.rs
@@ -168,9 +168,6 @@ impl HashValueStore {
             &mut self.new_ids,
             ChunkedVec::with_chunk_capacity(512 * 1024),
         )
-        // let new_ids = self.new_ids;
-        // let new_ids = std::mem::take(&mut self.new_ids);
-        // self.new_ids = ChunkedVec::with_chunk_capacity(512 * 1024);
     }
 }
 
@@ -412,6 +409,7 @@ impl InMemory {
         })
     }
 
+    /// Reload context from disk
     fn reload_database(&mut self) -> Result<(), ReloadError> {
         let (tree, parent_hash, commit) = {
             let mut ondisk = Persistent::try_new(PersistentConfiguration {
@@ -574,7 +572,6 @@ impl InMemory {
                 &mut self.current_cycle,
                 ChunkedVec::with_chunk_capacity(512 * 1024),
             );
-            // let values_in_cycle = std::mem::take(&mut self.current_cycle);
             let new_ids = self.hashes.take_new_ids();
 
             if let Err(e) = sender.try_send(Command::StartNewCycle {

--- a/tezos/context/src/kv_store/in_memory.rs
+++ b/tezos/context/src/kv_store/in_memory.rs
@@ -23,7 +23,6 @@ use tezos_timing::{RepositoryMemoryUsage, SerializeStats};
 use crate::{
     chunks::ChunkedVec,
     gc::{
-        sorted_map::SortedMap,
         worker::{Command, Cycles, GCThread, GC_PENDING_HASHIDS, PRESERVE_CYCLE_COUNT},
         GarbageCollectionError, GarbageCollector,
     },
@@ -192,7 +191,7 @@ impl GarbageCollector for InMemory {
 
     fn block_applied(
         &mut self,
-        referenced_older_objects: Vec<HashId>,
+        referenced_older_objects: ChunkedVec<HashId>,
     ) -> Result<(), GarbageCollectionError> {
         self.block_applied(referenced_older_objects);
         Ok(())
@@ -586,7 +585,7 @@ impl InMemory {
         }
     }
 
-    pub fn block_applied(&mut self, reused: Vec<HashId>) {
+    pub fn block_applied(&mut self, reused: ChunkedVec<HashId>) {
         if let Some(sender) = &self.sender {
             if let Err(e) = sender.send(Command::MarkReused { reused }) {
                 eprintln!("Fail to send Command::MarkReused to GC worker: {:?}", e);

--- a/tezos/context/src/kv_store/in_memory.rs
+++ b/tezos/context/src/kv_store/in_memory.rs
@@ -117,8 +117,10 @@ impl HashValueStore {
 
     pub(crate) fn get_vacant_object_hash(&mut self) -> Result<VacantObjectHash, HashIdError> {
         let (hash_id, entry) = if let Some(free_id) = self.get_free_id() {
-            if let Some(old_value) = self.values.set(free_id, None)? {
-                self.values_bytes = self.values_bytes.saturating_sub(old_value.len());
+            if self.values.contains_key(free_id)? {
+                if let Some(old_value) = self.values.set(free_id, None)? {
+                    self.values_bytes = self.values_bytes.saturating_sub(old_value.len());
+                }
             }
             (free_id, self.hashes.get_mut(free_id)?.ok_or(HashIdError)?)
         } else {

--- a/tezos/context/src/kv_store/in_memory.rs
+++ b/tezos/context/src/kv_store/in_memory.rs
@@ -5,7 +5,7 @@
 
 use std::{
     borrow::Cow,
-    collections::{hash_map::DefaultHasher, BTreeMap, VecDeque},
+    collections::{hash_map::DefaultHasher, VecDeque},
     hash::Hasher,
     mem::size_of,
     rc::Rc,
@@ -163,14 +163,13 @@ impl HashValueStore {
     }
 
     fn take_new_ids(&mut self) -> ChunkedVec<HashId> {
-        let new_ids = std::mem::replace(
+        std::mem::replace(
             &mut self.new_ids,
             ChunkedVec::with_chunk_capacity(512 * 1024),
-        );
+        )
         // let new_ids = self.new_ids;
         // let new_ids = std::mem::take(&mut self.new_ids);
         // self.new_ids = ChunkedVec::with_chunk_capacity(512 * 1024);
-        new_ids
     }
 }
 

--- a/tezos/context/src/kv_store/in_memory.rs
+++ b/tezos/context/src/kv_store/in_memory.rs
@@ -174,7 +174,7 @@ impl HashValueStore {
 }
 
 pub struct InMemory {
-    current_cycle: BTreeMap<HashId, Option<Arc<[u8]>>>,
+    current_cycle: BTreeMap<HashId, Arc<[u8]>>,
     pub hashes: HashValueStore,
     sender: Option<Sender<Command>>,
     pub context_hashes: Map<u64, HashId>,
@@ -551,7 +551,7 @@ impl InMemory {
     pub fn write_batch(&mut self, batch: Vec<(HashId, Arc<[u8]>)>) -> Result<(), DBError> {
         for (hash_id, value) in batch {
             self.hashes.insert_value_at(hash_id, Arc::clone(&value))?;
-            self.current_cycle.insert(hash_id, Some(value));
+            self.current_cycle.insert(hash_id, value);
         }
         Ok(())
     }

--- a/tezos/context/src/kv_store/in_memory.rs
+++ b/tezos/context/src/kv_store/in_memory.rs
@@ -98,6 +98,7 @@ impl HashValueStore {
             strings_total_bytes,
             shapes_total_bytes,
             commit_index_total_bytes,
+            new_ids_cap: self.new_ids.capacity(),
         }
     }
 

--- a/tezos/context/src/kv_store/in_memory.rs
+++ b/tezos/context/src/kv_store/in_memory.rs
@@ -242,7 +242,7 @@ impl KeyValueStoreBackend for InMemory {
     fn memory_usage(&self) -> RepositoryMemoryUsage {
         let strings_total_bytes = self.string_interner.memory_usage().total_bytes;
         let shapes_total_bytes = self.shapes.total_bytes();
-        let commit_index_total_bytes = self.context_hashes.capacity()
+        let commit_index_total_bytes = self.context_hashes.len()
             * (std::mem::size_of::<HashId>() + std::mem::size_of::<u64>());
 
         self.hashes.get_memory_usage(

--- a/tezos/context/src/kv_store/index_map.rs
+++ b/tezos/context/src/kv_store/index_map.rs
@@ -67,6 +67,11 @@ impl<K, V> IndexMap<K, V>
 where
     K: TryInto<usize>,
 {
+    pub fn contains_key(&mut self, key: K) -> Result<bool, K::Error> {
+        let index = key.try_into()?;
+        Ok(index < self.entries.len())
+    }
+
     pub fn set(&mut self, key: K, value: V) -> Result<V, K::Error> {
         Ok(std::mem::replace(&mut self.entries[key.try_into()?], value))
     }

--- a/tezos/context/src/kv_store/mod.rs
+++ b/tezos/context/src/kv_store/mod.rs
@@ -18,8 +18,8 @@ pub mod readonly_ipc;
 
 pub const INMEM: &str = "inmem";
 
-#[bitfield]
 #[allow(dead_code)]
+#[bitfield]
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 struct NonZero6BytesInner {
     bytes: B48,
@@ -44,10 +44,16 @@ impl NonZero6Bytes {
             })
         }
     }
+
+    // This avoid having compilation warnings
+    #[allow(dead_code)]
+    fn unused(self) {
+        NonZero6BytesInner::from_bytes(self.inner.into_bytes());
+    }
 }
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct HashId(NonZero6Bytes); // NonZeroU64 so that `Option<HashId>` is 8 bytes
+pub struct HashId(NonZero6Bytes);
 
 #[derive(Debug)]
 pub struct HashIdError;

--- a/tezos/context/src/kv_store/persistent.rs
+++ b/tezos/context/src/kv_store/persistent.rs
@@ -32,7 +32,7 @@ use crate::{
         },
         get_commit_hash,
         lock::Lock,
-        DBError, Flushable, KeyValueStoreBackend, Persistable, ReadStatistics,
+        DBError, Flushable, KeyValueStoreBackend, Persistable, ReadStatistics, ReloadError,
     },
     serialize::{
         deserialize_hash_id,
@@ -900,7 +900,7 @@ fn serialize_context_hash(
 }
 
 impl KeyValueStoreBackend for Persistent {
-    fn reload_database(&mut self) -> Result<(), DBError> {
+    fn reload_database(&mut self) -> Result<(), ReloadError> {
         if let Err(e) = self.reload_database() {
             elog!("Failed to reload database: {:?}", e);
             return Err(e.into());

--- a/tezos/context/src/kv_store/persistent.rs
+++ b/tezos/context/src/kv_store/persistent.rs
@@ -957,7 +957,7 @@ impl KeyValueStoreBackend for Persistent {
         let strings_total_bytes = self.string_interner.memory_usage().total_bytes;
         let hashes_capacity = self.hashes.in_memory.total_capacity();
         let shapes_total_bytes = self.shapes.total_bytes();
-        let commit_index_total_bytes = self.context_hashes.capacity()
+        let commit_index_total_bytes = self.context_hashes.len()
             * (std::mem::size_of::<ObjectReference>() + std::mem::size_of::<u64>());
 
         let total_bytes = (hashes_capacity * std::mem::size_of::<ObjectHash>())

--- a/tezos/context/src/kv_store/persistent.rs
+++ b/tezos/context/src/kv_store/persistent.rs
@@ -978,6 +978,7 @@ impl KeyValueStoreBackend for Persistent {
             strings_total_bytes,
             shapes_total_bytes,
             commit_index_total_bytes,
+            new_ids_cap: 0,
         }
     }
 

--- a/tezos/context/src/kv_store/readonly_ipc.rs
+++ b/tezos/context/src/kv_store/readonly_ipc.rs
@@ -17,7 +17,9 @@ use slog::{error, info};
 use tezos_timing::{RepositoryMemoryUsage, SerializeStats};
 use thiserror::Error;
 
-use crate::persistent::{get_commit_hash, DBError, Flushable, Persistable, ReadStatistics};
+use crate::persistent::{
+    get_commit_hash, DBError, Flushable, Persistable, ReadStatistics, ReloadError,
+};
 
 use crate::serialize::{in_memory, persistent, ObjectHeader};
 use crate::working_tree::shape::{DirectoryShapeId, ShapeStrings};
@@ -60,7 +62,7 @@ impl ReadonlyIpcBackend {
 impl NotGarbageCollected for ReadonlyIpcBackend {}
 
 impl KeyValueStoreBackend for ReadonlyIpcBackend {
-    fn reload_database(&mut self) -> Result<(), DBError> {
+    fn reload_database(&mut self) -> Result<(), ReloadError> {
         Ok(())
     }
 

--- a/tezos/context/src/lib.rs
+++ b/tezos/context/src/lib.rs
@@ -148,6 +148,7 @@ use std::array::TryFromSliceError;
 use std::num::TryFromIntError;
 use std::sync::PoisonError;
 
+use chunks::ChunkedVec;
 use gc::GarbageCollectionError;
 pub use kv_store::persistent::Persistent;
 use kv_store::HashId;
@@ -217,7 +218,10 @@ pub trait IndexApi<T: ShellContextApi + ProtocolContextApi> {
     // checkout context for hash
     fn checkout(&self, context_hash: &ContextHash) -> Result<Option<T>, ContextError>;
     // called after a block is applied
-    fn block_applied(&self, referenced_older_objects: Vec<HashId>) -> Result<(), ContextError>;
+    fn block_applied(
+        &self,
+        referenced_older_objects: ChunkedVec<HashId>,
+    ) -> Result<(), ContextError>;
     // called when a new cycle starts
     fn cycle_started(&mut self) -> Result<(), ContextError>;
     // get value for key from a point in history indicated by context hash

--- a/tezos/context/src/lib.rs
+++ b/tezos/context/src/lib.rs
@@ -460,4 +460,3 @@ impl std::hash::Hasher for NoHash {
 /// Since the keys are already integers, they do not need to be hashed.
 /// This `Map` will not call any hashing algorithm.
 pub type Map<K, V> = std::collections::BTreeMap<K, V>;
-// pub type Map<K, V> = std::collections::HashMap<K, V, NoHash>;

--- a/tezos/context/src/lib.rs
+++ b/tezos/context/src/lib.rs
@@ -459,4 +459,5 @@ impl std::hash::Hasher for NoHash {
 /// This is useful when the keys of the map are integers (u8, u32, u64, etc.)
 /// Since the keys are already integers, they do not need to be hashed.
 /// This `Map` will not call any hashing algorithm.
-pub type Map<K, V> = std::collections::HashMap<K, V, NoHash>;
+pub type Map<K, V> = std::collections::BTreeMap<K, V>;
+// pub type Map<K, V> = std::collections::HashMap<K, V, NoHash>;

--- a/tezos/context/src/persistent/mod.rs
+++ b/tezos/context/src/persistent/mod.rs
@@ -171,6 +171,33 @@ impl Default for ReadStatistics {
     }
 }
 
+#[derive(Debug, Error)]
+pub enum ReloadError {
+    #[error("Initialization error {error}")]
+    Init {
+        #[from]
+        error: IndexInitializationError,
+    },
+    #[error("DBError {error}")]
+    DBError {
+        #[from]
+        error: DBError,
+    },
+    // #[error("ContextError {error}")]
+    // ContextError {
+    //     #[from]
+    //     error: ContextError,
+    // },
+}
+
+impl From<ContextError> for ReloadError {
+    fn from(e: ContextError) -> Self {
+        ReloadError::DBError {
+            error: DBError::ContextError { error: Box::new(e) },
+        }
+    }
+}
+
 /// Possible errors for schema
 #[derive(Debug, Error)]
 pub enum DBError {

--- a/tezos/context/src/serialize/in_memory.rs
+++ b/tezos/context/src/serialize/in_memory.rs
@@ -11,6 +11,7 @@ use static_assertions::assert_eq_size;
 use tezos_timing::SerializeStats;
 
 use crate::{
+    chunks::ChunkedVec,
     kv_store::HashId,
     serialize::{deserialize_hash_id, ObjectHeader, ObjectTag},
     working_tree::{
@@ -182,7 +183,7 @@ pub fn serialize_object(
     storage: &Storage,
     strings: &StringInterner,
     stats: &mut SerializeStats,
-    batch: &mut Vec<(HashId, Arc<[u8]>)>,
+    batch: &mut ChunkedVec<(HashId, Arc<[u8]>)>,
     referenced_older_objects: &mut Vec<HashId>,
     repository: &mut ContextKeyValueStore,
     _object_offset: Option<AbsoluteOffset>,
@@ -268,7 +269,7 @@ fn serialize_inode(
     storage: &Storage,
     strings: &StringInterner,
     stats: &mut SerializeStats,
-    batch: &mut Vec<(HashId, Arc<[u8]>)>,
+    batch: &mut ChunkedVec<(HashId, Arc<[u8]>)>,
     referenced_older_objects: &mut Vec<HashId>,
     repository: &mut ContextKeyValueStore,
 ) -> Result<(), SerializationError> {

--- a/tezos/context/src/serialize/in_memory.rs
+++ b/tezos/context/src/serialize/in_memory.rs
@@ -184,7 +184,7 @@ pub fn serialize_object(
     strings: &StringInterner,
     stats: &mut SerializeStats,
     batch: &mut ChunkedVec<(HashId, Arc<[u8]>)>,
-    referenced_older_objects: &mut Vec<HashId>,
+    referenced_older_objects: &mut ChunkedVec<HashId>,
     repository: &mut ContextKeyValueStore,
     _object_offset: Option<AbsoluteOffset>,
 ) -> Result<Option<AbsoluteOffset>, SerializationError> {
@@ -270,7 +270,7 @@ fn serialize_inode(
     strings: &StringInterner,
     stats: &mut SerializeStats,
     batch: &mut ChunkedVec<(HashId, Arc<[u8]>)>,
-    referenced_older_objects: &mut Vec<HashId>,
+    referenced_older_objects: &mut ChunkedVec<HashId>,
     repository: &mut ContextKeyValueStore,
 ) -> Result<(), SerializationError> {
     use SerializationError::*;

--- a/tezos/context/src/serialize/in_memory.rs
+++ b/tezos/context/src/serialize/in_memory.rs
@@ -304,8 +304,8 @@ fn serialize_inode(
             // Make sure that INODE_POINTERS_NBYTES_TO_HASHES is correct.
             debug_assert_eq!(output.len(), INODE_POINTERS_NBYTES_TO_HASHES);
 
-            for (_, index) in pointers.iter() {
-                let pointer = storage.pointer_copy(index)?;
+            for (_, thin_pointer_id) in pointers.iter() {
+                let pointer = storage.pointer_copy(thin_pointer_id)?;
                 let hash_id = storage
                     .pointer_retrieve_hashid(&pointer, repository)?
                     .ok_or(MissingHashId)?;
@@ -316,8 +316,8 @@ fn serialize_inode(
             batch.push((hash_id, Arc::from(output.as_slice())));
 
             // Recursively serialize all children
-            for (_, index) in pointers.iter() {
-                let pointer = storage.pointer_copy(index)?;
+            for (_, thin_pointer_id) in pointers.iter() {
+                let pointer = storage.pointer_copy(thin_pointer_id)?;
 
                 let hash_id = storage
                     .pointer_retrieve_hashid(&pointer, repository)?

--- a/tezos/context/src/serialize/mod.rs
+++ b/tezos/context/src/serialize/mod.rs
@@ -11,6 +11,7 @@ use tezos_timing::SerializeStats;
 use thiserror::Error;
 
 use crate::{
+    chunks::ChunkedVec,
     hash::HashingError,
     kv_store::HashId,
     persistent::DBError,
@@ -34,16 +35,16 @@ const FULL_47_BITS: u64 = 0x7FFFFFFFFFFF;
 const FULL_31_BITS: u64 = 0x7FFFFFFF;
 
 pub type SerializeObjectSignature = fn(
-    &Object,                       // object
-    HashId,                        // object_hash_id
-    &mut Vec<u8>,                  // output
-    &Storage,                      // storage
-    &StringInterner,               // strings
-    &mut SerializeStats,           // statistics
-    &mut Vec<(HashId, Arc<[u8]>)>, // batch
-    &mut Vec<HashId>,              // referenced_older_objects
-    &mut ContextKeyValueStore,     // repository
-    Option<AbsoluteOffset>,        // offset
+    &Object,                              // object
+    HashId,                               // object_hash_id
+    &mut Vec<u8>,                         // output
+    &Storage,                             // storage
+    &StringInterner,                      // strings
+    &mut SerializeStats,                  // statistics
+    &mut ChunkedVec<(HashId, Arc<[u8]>)>, // batch
+    &mut Vec<HashId>,                     // referenced_older_objects
+    &mut ContextKeyValueStore,            // repository
+    Option<AbsoluteOffset>,               // offset
 ) -> Result<Option<AbsoluteOffset>, SerializationError>;
 
 #[derive(BitfieldSpecifier)]

--- a/tezos/context/src/serialize/mod.rs
+++ b/tezos/context/src/serialize/mod.rs
@@ -42,7 +42,7 @@ pub type SerializeObjectSignature = fn(
     &StringInterner,                      // strings
     &mut SerializeStats,                  // statistics
     &mut ChunkedVec<(HashId, Arc<[u8]>)>, // batch
-    &mut Vec<HashId>,                     // referenced_older_objects
+    &mut ChunkedVec<HashId>,              // referenced_older_objects
     &mut ContextKeyValueStore,            // repository
     Option<AbsoluteOffset>,               // offset
 ) -> Result<Option<AbsoluteOffset>, SerializationError>;

--- a/tezos/context/src/serialize/persistent.rs
+++ b/tezos/context/src/serialize/persistent.rs
@@ -12,6 +12,7 @@ use static_assertions::assert_eq_size;
 use tezos_timing::SerializeStats;
 
 use crate::{
+    chunks::ChunkedVec,
     kv_store::HashId,
     serialize::{deserialize_hash_id, serialize_hash_id, ObjectTag},
     working_tree::{
@@ -431,7 +432,7 @@ pub fn serialize_object(
     storage: &Storage,
     strings: &StringInterner,
     stats: &mut SerializeStats,
-    _batch: &mut Vec<(HashId, Arc<[u8]>)>,
+    _batch: &mut ChunkedVec<(HashId, Arc<[u8]>)>,
     _referenced_older_objects: &mut Vec<HashId>,
     repository: &mut ContextKeyValueStore,
     file_offset: Option<AbsoluteOffset>,

--- a/tezos/context/src/serialize/persistent.rs
+++ b/tezos/context/src/serialize/persistent.rs
@@ -84,7 +84,7 @@ struct CommitHeader {
 // Must fit in 1 byte
 assert_eq_size!(CommitHeader, u8);
 
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, Hash, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, Hash, PartialEq, Eq, Ord, PartialOrd)]
 pub struct AbsoluteOffset(u64);
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, Hash, PartialEq, Eq)]
 pub struct RelativeOffset(u64);

--- a/tezos/context/src/serialize/persistent.rs
+++ b/tezos/context/src/serialize/persistent.rs
@@ -1215,8 +1215,8 @@ mod tests {
         })
         .unwrap();
         let mut stats = SerializeStats::default();
-        let mut batch = Vec::new();
-        let mut older_objects = Vec::new();
+        let mut batch = ChunkedVec::with_chunk_capacity(1024);
+        let mut older_objects = ChunkedVec::with_chunk_capacity(1024);
         let fake_hash_id = HashId::try_from(1).unwrap();
 
         let offset = repo.synchronize_data(&[], &[0, 0, 0, 0, 0, 0]).unwrap();
@@ -1677,8 +1677,8 @@ mod tests {
         let mut storage = Storage::new();
         let mut strings = StringInterner::default();
         let mut stats = SerializeStats::default();
-        let mut batch = Vec::new();
-        let mut older_objects = Vec::new();
+        let mut batch = ChunkedVec::with_chunk_capacity(1024);
+        let mut older_objects = ChunkedVec::with_chunk_capacity(1024);
 
         let fake_hash_id = HashId::try_from(1).unwrap();
 

--- a/tezos/context/src/serialize/persistent.rs
+++ b/tezos/context/src/serialize/persistent.rs
@@ -433,7 +433,7 @@ pub fn serialize_object(
     strings: &StringInterner,
     stats: &mut SerializeStats,
     _batch: &mut ChunkedVec<(HashId, Arc<[u8]>)>,
-    _referenced_older_objects: &mut Vec<HashId>,
+    _referenced_older_objects: &mut ChunkedVec<HashId>,
     repository: &mut ContextKeyValueStore,
     file_offset: Option<AbsoluteOffset>,
 ) -> Result<Option<AbsoluteOffset>, SerializationError> {

--- a/tezos/context/src/tezedge_context.rs
+++ b/tezos/context/src/tezedge_context.rs
@@ -1120,8 +1120,12 @@ impl TezedgeContext {
             repository.commit(&self.tree, self.parent_commit_ref, author, message, date)?
         };
 
+        let mem = self.get_memory_usage()?;
+
+        println!("MEMORY_USAGE={:#?}", mem);
+
         send_statistics(BlockMemoryUsage {
-            context: Box::new(self.get_memory_usage()?),
+            context: Box::new(mem),
             serialize: serialize_stats,
         });
 

--- a/tezos/context/src/tezedge_context.rs
+++ b/tezos/context/src/tezedge_context.rs
@@ -1126,7 +1126,7 @@ impl TezedgeContext {
 
         let mem = self.get_memory_usage()?;
 
-        println!("MEMORY_USAGE={:#?}", mem);
+        // println!("MEMORY_USAGE={:#?}", mem);
 
         send_statistics(BlockMemoryUsage {
             context: Box::new(mem),

--- a/tezos/context/src/tezedge_context.rs
+++ b/tezos/context/src/tezedge_context.rs
@@ -1126,8 +1126,6 @@ impl TezedgeContext {
 
         let mem = self.get_memory_usage()?;
 
-        // println!("MEMORY_USAGE={:#?}", mem);
-
         send_statistics(BlockMemoryUsage {
             context: Box::new(mem),
             serialize: serialize_stats,

--- a/tezos/context/src/tezedge_context.rs
+++ b/tezos/context/src/tezedge_context.rs
@@ -15,6 +15,7 @@ use ocaml_interop::BoxRoot;
 use tezos_context_api::StringDirectoryMap;
 use tezos_timing::{BlockMemoryUsage, ContextMemoryUsage};
 
+use crate::chunks::ChunkedVec;
 use crate::{
     hash::ObjectHash,
     kv_store::HashId,
@@ -863,7 +864,10 @@ impl IndexApi<TezedgeContext> for TezedgeIndex {
         )))
     }
 
-    fn block_applied(&self, referenced_older_objects: Vec<HashId>) -> Result<(), ContextError> {
+    fn block_applied(
+        &self,
+        referenced_older_objects: ChunkedVec<HashId>,
+    ) -> Result<(), ContextError> {
         Ok(self
             .repository
             .write()?

--- a/tezos/context/src/working_tree/shape.rs
+++ b/tezos/context/src/working_tree/shape.rs
@@ -180,8 +180,8 @@ impl DirectoryShapes {
         let shape_hash = DirectoryShapeHash(hasher.finish());
 
         match self.hash_to_strings.entry(shape_hash) {
-            Occupied(entry) => Ok(Some(entry.get().0)),
-            Vacant(entry) => {
+            std::collections::btree_map::Entry::Occupied(entry) => Ok(Some(entry.get().0)),
+            std::collections::btree_map::Entry::Vacant(entry) => {
                 let start = self.shapes.len() as u64;
                 let length = self.temp.len() as u32;
 

--- a/tezos/context/src/working_tree/shape.rs
+++ b/tezos/context/src/working_tree/shape.rs
@@ -3,10 +3,7 @@
 
 use std::{
     borrow::Cow,
-    collections::{
-        hash_map::DefaultHasher,
-        hash_map::Entry::{Occupied, Vacant},
-    },
+    collections::hash_map::DefaultHasher,
     convert::{TryFrom, TryInto},
     hash::Hasher,
     io::Read,

--- a/tezos/context/src/working_tree/storage.rs
+++ b/tezos/context/src/working_tree/storage.rs
@@ -10,7 +10,7 @@ use std::{
     borrow::Cow,
     cell::{Cell, RefCell},
     cmp::Ordering,
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     convert::{TryFrom, TryInto},
     mem::size_of,
     ops::{Range, RangeInclusive},
@@ -1108,11 +1108,11 @@ pub struct Storage {
     /// because they are immutables.
     /// But those "intermediates" pointers do not need/have a `HashId`/`AbsoluteOffset`
     /// associated to them, they are required at commit time only.
-    pointers_data: RefCell<HashMap<u64, ObjectReference>>,
+    pointers_data: RefCell<BTreeMap<u64, ObjectReference>>,
     /// Objects bytes are read from disk into this vector
     pub data: Vec<u8>,
     /// Map of deserialized (from disk) offset to their `HashId`.
-    pub offsets_to_hash_id: HashMap<AbsoluteOffset, HashId>,
+    pub offsets_to_hash_id: BTreeMap<AbsoluteOffset, HashId>,
 }
 
 #[derive(Debug)]
@@ -1171,7 +1171,7 @@ impl Storage {
             nodes: IndexMap::with_chunk_capacity(DEFAULT_NODES_CAPACITY), // ~3MB
             inodes: IndexMap::with_chunk_capacity(DEFAULT_INODES_CAPACITY), // ~20MB
             data: Vec::with_capacity(100_000), // ~97KB
-            offsets_to_hash_id: HashMap::default(),
+            offsets_to_hash_id: Default::default(),
             fat_pointers: IndexMap::with_chunk_capacity(DEFAULT_FAT_POINTERS_CAPACITY), // ~262KB
             pointers_data: Default::default(),
             thin_pointers: IndexMap::with_chunk_capacity(DEFAULT_THIN_POINTERS_CAPACITY), // ~525KB
@@ -2498,7 +2498,7 @@ impl Storage {
         self.blobs = ChunkedVec::empty();
         self.inodes = IndexMap::empty();
         self.data = Vec::new();
-        self.offsets_to_hash_id = HashMap::default();
+        self.offsets_to_hash_id = Default::default();
         self.thin_pointers = IndexMap::empty();
         self.fat_pointers = IndexMap::empty();
         self.pointers_data = Default::default();

--- a/tezos/context/src/working_tree/storage.rs
+++ b/tezos/context/src/working_tree/storage.rs
@@ -1154,7 +1154,7 @@ impl Default for Storage {
 type IsNewKey = bool;
 
 const DEFAULT_DIRECTORIES_CAPACITY: usize = 512 * 1024;
-const DEFAULT_BLOBS_CAPACITY: usize = 128 * 1024;
+const DEFAULT_BLOBS_CAPACITY: usize = 256 * 1024;
 const DEFAULT_NODES_CAPACITY: usize = 128 * 1024;
 const DEFAULT_INODES_CAPACITY: usize = 32 * 1024;
 const DEFAULT_FAT_POINTERS_CAPACITY: usize = 32 * 1024;

--- a/tezos/context/src/working_tree/storage.rs
+++ b/tezos/context/src/working_tree/storage.rs
@@ -1142,6 +1142,8 @@ impl<'a> std::ops::Deref for Blob<'a> {
 
 assert_eq_size!([u32; 2], (StringId, DirEntryId));
 
+assert_eq_size!([u8; 7], Option<[u8; 6]>);
+
 impl Default for Storage {
     fn default() -> Self {
         Self::new()

--- a/tezos/context/src/working_tree/storage.rs
+++ b/tezos/context/src/working_tree/storage.rs
@@ -624,7 +624,7 @@ impl Iterator for PointersBitfieldIterator {
 
 /// Points to a subslice of `Storage::thin_pointers`
 ///
-/// An inode pointer may have 0 to 32 pointers.
+/// An inode pointer may have 1 to 32 pointers.
 /// Some might be null or not.
 /// Each pointer, when not null, has an index associated to it (0 to 31).
 ///
@@ -639,7 +639,7 @@ impl Iterator for PointersBitfieldIterator {
 /// }
 ///
 /// This `PointersId` refers to a subslice of `Storage::thin_pointers` of length
-/// 5 (they are 5 bits set in `bitfield`).
+/// 5 (there are 5 bits set in `bitfield`).
 ///
 /// The first pointer is at `start + 0`: Storage::thin_pointers[15]
 /// The second pointer is at `start + 1`: Storage::thin_pointers[16]

--- a/tezos/context/src/working_tree/string_interner.rs
+++ b/tezos/context/src/working_tree/string_interner.rs
@@ -347,7 +347,7 @@ impl StringInterner {
         let big_strings_cap = self.big_strings.strings.capacity();
 
         StringsMemoryUsage {
-            all_strings_map_cap: self.string_to_offset.capacity(),
+            all_strings_map_cap: self.string_to_offset.len(),
             all_strings_map_len: self.string_to_offset.len(),
             all_strings_cap,
             all_strings_len: self.all_strings.len(),

--- a/tezos/context/src/working_tree/working_tree.rs
+++ b/tezos/context/src/working_tree/working_tree.rs
@@ -1124,7 +1124,7 @@ impl WorkingTree {
                         data.add_older_object(dir_entry, storage, strings)?;
                         return Ok(());
                     }
-                    dir_entry.set_commited(true);
+                    // dir_entry.set_commited(true);
 
                     if let Some(offset) = data.get_dedup_object(object_hash_id) {
                         dir_entry.set_offset(offset);

--- a/tezos/context/src/working_tree/working_tree.rs
+++ b/tezos/context/src/working_tree/working_tree.rs
@@ -1125,7 +1125,6 @@ impl WorkingTree {
                         data.add_older_object(dir_entry, storage, strings)?;
                         return Ok(());
                     }
-                    // dir_entry.set_commited(true);
 
                     if let Some(offset) = data.get_dedup_object(object_hash_id) {
                         dir_entry.set_offset(offset);

--- a/tezos/context/src/working_tree/working_tree.rs
+++ b/tezos/context/src/working_tree/working_tree.rs
@@ -89,7 +89,7 @@ use super::{
 pub struct PostCommitData {
     pub commit_ref: ObjectReference,
     pub batch: ChunkedVec<(HashId, Arc<[u8]>)>,
-    pub reused: Vec<HashId>,
+    pub reused: ChunkedVec<HashId>,
     pub serialize_stats: Box<SerializeStats>,
     pub output: Vec<u8>,
 }
@@ -156,7 +156,7 @@ impl PostCommitData {
         Self {
             commit_ref: ObjectReference::new(Some(commit_hash), None),
             batch: ChunkedVec::empty(),
-            reused: Default::default(),
+            reused: ChunkedVec::empty(),
             serialize_stats: Default::default(),
             output: Default::default(),
         }
@@ -472,7 +472,7 @@ pub enum CheckObjectHashError {
 
 struct SerializingData<'a> {
     batch: ChunkedVec<(HashId, Arc<[u8]>)>,
-    referenced_older_objects: Vec<HashId>,
+    referenced_older_objects: ChunkedVec<HashId>,
     repository: &'a mut ContextKeyValueStore,
     serialized: Vec<u8>,
     stats: Box<SerializeStats>,
@@ -492,7 +492,7 @@ impl<'a> SerializingData<'a> {
     ) -> Self {
         Self {
             batch: ChunkedVec::with_chunk_capacity(8 * 1024),
-            referenced_older_objects: Vec::with_capacity(2048),
+            referenced_older_objects: ChunkedVec::with_chunk_capacity(4096),
             repository,
             serialized: Vec::with_capacity(2048),
             stats: Default::default(),

--- a/tezos/timing/src/lib.rs
+++ b/tezos/timing/src/lib.rs
@@ -238,6 +238,8 @@ pub struct RepositoryMemoryUsage {
     pub shapes_total_bytes: usize,
     /// Bytes occupied by commit index in the repository
     pub commit_index_total_bytes: usize,
+    ///
+    pub new_ids_cap: usize,
 }
 
 #[derive(Debug)]

--- a/tezos/timing/src/lib.rs
+++ b/tezos/timing/src/lib.rs
@@ -238,7 +238,7 @@ pub struct RepositoryMemoryUsage {
     pub shapes_total_bytes: usize,
     /// Bytes occupied by commit index in the repository
     pub commit_index_total_bytes: usize,
-    ///
+    /// Capacity of `HashValueStore::new_ids`
     pub new_ids_cap: usize,
 }
 


### PR DESCRIPTION
- Load the persistent context and apply blocks in memory
- Make `HashId` 6 bytes instead of 8. They are heavily used in the in-memory context and it saves memory
- Replace `HashMap` with `BTreeMap`. I don't know yet the impact on the memory usage, but it doesn't seem to change much
- Use `SortedMap` instead of `BTreeMap` in the garbage collector. This saves some spaces
- Add some logs in the garbage collector, activated with an environment variable