### PR TITLE
Disable retried application in mempool

### DIFF
--- a/light_node/src/configuration.rs
+++ b/light_node/src/configuration.rs
@@ -1090,7 +1090,7 @@ impl Environment {
                         s.parse()
                             .expect("Boolean value expected for disable-endorsements-precheck")
                     }),
-                disable_apply_retry: args.value_of("disable-apply-retry").map_or(true, |s| {
+                disable_apply_retry: args.value_of("disable-apply-retry").map_or(false, |s| {
                     s.parse()
                         .expect("Boolean value expected for disable-apply-retry")
                 }),

--- a/shell_automaton/src/block_applier/block_applier_actions.rs
+++ b/shell_automaton/src/block_applier/block_applier_actions.rs
@@ -115,11 +115,10 @@ pub struct BlockApplierApplyProtocolRunnerApplyRetryAction {
 
 impl EnablingCondition<State> for BlockApplierApplyProtocolRunnerApplyRetryAction {
     fn is_enabled(&self, state: &State) -> bool {
-        let first_attempt = match &state.block_applier.current {
+        match &state.block_applier.current {
             BlockApplierApplyState::ProtocolRunnerApplyPending { retry, .. } => retry.is_none(),
             _ => false,
-        };
-        first_attempt && (!state.is_bootstrapped_strict() || !state.config.disable_apply_retry)
+        }
     }
 }
 

--- a/shell_automaton/src/block_applier/block_applier_reducer.rs
+++ b/shell_automaton/src/block_applier/block_applier_reducer.rs
@@ -100,6 +100,7 @@ pub fn block_applier_reducer(state: &mut State, action: &ActionWithMeta) {
                     chain_id,
                     block,
                     block_meta,
+                    retry,
                     ..
                 } => {
                     state.block_applier.current =
@@ -111,6 +112,7 @@ pub fn block_applier_reducer(state: &mut State, action: &ActionWithMeta) {
                             block: block.clone(),
                             block_meta: block_meta.clone(),
                             apply_result: content.apply_result.clone(),
+                            retry: retry.clone(),
                         };
                 }
                 _ => return,
@@ -125,6 +127,7 @@ pub fn block_applier_reducer(state: &mut State, action: &ActionWithMeta) {
                     block,
                     block_meta,
                     apply_result,
+                    retry,
                     ..
                 } => {
                     state.block_applier.current = BlockApplierApplyState::StoreApplyResultPending {
@@ -136,6 +139,7 @@ pub fn block_applier_reducer(state: &mut State, action: &ActionWithMeta) {
                         block: block.clone(),
                         block_meta: block_meta.clone(),
                         apply_result: apply_result.clone(),
+                        retry: retry.clone(),
                     };
                 }
                 _ => return,
@@ -150,6 +154,7 @@ pub fn block_applier_reducer(state: &mut State, action: &ActionWithMeta) {
                     chain_id,
                     block,
                     apply_result,
+                    retry,
                     ..
                 } => {
                     state.block_applier.current = BlockApplierApplyState::StoreApplyResultSuccess {
@@ -161,6 +166,7 @@ pub fn block_applier_reducer(state: &mut State, action: &ActionWithMeta) {
                         block: block.clone(),
                         block_additional_data: content.block_additional_data.clone(),
                         apply_result: apply_result.clone(),
+                        retry: retry.clone(),
                     };
                 }
                 _ => return,
@@ -193,6 +199,7 @@ pub fn block_applier_reducer(state: &mut State, action: &ActionWithMeta) {
                     block,
                     block_additional_data,
                     apply_result,
+                    retry,
                 } => {
                     state.block_applier.last_applied = block.hash.clone().into();
                     state.block_applier.current = BlockApplierApplyState::Success {
@@ -204,6 +211,7 @@ pub fn block_applier_reducer(state: &mut State, action: &ActionWithMeta) {
                         block: block.clone(),
                         block_additional_data: block_additional_data.clone(),
                         apply_result: apply_result.clone(),
+                        retry: retry.clone(),
                     };
                 }
                 _ => return,

--- a/shell_automaton/src/block_applier/block_applier_state.rs
+++ b/shell_automaton/src/block_applier/block_applier_state.rs
@@ -69,6 +69,8 @@ pub enum BlockApplierApplyState {
         block: Arc<BlockHeaderWithHash>,
         block_meta: Arc<Meta>,
         apply_result: Arc<ApplyBlockResponse>,
+        /// Is retry or not and if yes, what is the reason.
+        retry: Option<ApplyBlockError>,
     },
 
     StoreApplyResultPending {
@@ -80,6 +82,8 @@ pub enum BlockApplierApplyState {
         block: Arc<BlockHeaderWithHash>,
         block_meta: Arc<Meta>,
         apply_result: Arc<ApplyBlockResponse>,
+        /// Is retry or not and if yes, what is the reason.
+        retry: Option<ApplyBlockError>,
     },
     StoreApplyResultSuccess {
         time: u64,
@@ -90,6 +94,8 @@ pub enum BlockApplierApplyState {
         block: Arc<BlockHeaderWithHash>,
         block_additional_data: Arc<BlockAdditionalData>,
         apply_result: Arc<ApplyBlockResponse>,
+        /// Is retry or not and if yes, what is the reason.
+        retry: Option<ApplyBlockError>,
     },
 
     Error {
@@ -106,6 +112,8 @@ pub enum BlockApplierApplyState {
         block: Arc<BlockHeaderWithHash>,
         block_additional_data: Arc<BlockAdditionalData>,
         apply_result: Arc<ApplyBlockResponse>,
+        /// Is retry or not and if yes, what is the reason.
+        retry: Option<ApplyBlockError>,
     },
 }
 


### PR DESCRIPTION
The node will always retry block application, but mempool will optionally ignore blocks applied after retry.