### PR TITLE
RPCs for tezedge TUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3102,7 +3102,7 @@ dependencies = [
 [[package]]
 name = "redux-rs"
 version = "0.1.0"
-source = "git+https://github.com/tezedge/redux-rs.git?rev=c2f6946#c2f6946687ddad0edea1008ae74f3b67a6c249bf"
+source = "git+https://github.com/tezedge/redux-rs.git?rev=56e116d#56e116d3e5d740a992a758b744c3705eebe01fd8"
 dependencies = [
  "enum_dispatch",
  "fuzzcheck",

--- a/rpc/src/server/dev_handler.rs
+++ b/rpc/src/server/dev_handler.rs
@@ -639,3 +639,12 @@ pub async fn dev_shell_automaton_stats_current_head_peers(
 
     make_json_response(&result)
 }
+
+pub async fn dev_shell_automaton_endrosement_stats(
+    _: Request<Body>,
+    _: Params,
+    _: Query,
+    env: Arc<RpcServiceEnvironment>,
+) -> ServiceResult {
+    make_json_response(&dev_services::get_shell_automaton_endrosement_stats(&env).await?)
+}

--- a/rpc/src/server/dev_handler.rs
+++ b/rpc/src/server/dev_handler.rs
@@ -648,3 +648,13 @@ pub async fn dev_shell_automaton_endrosement_stats(
 ) -> ServiceResult {
     make_json_response(&dev_services::get_shell_automaton_endrosement_stats(&env).await?)
 }
+// best_remote_level
+
+pub async fn best_remote_level(
+    _: Request<Body>,
+    _: Params,
+    _: Query,
+    env: Arc<RpcServiceEnvironment>,
+) -> ServiceResult {
+    make_json_response(&dev_services::get_best_remote_level(&env).await?)
+}

--- a/rpc/src/server/mod.rs
+++ b/rpc/src/server/mod.rs
@@ -47,6 +47,8 @@ pub type RpcServiceEnvironmentRef = Arc<RpcServiceEnvironment>;
 pub struct RpcCollectedState {
     #[get = "pub(crate)"]
     current_head: Arc<BlockHeaderWithHash>,
+    #[get = "pub(crate)"]
+    best_remote_level: Option<i32>,
 
     // Wakers for open streams (monitors) that access the mempool state
     streams: StreamWakers,

--- a/rpc/src/server/router.rs
+++ b/rpc/src/server/router.rs
@@ -356,6 +356,11 @@ pub(crate) fn create_routes(tezedge_is_enabled: bool) -> PathTree<MethodHandler>
         "/dev/shell/automaton/stats/mempool/endorsements",
         dev_handler::dev_shell_automaton_endrosement_stats,
     );
+    routes.handle(
+        hash_set![Method::GET],
+        "/dev/peers/best_remote_level",
+        dev_handler::best_remote_level,
+    );
 
     routes.handle(
         hash_set![Method::GET],

--- a/rpc/src/server/router.rs
+++ b/rpc/src/server/router.rs
@@ -351,6 +351,11 @@ pub(crate) fn create_routes(tezedge_is_enabled: bool) -> PathTree<MethodHandler>
         "/dev/shell/automaton/stats/current_head/application",
         dev_handler::dev_shell_automaton_stats_current_head_application,
     );
+    routes.handle(
+        hash_set![Method::GET],
+        "/dev/shell/automaton/stats/mempool/endorsements",
+        dev_handler::dev_shell_automaton_endrosement_stats,
+    );
 
     routes.handle(
         hash_set![Method::GET],

--- a/rpc/src/server/rpc_server.rs
+++ b/rpc/src/server/rpc_server.rs
@@ -55,6 +55,7 @@ impl RpcServer {
     ) -> Self {
         let shared_state = Arc::new(RwLock::new(RpcCollectedState {
             current_head: hydrated_current_head_block,
+            best_remote_level: None,
             streams: HashMap::new(),
         }));
 
@@ -140,6 +141,7 @@ pub fn handle_notify_rpc_server_msg(
     match env.state().write() {
         Ok(mut current_head_ref) => {
             current_head_ref.current_head = notification.block.clone();
+            current_head_ref.best_remote_level = notification.best_remote_level.clone();
             current_head_ref.wake_up_all_streams();
         }
         Err(e) => {

--- a/rpc/src/services/dev_services.rs
+++ b/rpc/src/services/dev_services.rs
@@ -11,7 +11,7 @@ use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::convert::TryFrom;
 use std::vec;
 
-use crypto::hash::{ContractKt1Hash, OperationHash};
+use crypto::hash::ContractKt1Hash;
 use serde::{Deserialize, Serialize};
 use shell_automaton::mempool::{OperationKind, OperationValidationResult};
 use shell_automaton::service::storage_service::ActionGraph;
@@ -44,9 +44,7 @@ use crate::server::RpcServiceEnvironment;
 
 use crate::services::protocol::get_blocks_per_cycle;
 
-use super::base_services::{
-    get_additional_data_or_fail, get_raw_block_header_with_hash,
-};
+use super::base_services::{get_additional_data_or_fail, get_raw_block_header_with_hash};
 
 pub type ContractAddress = Vec<u8>;
 
@@ -1132,4 +1130,15 @@ pub(crate) async fn get_shell_automaton_endrosement_stats(
         })
         .collect();
     Ok(result)
+}
+
+// get_best_remote_level
+pub(crate) async fn get_best_remote_level(
+    env: &RpcServiceEnvironment,
+) -> anyhow::Result<Option<i32>> {
+    if let Ok(rpc_state) = env.state().read() {
+        Ok(*rpc_state.best_remote_level())
+    } else {
+        Ok(None)
+    }
 }

--- a/rpc/src/services/mempool_services.rs
+++ b/rpc/src/services/mempool_services.rs
@@ -71,6 +71,7 @@ pub async fn inject_operation(
     let msg = RpcShellAutomatonMsg::InjectOperation {
         operation: operation.clone(),
         operation_hash: operation_hash.clone(),
+        injected: start_request,
     };
     let receiver: tokio::sync::oneshot::Receiver<serde_json::Value> =
         env.shell_automaton_sender().send(msg).await.map_err(|_| {
@@ -207,6 +208,7 @@ pub async fn inject_block(
             chain_id: chain_id.as_ref().clone(),
             block_hash: header.hash.clone(),
             block_header: header.header.clone(),
+            injected: start_request,
         })
         .await
     {

--- a/shell-integration/src/messages.rs
+++ b/shell-integration/src/messages.rs
@@ -86,6 +86,7 @@ pub mod notifications {
         pub chain_id: Arc<ChainId>,
         pub block: Arc<BlockHeaderWithHash>,
         pub is_bootstrapped: bool,
+        pub best_remote_level: Option<i32>,
     }
 
     impl NewCurrentHeadNotification {
@@ -93,11 +94,13 @@ pub mod notifications {
             chain_id: Arc<ChainId>,
             block: Arc<BlockHeaderWithHash>,
             is_bootstrapped: bool,
+            best_remote_level: Option<i32>,
         ) -> Self {
             Self {
                 chain_id,
                 block,
                 is_bootstrapped,
+                best_remote_level,
             }
         }
     }

--- a/shell/src/chain_manager.rs
+++ b/shell/src/chain_manager.rs
@@ -611,14 +611,16 @@ impl ChainManager {
 
                                     // if increasing, propage to peer_branch_bootstrapper to add to the branch for increase and download latest data
                                     if was_updated {
+                                        let message_current_head = BlockHeaderWithHash::new(
+                                            message.current_block_header().clone(),
+                                        )?;
+
+                                        remote_current_head_state
+                                            .update_remote_head(&message_current_head);
+
                                         match chain_state.peer_branch_bootstrapper() {
                                             Some(peer_branch_bootstrapper) => {
                                                 // check if we started branch bootstrapper, try to update current_head to peer's pipelines
-                                                let message_current_head =
-                                                    BlockHeaderWithHash::new(
-                                                        message.current_block_header().clone(),
-                                                    )?;
-
                                                 peer_branch_bootstrapper.tell(
                                                     UpdateBranchBootstraping::new(
                                                         peer.peer_id.clone(),
@@ -1049,6 +1051,7 @@ impl ChainManager {
                             chain_id.clone(),
                             block.clone(),
                             is_bootstrapped,
+                            self.remote_current_head_state.get_remote_level(),
                         ),
                     )),
                     topic: ShellChannelTopic::ShellNewCurrentHead.into(),

--- a/shell/src/state/head_state.rs
+++ b/shell/src/state/head_state.rs
@@ -177,6 +177,10 @@ impl RemoteBestKnownCurrentHead {
             ));
         }
     }
+
+    pub fn get_remote_level(&self) -> Option<i32> {
+        self.remote.as_ref().map(|head| *head.level())
+    }
 }
 
 pub fn has_any_higher_than(

--- a/shell_automaton/Cargo.toml
+++ b/shell_automaton/Cargo.toml
@@ -32,7 +32,7 @@ slog = { version = "2.7", features = ["max_level_trace", "release_max_level_trac
 strum = "0.20"
 strum_macros = "0.20"
 
-redux-rs = { git = "https://github.com/tezedge/redux-rs.git", rev = "c2f6946", features = ["serde"] }
+redux-rs = { git = "https://github.com/tezedge/redux-rs.git", rev = "56e116d", features = ["serde"] }
 
 crypto = { path = "../crypto" }
 storage = { path = "../storage" }

--- a/shell_automaton/src/mempool/mempool_actions.rs
+++ b/shell_automaton/src/mempool/mempool_actions.rs
@@ -86,6 +86,7 @@ pub struct MempoolOperationInjectAction {
     pub operation: Operation,
     pub operation_hash: OperationHash,
     pub rpc_id: RpcId,
+    pub injected_timestamp: u64,
 }
 
 impl EnablingCondition<State> for MempoolOperationInjectAction {
@@ -102,6 +103,7 @@ pub struct BlockInjectAction {
     pub chain_id: ChainId,
     pub block_hash: BlockHash,
     pub block_header: Arc<BlockHeader>,
+    pub injected_timestamp: u64,
 }
 
 impl EnablingCondition<State> for BlockInjectAction {

--- a/shell_automaton/src/mempool/mempool_reducer.rs
+++ b/shell_automaton/src/mempool/mempool_reducer.rs
@@ -481,6 +481,7 @@ pub fn mempool_reducer(state: &mut State, action: &ActionWithMeta) {
             operation,
             operation_hash,
             rpc_id,
+            injected_timestamp,
         }) => {
             let level = mempool_state
                 .local_head_state
@@ -529,6 +530,7 @@ pub fn mempool_reducer(state: &mut State, action: &ActionWithMeta) {
                         block_timestamp,
                     },
                     operation.data(),
+                    injected_timestamp,
                 );
         }
         Action::MempoolRegisterOperationsStream(act) => {

--- a/shell_automaton/src/mempool/mempool_state.rs
+++ b/shell_automaton/src/mempool/mempool_state.rs
@@ -136,6 +136,7 @@ pub struct OperationStats {
     pub validation_result: Option<(u64, OperationValidationResult, Option<u64>, Option<u64>)>,
     pub validations: Vec<OperationValidationStats>,
     pub nodes: HashMap<CryptoboxPublicKeyHash, OperationNodeStats>,
+    pub injected_timestamp: Option<u64>,
 }
 
 impl OperationStats {
@@ -148,6 +149,7 @@ impl OperationStats {
             validation_result: None,
             validations: vec![],
             nodes: HashMap::new(),
+            injected_timestamp: None,
         }
     }
 
@@ -229,7 +231,9 @@ impl OperationStats {
         self_pkh: &CryptoboxPublicKeyHash,
         stats: OperationNodeCurrentHeadStats,
         op_content: &[u8],
+        injected_timestamp: &u64,
     ) {
+        self.injected(injected_timestamp);
         self.set_kind_with(|| OperationKind::from_operation_content_raw(op_content));
         self.min_time = Some(
             self.min_time
@@ -376,6 +380,9 @@ impl OperationStats {
                 },
             );
         }
+    }
+    pub fn injected(&mut self, time: &u64) {
+        self.injected_timestamp = Some(*time);
     }
 }
 

--- a/shell_automaton/src/mempool/mempool_state.rs
+++ b/shell_automaton/src/mempool/mempool_state.rs
@@ -123,7 +123,7 @@ pub struct PeerState {
     pub(super) known_valid_to_send: Vec<OperationHash>,
 }
 
-pub type OperationsStats = HashMap<OperationHash, OperationStats>;
+pub type OperationsStats = BTreeMap<OperationHash, OperationStats>;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct OperationStats {

--- a/shell_automaton/src/peer/message/read/peer_message_read_effects.rs
+++ b/shell_automaton/src/peer/message/read/peer_message_read_effects.rs
@@ -51,6 +51,7 @@ fn stats_message_received(
                             time,
                             Some(address),
                             node_id,
+                            None,
                         );
                     })
                     .unwrap_or(());
@@ -68,6 +69,7 @@ fn stats_message_received(
                         time,
                         Some(address),
                         node_id,
+                        None,
                     );
                     if let Some(time) = pending_block_header_requests.get(&b) {
                         stats.block_header_download_start(&b, *time);

--- a/shell_automaton/src/service/rpc_service.rs
+++ b/shell_automaton/src/service/rpc_service.rs
@@ -1,7 +1,12 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::{collections::HashMap, sync::Arc, thread};
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+    thread,
+    time::Instant,
+};
 
 use crypto::hash::{BlockHash, ChainId, OperationHash};
 use tezos_messages::p2p::encoding::{
@@ -46,6 +51,9 @@ pub enum RpcRequest {
     GetMempoolOperationStats {
         channel: oneshot::Sender<crate::mempool::OperationsStats>,
     },
+    GetMempooEndrosementsStats {
+        channel: oneshot::Sender<BTreeMap<OperationHash, crate::mempool::OperationStats>>,
+    },
     GetBlockStats {
         channel: oneshot::Sender<Option<crate::service::statistics_service::BlocksApplyStats>>,
     },
@@ -53,11 +61,13 @@ pub enum RpcRequest {
     InjectOperation {
         operation_hash: OperationHash,
         operation: Operation,
+        injected: Instant,
     },
     InjectBlock {
         chain_id: ChainId,
         block_header: Arc<BlockHeader>,
         block_hash: BlockHash,
+        injected: Instant,
     },
     RequestCurrentHeadFromConnectedPeers,
     RemoveOperations {

--- a/shell_automaton/src/service/statistics_service/mod.rs
+++ b/shell_automaton/src/service/statistics_service/mod.rs
@@ -25,7 +25,7 @@ pub struct BlockApplyStats {
 
     pub receive_timestamp: u64,
 
-    pub injected: bool,
+    pub injected: Option<u64>,
     pub baker: Option<SignaturePublicKey>,
     pub priority: Option<u16>,
 
@@ -176,6 +176,7 @@ impl StatisticsService {
         receive_timestamp: u64,
         peer: Option<SocketAddr>,
         node_id: Option<CryptoboxPublicKeyHash>,
+        injected_timestamp: Option<u64>,
     ) {
         let levels = &mut self.levels;
         let stats = self
@@ -188,7 +189,7 @@ impl StatisticsService {
                     block_timestamp,
                     validation_pass,
                     receive_timestamp,
-                    injected: peer.is_none(),
+                    injected: injected_timestamp,
                     ..BlockApplyStats::default()
                 }
             });
@@ -396,5 +397,11 @@ impl StatisticsService {
                 .ops_send_end
                 .push((time, validation_pass));
         });
+    }
+
+    pub fn block_injected(&mut self, block_hash: &BlockHash, time: u64) {
+        if let Some(v) = self.blocks_apply.get_mut(block_hash) {
+            v.injected = Some(time)
+        }
     }
 }

--- a/shell_automaton/src/stats/current_head/stats_current_head_effects.rs
+++ b/shell_automaton/src/stats/current_head/stats_current_head_effects.rs
@@ -30,6 +30,7 @@ where
             chain_id: _,
             block_hash,
             block_header,
+            injected_timestamp,
         }) => {
             let node_id = store.state.get().config.identity.peer_id.clone();
             store.service.statistics().map(|s| {
@@ -41,6 +42,7 @@ where
                     action.time_as_nanos(),
                     None,
                     Some(node_id),
+                    Some(*injected_timestamp),
                 );
             });
         }


### PR DESCRIPTION
This PR adds two additional RPCs for use in the TUI. 

/dev/shell/automaton/stats/mempool/endorsements -> Gets the operation statistics only for endorsements from the state machine (mempool). 

/dev/peers/best_remote_level -> The best remote level of the connected peers, this info is coming from the old actor system