### PR TITLE
use fixed size array for Nonce::new()

### DIFF
--- a/crypto/src/crypto_box.rs
+++ b/crypto/src/crypto_box.rs
@@ -202,6 +202,8 @@ impl From<FromHexError> for CryptoError {
 #[cfg(test)]
 mod tests {
 
+    use std::convert::TryInto;
+
     use super::*;
     use crate::nonce::NONCE_SIZE;
 
@@ -239,9 +241,11 @@ mod tests {
         )?;
         let pck = PrecomputedKey::precompute(&pk, &sk);
 
-        let nonce = Nonce::new(&hex::decode(
-            "8dde158c55cff52f4be9352787d333e616a67853640d72c5",
-        )?);
+        let nonce = Nonce::new(
+            &hex::decode("8dde158c55cff52f4be9352787d333e616a67853640d72c5")?
+                .try_into()
+                .unwrap(),
+        );
         let msg = hex::decode("00874d1b98317bd6efad8352a7144c9eb0b218c9130e0a875973908ddc894b764ffc0d7f176cf800b978af9e919bdc35122585168475096d0ebcaca1f2a1172412b91b363ff484d1c64c03417e0e755e696c386a0000002d53414e44424f5845445f54455a4f535f414c5048414e45545f323031382d31312d33305431353a33303a35365a00000000")?;
 
         let encrypted_msg = pck.encrypt(&msg, &nonce)?;
@@ -261,9 +265,11 @@ mod tests {
         )?;
         let pck = PrecomputedKey::precompute(&pk, &sk);
 
-        let nonce = Nonce::new(&hex::decode(
-            "8dde158c55cff52f4be9352787d333e616a67853640d72c5",
-        )?);
+        let nonce = Nonce::new(
+            &hex::decode("8dde158c55cff52f4be9352787d333e616a67853640d72c5")?
+                .try_into()
+                .unwrap(),
+        );
         let enc = hex::decode("45d82d5c4067f5c32748596c1bbc93a9f87b5b1f2058ddd82b6f081ca484b672395c7473ab897c64c01c33878ac1ccb6919a75c9938d8bcf0e7917ddac13a787cfb5c9a5aea50d24502cf86b5c9b000358c039334ec077afe98936feec0dabfff35f14cafd2cd3173bbd56a7c6e5bf6f5f57c92b59b129918a5895e883e7d999b191aad078c4a5b164144c1beaed58b49ba9be094abf3a3bd9")?;
 
         let decrypted_msg = pck.decrypt(&enc, &nonce)?;
@@ -283,9 +289,11 @@ mod tests {
         )?;
         let pck = PrecomputedKey::precompute(&pk, &sk);
 
-        let nonce = Nonce::new(&hex::decode(
-            "8dde158c55cff52f4be9352787d333e616a67853640d72c5",
-        )?);
+        let nonce = Nonce::new(
+            &hex::decode("8dde158c55cff52f4be9352787d333e616a67853640d72c5")?
+                .try_into()
+                .unwrap(),
+        );
         let msg = "hello world";
 
         let enc = pck.encrypt(msg.as_bytes(), &nonce)?;

--- a/shell_automaton/src/service/randomness_service.rs
+++ b/shell_automaton/src/service/randomness_service.rs
@@ -3,7 +3,7 @@
 
 use std::{fmt::Debug, net::SocketAddr};
 
-use crypto::nonce::Nonce;
+use crypto::nonce::{Nonce, NONCE_SIZE};
 use rand::seq::SliceRandom;
 use rand::Rng;
 
@@ -25,7 +25,7 @@ where
     R: Rng + Debug,
 {
     fn get_nonce(&mut self, _: SocketAddr) -> Nonce {
-        let mut b = [0; 24];
+        let mut b: [u8; NONCE_SIZE] = [0; NONCE_SIZE];
         self.fill(&mut b);
         Nonce::new(&b)
     }

--- a/shell_automaton/testing/src/service/randomness_service.rs
+++ b/shell_automaton/testing/src/service/randomness_service.rs
@@ -3,7 +3,7 @@
 
 use std::net::SocketAddr;
 
-use crypto::nonce::Nonce;
+use crypto::nonce::{Nonce, NONCE_SIZE};
 use shell_automaton::service::RandomnessService;
 
 #[derive(Debug, Clone)]
@@ -14,7 +14,7 @@ pub enum RandomnessServiceMocked {
 impl RandomnessService for RandomnessServiceMocked {
     fn get_nonce(&mut self, _: SocketAddr) -> Nonce {
         match self {
-            Self::Dummy => Nonce::new(&[0; 24]),
+            Self::Dummy => Nonce::new(&[0; NONCE_SIZE]),
         }
     }
 


### PR DESCRIPTION
Now instead of taking `&[u8]` we use `&[u8; NONCE_SIZE]` and remove the length check assertion. Every call to `Nonce::new` was fixed to the new argument type.

In case of `generate_nonces` a possible mismatch in sizes is converted to the already existing `Blake2bError::InvalidLenght`, however in practice this shouldn't happen unless a bug is present in the hashing function `blake2b::digest_256`.