### PR TITLE
Replace chrono crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,12 +15,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
+name = "aes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+ "opaque-debug",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.4",
+ "getrandom 0.2.5",
  "once_cell",
  "version_check",
 ]
@@ -45,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.53"
+version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
+checksum = "159bb86af3a200e19a068f4224eae4c8bb2d0fa054c7e5d1cacd5cef95e684cd"
 
 [[package]]
 name = "arbitrary"
@@ -129,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "async-global-executor"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9586ec52317f36de58453159d48351bc244bc24ced3effc1fce22f3d48664af6"
+checksum = "c026b7e44f1316b567ee750fea85103f87fcb80792b860e979f221259796ca0a"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -164,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6a8ea61bf9947a1007c5cada31e647dbc77b103c679858150003ba697ea798b"
+checksum = "e97a171d191782fba31bb902b14ad94e24a68145032b7eedf871ab0bc0d077b6"
 dependencies = [
  "event-listener",
 ]
@@ -295,6 +307,12 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "base64ct"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a32fd6af2b5827bce66c29053ba0e7c42b9dcab01835835058558c10851a46b"
 
 [[package]]
 name = "bencher"
@@ -517,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 dependencies = [
  "jobserver",
 ]
@@ -546,24 +564,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75476fe966a8af7c0ceae2a3e514afa87d4451741fcdfab8bfaa07ad301842ec"
 
 [[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "serde 1.0.136",
- "time",
- "winapi",
-]
-
-[[package]]
 name = "chunked_transfer"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
+
+[[package]]
+name = "cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "clang-sys"
@@ -593,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.14"
+version = "3.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63edc3f163b3c71ec8aa23f9bd6070f77edbf3d1d198b164afa90ff00e4ec62"
+checksum = "ced1892c55c910c1219e98d6fc8d71f6bddba7905866ce740066d8bfea859312"
 dependencies = [
  "atty",
  "bitflags",
@@ -605,14 +618,14 @@ dependencies = [
  "os_str_bytes",
  "strsim 0.10.0",
  "termcolor",
- "textwrap 0.14.2",
+ "textwrap 0.15.0",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.0.14"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1132dc3944b31c20dd8b906b3a9f0a5d0243e092d59171414969657ac6aa85"
+checksum = "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -662,11 +675,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
 name = "context-tool"
 version = "1.17.0"
 dependencies = [
  "byte-unit",
- "clap 3.0.14",
+ "clap 3.1.5",
  "crypto",
  "termcolor",
  "tezos_context",
@@ -677,6 +696,12 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
@@ -731,7 +756,7 @@ dependencies = [
  "clap 2.34.0",
  "criterion-plot",
  "csv",
- "itertools 0.10.3",
+ "itertools",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -753,7 +778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
 dependencies = [
  "cast",
- "itertools 0.10.3",
+ "itertools",
 ]
 
 [[package]]
@@ -840,11 +865,12 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4600d695eb3f6ce1cd44e6e291adceb2cc3ab12f20a33777ecd0bf6eba34e06"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
  "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -1054,12 +1080,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb780dce4f9a8f5c087362b3a4595936b2019e7c8b30f2c3e9a7e94e6ae9837"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
  "block-buffer 0.10.2",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1112,7 +1139,6 @@ name = "edgekv"
 version = "1.17.0"
 dependencies = [
  "bincode",
- "chrono",
  "crc",
  "crc32fast",
  "env_logger",
@@ -1124,6 +1150,7 @@ dependencies = [
  "serde 1.0.136",
  "serial_test",
  "thiserror",
+ "time",
 ]
 
 [[package]]
@@ -1146,6 +1173,26 @@ dependencies = [
  "rand_core 0.6.3",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "enum-iterator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
+dependencies = [
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -1579,9 +1626,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
+checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1598,6 +1645,19 @@ dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.15",
  "syn 1.0.86",
+]
+
+[[package]]
+name = "git2"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e7d3b96ec1fcaa8431cf04a4f1ef5caafe58d5cf7bcc31f09c1626adddb0ffe"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
 ]
 
 [[package]]
@@ -1754,6 +1814,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "hmac-drbg"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1892,29 +1961,20 @@ dependencies = [
 
 [[package]]
 name = "ipmpsc"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf1250597d5fc1dc4b2a08183ac9a6cc3365080a5e808d15e5a36a931f7ba9b"
+version = "0.5.2"
+source = "git+https://github.com/tezedge/ipmpsc#fbaa1b328a0d5dd53fd94c6f67e6f9607daf8689"
 dependencies = [
+ "anyhow",
  "bincode",
  "hex",
  "libc",
- "memmap",
+ "memmap2",
  "serde 1.0.136",
- "sha2",
+ "sha2 0.9.9",
  "tempfile",
  "thiserror",
  "vergen",
  "winapi",
-]
-
-[[package]]
-name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -2019,9 +2079,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.117"
+version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
+checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
 name = "libflate"
@@ -2041,6 +2101,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39a734c0493409afcd49deee13c006a04e3586b9761a03543c6272c9c51f2f5a"
 dependencies = [
  "rle-decode-fast",
+]
+
+[[package]]
+name = "libgit2-sys"
+version = "0.13.1+1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43e598aa7a4faedf1ea1b4608f582b06f0f40211eec551b7ef36019ae3f62def"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
 ]
 
 [[package]]
@@ -2079,7 +2151,7 @@ dependencies = [
  "libsecp256k1-gen-genmult",
  "rand 0.8.5",
  "serde 1.0.136",
- "sha2",
+ "sha2 0.9.9",
  "typenum",
 ]
 
@@ -2142,6 +2214,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
 dependencies = [
  "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -2210,7 +2283,6 @@ dependencies = [
 name = "logging"
 version = "1.17.0"
 dependencies = [
- "chrono",
  "libflate",
  "nix",
  "serde 1.0.136",
@@ -2219,6 +2291,7 @@ dependencies = [
  "slog-json",
  "slog-term",
  "tempfile",
+ "time",
 ]
 
 [[package]]
@@ -2281,6 +2354,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmap2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723e3ebdcdc5c023db1df315364573789f8857c11b631a2fdfad7c00f5c046b4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2297,9 +2379,9 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "mime_guess"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
 dependencies = [
  "mime",
  "unicase",
@@ -2326,6 +2408,19 @@ name = "mio"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba272f85fa0b41fc91872be579b3bbe0f56b792aa361a380eb669469f68dafb2"
 dependencies = [
  "libc",
  "log",
@@ -2417,7 +2512,7 @@ dependencies = [
  "futures",
  "getset",
  "hex",
- "itertools 0.10.3",
+ "itertools",
  "lazy_static",
  "quickcheck",
  "quickcheck_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2593,6 +2688,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2679,7 +2783,7 @@ checksum = "d053368e1bae4c8a672953397bd1bd7183dde1c72b0b7612a15719173148d186"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "sha2",
+ "sha2 0.9.9",
 ]
 
 [[package]]
@@ -2706,7 +2810,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.1",
 ]
 
 [[package]]
@@ -2721,6 +2835,19 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2749,10 +2876,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d791538a6dcc1e7cb7fe6f6b58aca40e7f79403c45b2bc274008b5e647af1d8"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.3",
+ "subtle",
+]
+
+[[package]]
 name = "path-tree"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "284ddd88011a675276be272a00d0d5277ac7859e55bd454d58398aac1e01b8dc"
+
+[[package]]
+name = "pbkdf2"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
+dependencies = [
+ "digest 0.10.3",
+ "hmac 0.12.1",
+ "password-hash",
+ "sha2 0.10.2",
+]
 
 [[package]]
 name = "peeking_take_while"
@@ -3043,7 +3193,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.4",
+ "getrandom 0.2.5",
 ]
 
 [[package]]
@@ -3082,9 +3232,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c"
 dependencies = [
  "bitflags",
 ]
@@ -3095,7 +3245,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.2.4",
+ "getrandom 0.2.5",
  "redox_syscall",
 ]
 
@@ -3214,13 +3364,12 @@ dependencies = [
  "async_ipc",
  "bincode",
  "cached",
- "chrono",
  "crypto",
  "futures",
  "getset",
  "hex",
  "hyper",
- "itertools 0.10.3",
+ "itertools",
  "lazy_static",
  "num",
  "path-tree",
@@ -3242,6 +3391,7 @@ dependencies = [
  "tezos_protocol_ipc_client",
  "tezos_timing",
  "thiserror",
+ "time",
  "tokio",
  "tokio-stream",
  "url",
@@ -3279,9 +3429,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b323592e3164322f5b193dc4302e4e36cd8d37158a712d664efae1a5c2791700"
+checksum = "4fbfeb8d0ddb84706bc597a5574ab8912817c52a397f819e5b614e2265206921"
 dependencies = [
  "log",
  "ring",
@@ -3324,13 +3474,13 @@ dependencies = [
  "clap 2.34.0",
  "colored",
  "hex",
- "itertools 0.10.3",
+ "itertools",
  "nix",
  "os_type",
  "rand 0.7.3",
  "serde 1.0.136",
  "serde_json",
- "sha2",
+ "sha2 0.9.9",
  "slog",
  "slog-async",
  "slog-term",
@@ -3365,9 +3515,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0486718e92ec9a68fbed73bb5ef687d71103b142595b406835649bebd33f72c7"
+checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
 
 [[package]]
 name = "serde"
@@ -3434,7 +3584,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
 dependencies = [
  "lazy_static",
- "parking_lot",
+ "parking_lot 0.11.2",
  "serial_test_derive",
 ]
 
@@ -3470,7 +3620,18 @@ checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.2",
+ "digest 0.10.3",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77f4e7f65455545c2153c1253d25056825e77ee2533f0e41deb65a93a34852f"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -3484,6 +3645,17 @@ dependencies = [
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -3501,14 +3673,13 @@ version = "1.17.0"
 dependencies = [
  "anyhow",
  "async_ipc",
- "chrono",
  "crypto",
  "dns-lookup",
  "fs_extra",
  "futures",
  "getset",
  "hex",
- "itertools 0.10.3",
+ "itertools",
  "lazy_static",
  "networking",
  "nix",
@@ -3533,6 +3704,7 @@ dependencies = [
  "tezos_messages",
  "tezos_protocol_ipc_client",
  "thiserror",
+ "time",
  "tokio",
  "zip",
 ]
@@ -3556,7 +3728,7 @@ dependencies = [
  "fuzzcheck_mutators_derive",
  "getset",
  "hex",
- "mio",
+ "mio 0.7.14",
  "networking",
  "nix",
  "num-bigint 0.3.3",
@@ -3680,7 +3852,7 @@ dependencies = [
  "fxhash",
  "libc",
  "log",
- "parking_lot",
+ "parking_lot 0.11.2",
 ]
 
 [[package]]
@@ -3721,14 +3893,14 @@ dependencies = [
 
 [[package]]
 name = "slog-json"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f7f7a952ce80fca9da17bf0a53895d11f8aa1ba063668ca53fc72e7869329e9"
+checksum = "70f825ce7346f40aa318111df5d3a94945a7fdca9081584cb9b05692fb3dfcb4"
 dependencies = [
- "chrono",
  "serde 1.0.136",
  "serde_json",
  "slog",
+ "time",
 ]
 
 [[package]]
@@ -3755,15 +3927,15 @@ dependencies = [
 
 [[package]]
 name = "slog-term"
-version = "2.8.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3668dd2252f4381d64de0c79e6c8dc6bd509d1cab3535b35a3fc9bafd1241d5"
+checksum = "87d29185c55b7b258b4f120eab00f48557d4d9bc814f41713f449d35b0f8977c"
 dependencies = [
  "atty",
- "chrono",
  "slog",
  "term",
  "thread_local",
+ "time",
 ]
 
 [[package]]
@@ -3842,7 +4014,7 @@ dependencies = [
  "fuzzcheck",
  "getset",
  "hex",
- "itertools 0.10.3",
+ "itertools",
  "lazy_static",
  "num_cpus",
  "rand 0.7.3",
@@ -3939,6 +4111,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07fa4c84a5305909b0eedfcc8d1f2fafdbede645bb700a45ecaafe681a0ac5d6"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "winapi",
+]
+
+[[package]]
 name = "take_mut"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3977,9 +4163,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
@@ -3995,9 +4181,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "tezedge-actor-system"
@@ -4031,7 +4217,7 @@ dependencies = [
  "os_type",
  "serde 1.0.136",
  "serde_json",
- "sha2",
+ "sha2 0.9.9",
 ]
 
 [[package]]
@@ -4040,7 +4226,6 @@ version = "1.17.0"
 dependencies = [
  "anyhow",
  "assert-json-diff 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono",
  "crypto",
  "derive_builder",
  "fuzzcheck",
@@ -4055,6 +4240,7 @@ dependencies = [
  "tezos_encoding",
  "tezos_messages",
  "thiserror",
+ "time",
  "url",
 ]
 
@@ -4098,7 +4284,6 @@ dependencies = [
 name = "tezos_context_api"
 version = "1.17.0"
 dependencies = [
- "chrono",
  "crypto",
  "derive_builder",
  "fuzzcheck",
@@ -4108,6 +4293,7 @@ dependencies = [
  "strum_macros",
  "tezos_encoding",
  "tezos_messages",
+ "time",
 ]
 
 [[package]]
@@ -4223,7 +4409,6 @@ dependencies = [
  "anyhow",
  "assert-json-diff 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
- "chrono",
  "criterion",
  "crypto",
  "csv",
@@ -4246,6 +4431,7 @@ dependencies = [
  "tezos_encoding_derive",
  "tezos_identity",
  "thiserror",
+ "time",
 ]
 
 [[package]]
@@ -4330,13 +4516,22 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
 dependencies = [
+ "itoa 1.0.1",
  "libc",
- "winapi",
+ "num_threads",
+ "serde 1.0.136",
+ "time-macros",
 ]
+
+[[package]]
+name = "time-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6"
 
 [[package]]
 name = "tinytemplate"
@@ -4365,19 +4560,20 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.16.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
+checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
 dependencies = [
  "bytes",
  "libc",
  "memchr",
- "mio",
+ "mio 0.8.0",
  "num_cpus",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.0",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "winapi",
 ]
@@ -4460,9 +4656,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d8d93354fe2a8e50d5953f5ae2e47a3fc2ef03292e7ea46e3cc38f549525fb9"
+checksum = "f6c650a8ef0cd2dd93736f033d21cbd1224c5a967aa0c258d00fcf7dafef9b9f"
 dependencies = [
  "cfg-if",
  "log",
@@ -4505,9 +4701,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74786ce43333fcf51efe947aed9718fbe46d5c7328ec3f1029e818083966d9aa"
+checksum = "9e0ab7bdc962035a87fba73f3acca9b8a8d0034c2e6f60b84aeaaddddc155dce"
 dependencies = [
  "ansi_term",
  "lazy_static",
@@ -4661,7 +4857,7 @@ name = "uuid"
 version = "0.8.2-cleanup-unsafe-1"
 source = "git+https://github.com/tezedge/uuid?tag=v0.8.2-cleanup-unsafe-1#90da5950d270f2f80310cc733030048682e3db06"
 dependencies = [
- "getrandom 0.2.4",
+ "getrandom 0.2.5",
 ]
 
 [[package]]
@@ -4694,13 +4890,19 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7141e445af09c8919f1d5f8a20dae0b20c3b57a45dee0d5823c6ed5d237f15a"
+version = "6.0.2"
+source = "git+https://github.com/tezedge/vergen?branch=replace-chrono#49f4c9c5a063794e100bf4a8bc43790a166211e9"
 dependencies = [
- "bitflags",
- "chrono",
+ "anyhow",
+ "cfg-if",
+ "enum-iterator",
+ "getset",
+ "git2",
  "rustc_version",
+ "rustversion",
+ "sysinfo",
+ "thiserror",
+ "time",
 ]
 
 [[package]]
@@ -4923,6 +5125,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-sys"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
+
+[[package]]
 name = "wyz"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4937,31 +5182,35 @@ checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
 [[package]]
 name = "zip"
 version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815"
+source = "git+https://github.com/zip-rs/zip.git?rev=2009d162fbaf162190e6495e211cebfe6cd98a96#2009d162fbaf162190e6495e211cebfe6cd98a96"
 dependencies = [
+ "aes",
  "byteorder",
  "bzip2",
+ "constant_time_eq",
  "crc32fast",
  "flate2",
- "thiserror",
+ "hmac 0.12.1",
+ "pbkdf2",
+ "sha1",
  "time",
+ "zstd",
 ]
 
 [[package]]
 name = "zstd"
-version = "0.5.4+zstd.1.4.7"
+version = "0.10.0+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69996ebdb1ba8b1517f61387a883857818a66c8a295f487b1ffd8fd9d2c82910"
+checksum = "3b1365becbe415f3f0fcd024e2f7b45bacfb5bdd055f0dc113571394114e7bdd"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "2.0.6+zstd.1.4.7"
+version = "4.1.4+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98aa931fb69ecee256d44589d19754e61851ae4769bf963b385119b1cc37a49e"
+checksum = "2f7cd17c9af1a4d6c24beb1cc54b17e2ef7b593dc92f19e9d9acad8b182bbaee"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -4969,12 +5218,10 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.4.18+zstd.1.4.7"
+version = "1.6.3+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6e8778706838f43f771d80d37787cb2fe06dafe89dd3aebaf6721b9eaec81"
+checksum = "fc49afa5c8d634e75761feda8c592051e7eeb4683ba827211eb0d731d3402ea8"
 dependencies = [
  "cc",
- "glob",
- "itertools 0.9.0",
  "libc",
 ]

--- a/apps/deploy_monitoring/Cargo.toml
+++ b/apps/deploy_monitoring/Cargo.toml
@@ -9,7 +9,7 @@ default-run = "deploy-monitoring"
 anyhow = "1.0"
 async-trait = "0.1"
 clap = "2.33"
-chrono = "0.4"
+time = "0.3"
 thiserror = "1.0"
 fs2 = "0.4"
 fs_extra = "1.2"
@@ -24,7 +24,7 @@ serde_json = "1.0"
 shiplift = { git = "https://github.com/tezedge/shiplift.git", branch = "master" }
 slog = { version = "2.7", features = ["nested-values", "max_level_trace", "release_max_level_trace"] }
 slog-async = "2.6"
-slog-term = "2.8"
+slog-term = "2.9"
 sysinfo = "0.16"
 tokio = { version = "1.12", features = ["full"] }
 wait-timeout = "0.2"

--- a/apps/deploy_monitoring/src/monitors/deploy.rs
+++ b/apps/deploy_monitoring/src/monitors/deploy.rs
@@ -8,7 +8,6 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use anyhow::bail;
-use chrono::Utc;
 use shiplift::Docker;
 use slog::{info, warn, Logger};
 use zip::write::ZipWriter;
@@ -66,7 +65,7 @@ impl DeployMonitor {
         if !Path::new("/tmp/tezedge-monitoring-logs").exists() {
             std::fs::create_dir("/tmp/tezedge-monitoring-logs")?;
         }
-        let timestamp = Utc::now().time().to_string();
+        let timestamp = OffsetDateTime::now_utc().time().to_string();
         let file_name = format!("{}_crash.log", &timestamp);
         let zip_name = format!("{}_crash.zip", &timestamp);
         let file_path = format!("/tmp/tezedge-monitoring-logs/{}", &zip_name);

--- a/apps/node_monitoring/Cargo.lock
+++ b/apps/node_monitoring/Cargo.lock
@@ -137,7 +137,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time",
+ "time 0.1.43",
  "winapi",
 ]
 
@@ -555,7 +555,7 @@ checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
 dependencies = [
  "bytes",
  "fnv",
- "itoa",
+ "itoa 0.4.8",
 ]
 
 [[package]]
@@ -596,7 +596,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 0.4.8",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -688,6 +688,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
 name = "js-sys"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,9 +710,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.105"
+version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
+checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
 name = "lock_api"
@@ -866,10 +872,9 @@ dependencies = [
 
 [[package]]
 name = "node-monitoring"
-version = "1.9.0"
+version = "1.17.0"
 dependencies = [
  "cfg-if",
- "chrono",
  "clap",
  "fs2",
  "fs_extra",
@@ -888,6 +893,7 @@ dependencies = [
  "slog-term",
  "sysinfo",
  "thiserror",
+ "time 0.3.7",
  "tokio",
  "wait-timeout",
  "warp",
@@ -986,6 +992,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
+dependencies = [
  "libc",
 ]
 
@@ -1559,7 +1574,7 @@ version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
@@ -1571,7 +1586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
@@ -1627,15 +1642,15 @@ dependencies = [
 
 [[package]]
 name = "slog-term"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c1e7e5aab61ced6006149ea772770b84a0d16ce0f7885def313e4829946d76"
+checksum = "87d29185c55b7b258b4f120eab00f48557d4d9bc814f41713f449d35b0f8977c"
 dependencies = [
  "atty",
- "chrono",
  "slog",
  "term",
  "thread_local",
+ "time 0.3.7",
 ]
 
 [[package]]
@@ -1764,6 +1779,24 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
+dependencies = [
+ "itoa 1.0.1",
+ "libc",
+ "num_threads",
+ "time-macros",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6"
 
 [[package]]
 name = "tinyvec"

--- a/apps/node_monitoring/Cargo.toml
+++ b/apps/node_monitoring/Cargo.toml
@@ -8,7 +8,7 @@ default-run = "node-monitoring"
 [dependencies]
 cfg-if = "1.0"
 clap = "2.33"
-chrono = "0.4"
+time = "0.3"
 thiserror = "1"
 fs2 = "0.4"
 fs_extra = "1.2"
@@ -22,7 +22,7 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 slog = { version = "2.7", features = ["nested-values", "max_level_trace", "release_max_level_trace"] }
 slog-async = "2.6"
-slog-term = "2.8"
+slog-term = "2.9"
 sysinfo = { git = "https://github.com/tezedge/sysinfo.git", tag = "tezedge-v0.19.2-1" }
 tokio = { version = "1.12", features = ["full"] }
 wait-timeout = "0.2"

--- a/apps/node_monitoring/src/monitors/resource.rs
+++ b/apps/node_monitoring/src/monitors/resource.rs
@@ -9,7 +9,6 @@ use std::hash::Hash;
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
 
-use chrono::Utc;
 use thiserror::Error;
 use getset::Getters;
 use merge::Merge;
@@ -17,6 +16,7 @@ use netinfo::Netinfo;
 use serde::Serialize;
 use slog::{error, warn, Logger};
 use sysinfo::{System, SystemExt};
+use time::OffsetDateTime;
 
 use crate::display_info::{NodeInfo, OcamlDiskData, TezedgeDiskData};
 use crate::monitors::alerts::Alerts;
@@ -441,13 +441,13 @@ impl ResourceMonitor {
                     };
 
                     ResourceUtilization {
-                        timestamp: chrono::Local::now().timestamp(),
+                        timestamp: OffsetDateTime::now_utc().unix_timestamp(),
                         memory: MemoryStats {
                             node: node_memory,
                             validators: validators_memory,
                         },
-                        tezedge_disk: Some(node_disk.try_into()?),
                         ocaml_disk: None,
+                        tezedge_disk: Some(node_disk.try_into()?),
                         cpu: CpuStats {
                             node: node_cpu,
                             validators: validators_cpu,
@@ -456,8 +456,8 @@ impl ResourceMonitor {
                             node: node_io,
                             validators: validators_io,
                         },
-                        head_info: current_head_info,
                         network: network_stats,
+                        head_info: current_head_info,
                         total_disk_space,
                         free_disk_space,
                     }
@@ -492,7 +492,7 @@ impl ResourceMonitor {
                     };
 
                     ResourceUtilization {
-                        timestamp: chrono::Local::now().timestamp(),
+                        timestamp: OffsetDateTime::now_utc().unix_timestamp(),
                         memory: MemoryStats {
                             node: node_memory,
                             validators: validators_memory,
@@ -596,7 +596,7 @@ async fn handle_alerts(
     };
 
     // current time timestamp
-    let current_time = Utc::now().timestamp();
+    let current_time = OffsetDateTime::now_utc().unix_timestamp();
 
     let last_head = last_checked_head_level.get(node_tag).copied();
     let current_head_info = last_measurement.head_info.clone();

--- a/edgekv/Cargo.toml
+++ b/edgekv/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 crc = "2.0.0-rc.1"
-chrono = "0.4"
+time = "0.3"
 fs_extra = "1.2.0"
 fs2 = "0.4.3"
 thiserror = "1.0"

--- a/edgekv/src/file_ops.rs
+++ b/edgekv/src/file_ops.rs
@@ -5,7 +5,6 @@ use crate::datastore::{KeyDirEntry, KeysDir};
 use crate::errors::EdgeKVError;
 use crate::schema::{DataEntry, Decoder, Encoder, HintEntry};
 use crate::Result;
-use chrono::Utc;
 use fs2::FileExt;
 use fs_extra::dir::DirOptions;
 use std::collections::BTreeMap;
@@ -13,6 +12,7 @@ use std::fs::{File, OpenOptions};
 use std::io::{BufReader, BufWriter, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use time::OffsetDateTime;
 
 const DATA_FILE_EXTENSION: &str = "data";
 const HINT_FILE_EXTENSION: &str = "hint";
@@ -255,7 +255,7 @@ impl ActiveFilePair {
 pub fn create_new_file_pair<P: AsRef<Path>>(dir: P) -> Result<FilePair> {
     fs_extra::dir::create_all(dir.as_ref(), false)?;
 
-    let file_name = Utc::now().timestamp_nanos().to_string();
+    let file_name = OffsetDateTime::now_utc().unix_timestamp_nanos().to_string();
     let mut data_file_path = PathBuf::new();
     data_file_path.push(dir.as_ref());
     data_file_path.push(format!("{}.{}", file_name, DATA_FILE_EXTENSION));

--- a/edgekv/src/schema.rs
+++ b/edgekv/src/schema.rs
@@ -1,9 +1,9 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use chrono::Utc;
 use crc::{Crc, CRC_32_CKSUM};
 use std::io::Read;
+use time::OffsetDateTime;
 pub const CRC_CKSUM: Crc<u32> = Crc::<u32>::new(&CRC_32_CKSUM);
 use crate::Result;
 
@@ -82,7 +82,7 @@ impl Decoder for DataEntry {
 
 impl DataEntry {
     pub fn new(key: Vec<u8>, value: Vec<u8>) -> Self {
-        let timestamp = Utc::now().timestamp();
+        let timestamp = OffsetDateTime::now_utc().unix_timestamp();
         let key_size = key.len() as u64;
         let value_size = value.len() as u64;
 

--- a/ipc/Cargo.toml
+++ b/ipc/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version = "1.0", features = ["derive"] }
 [dev-dependencies]
 serial_test = "0.5"
 libc = "0.2.65"
-ipmpsc = "0.4"
+ipmpsc = { git = "https://github.com/tezedge/ipmpsc" }
 bencher = "0.1.5"
 
 [[bench]]

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -6,14 +6,14 @@ edition = "2021"
 
 
 [dependencies]
-chrono = "0.4"
+time = { version = "0.3", features = ["local-offset", "formatting"] }
 libflate = "1"
 nix = "0.23"
 serde = { version = "1.0", features = ["derive"] }
 slog = { version = "2.7", features = ["max_level_trace", "release_max_level_trace"] }
-slog-json = "2.3"
+slog-json = "2.6"
 slog-async = "2.6"
-slog-term = "2.8"
+slog-term = "2.9"
 
 [dev-dependencies]
 tempfile = "3"

--- a/logging/src/detailed_json.rs
+++ b/logging/src/detailed_json.rs
@@ -5,6 +5,8 @@ use std::io;
 
 use slog::*;
 use slog::{FnValue, Level, Record};
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
 
 /// Get hostname for current machine
 fn get_hostname() -> String {
@@ -60,5 +62,11 @@ pub fn default<W>(io: W) -> slog_json::Json<W>
 where
     W: io::Write,
 {
-    new_with_ts_fn(io, |_: &Record| chrono::Local::now().to_rfc3339()).build()
+    const INVALID_TIME: &str = "invalid timestamp";
+    new_with_ts_fn(io, |_: &Record| {
+        OffsetDateTime::now_utc()
+            .format(&Rfc3339)
+            .unwrap_or_else(|_| String::from(INVALID_TIME))
+    })
+    .build()
 }

--- a/networking/Cargo.toml
+++ b/networking/Cargo.toml
@@ -27,7 +27,7 @@ tezos_messages = { path = "../tezos/messages" }
 [dev-dependencies]
 tokio-test = { version = "0.4" }
 async-std = { version = "1.9", features = ["attributes"] }
-slog-term = "2.8"
+slog-term = "2.9"
 slog-async = "2.6"
 slog-envlogger = "2.2"
 criterion = { version = "0.3", features = ["html_reports"] }

--- a/protocol_runner/Cargo.toml
+++ b/protocol_runner/Cargo.toml
@@ -11,7 +11,7 @@ thiserror = "1.0"
 jemallocator = "0.3.2"
 slog = { version = "2.7", features = ["max_level_trace", "release_max_level_trace"] }
 slog-async = "2.6"
-slog-term = "2.8"
+slog-term = "2.9"
 # local dependencies
 crypto = { path = "../crypto" }
 tezos_api = { path = "../tezos/api" }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -7,7 +7,7 @@ build = "build.rs"
 
 [dependencies]
 anyhow = "1.0"
-chrono = { version = "0.4", features = ["serde"] }
+time = { version = "0.3", features = ["serde"] }
 getset = "0.1"
 thiserror = "1.0"
 futures = "0.3"

--- a/rpc/src/helpers.rs
+++ b/rpc/src/helpers.rs
@@ -7,7 +7,6 @@ use std::{convert::TryInto, ops::Neg};
 
 use anyhow::bail;
 use async_ipc::IpcError;
-use chrono::{SecondsFormat, Utc};
 use hex::FromHexError;
 use hyper::{Body, Request};
 use serde::{Deserialize, Serialize};
@@ -27,6 +26,8 @@ use tezos_messages::p2p::binary_message::MessageHashError;
 use tezos_messages::p2p::encoding::block_header::Level;
 use tezos_messages::p2p::encoding::prelude::*;
 use tezos_messages::{ts_to_rfc3339, TimestampOutOfRangeError};
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
 
 use crate::encoding::base_types::UniString;
 use crate::server::{HasSingleValue, Query, RpcServiceEnvironment};
@@ -751,7 +752,9 @@ pub(crate) async fn get_prevalidators(
             status: WorkerStatus {
                 phase: WorkerStatusPhase::Running,
                 // TODO: proper time
-                since: Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true),
+                since: OffsetDateTime::now_utc()
+                    .format(&Rfc3339)
+                    .unwrap_or_else(|_| String::from("invalid timestamp")),
             },
         }])
     }

--- a/sandbox/Cargo.toml
+++ b/sandbox/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 slog = { version = "2.7", features = ["nested-values", "max_level_trace", "release_max_level_trace"] }
 slog-async = "2.6"
-slog-term = "2.8"
+slog-term = "2.9"
 tokio = { version = "1.12", features = ["full"] }
 warp = "0.3"
 wait-timeout = "0.2"

--- a/shell/Cargo.toml
+++ b/shell/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 async_ipc = { path = "../async-ipc" }
-chrono = "0.4"
+time = "0.3"
 dns-lookup = "1.0.1"
 thiserror = "1.0"
 futures = "0.3"
@@ -38,9 +38,9 @@ tezos_protocol_ipc_client = { path = "../tezos/protocol-ipc-client" }
 [dev-dependencies]
 serial_test = "0.5"
 slog-async = "2.6"
-slog-term = "2.8"
+slog-term = "2.9"
 fs_extra = "1.2.0"
-zip = "0.5.5"
+zip = { git = "https://github.com/zip-rs/zip.git", rev = "2009d162fbaf162190e6495e211cebfe6cd98a96" }
 tokio = { version = "1.12", features = ["sync"] }
 nom = "6.1"
 tezos_encoding = { path = "../tezos/encoding" }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -21,7 +21,7 @@ slog = { version = "2.7", features = ["max_level_trace", "release_max_level_trac
 sled = "0.34.6"
 strum = "0.20"
 strum_macros = "0.20"
-zstd = "0.5.3+zstd.1.4.5"
+zstd = "0.10.0"
 edgekv = { path = "../edgekv" }
 fuzzcheck = { git = "https://github.com/tezedge/fuzzcheck-rs.git", optional = true }
 
@@ -33,7 +33,7 @@ tezos_context_api = { path = "../tezos/context-api" }
 
 # Context actions replayer binary and his dependencies
 clap = "2.33"
-slog-term = "2.8"
+slog-term = "2.9"
 slog-async = "2.6"
 
 [[bench]]

--- a/tezos/api/Cargo.toml
+++ b/tezos/api/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 anyhow = "1.0"
 derive_builder = "0.9"
 thiserror = "1.0"
-chrono = { version = "0.4", features = ["serde"] }
+time = { version = "0.3", features = ["parsing"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 slog = { version = "2.7", features = ["max_level_trace", "release_max_level_trace"] }

--- a/tezos/context-api/Cargo.toml
+++ b/tezos/context-api/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Bruno Deferrari <bruno.deferrari@viablesystems.io>"]
 
 [dependencies]
 derive_builder = "0.9"
-chrono = { version = "0.4", features = ["serde"] }
+time = { version = "0.3", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 strum = "0.20"
 strum_macros = "0.20"

--- a/tezos/interop/Cargo.toml
+++ b/tezos/interop/Cargo.toml
@@ -36,7 +36,7 @@ thiserror = "1.0"
 hex = "0.4"
 serde_json = "1.0"
 slog-async = "2.6"
-slog-term = "2.8"
+slog-term = "2.9"
 
 [[bench]]
 name = "interop_benchmark"

--- a/tezos/messages/Cargo.toml
+++ b/tezos/messages/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 bytes = "1"
-chrono = { version = "0.4", features = ["serde"] }
+time = { version = "0.3", features = ["formatting"] }
 derive_builder = "0.9"
 thiserror = "1.0"
 getset = "0.1"


### PR DESCRIPTION
- Replaced `chrono` with `time` in Tezedge sources
- Bumped `slog-term` to get rid of `chrono` dep
- Patched `ipmpsc` with `vergen` updated to `6`
- Patched `vergen` with `chrono` replaced with `time`
- Replaced `zip` with git `master`that has `chrono` replaced with `time` (dev dependency, shouln't be an issue)
- Udated `zstd` dependency in `storage` to match native lib version with the one from `zip`