### PR TITLE
Disable prechecking for Ithaca

### DIFF
--- a/shell_automaton/src/current_head_precheck/mod.rs
+++ b/shell_automaton/src/current_head_precheck/mod.rs
@@ -5,6 +5,7 @@
 // `shell_automaton::current_head::precheck` module and adjust names.
 
 mod current_head_precheck_state;
+use crypto::hash::BlockHash;
 pub use current_head_precheck_state::*;
 
 mod current_head_precheck_actions;
@@ -15,3 +16,19 @@ pub use current_head_precheck_reducer::*;
 
 mod current_head_precheck_effects;
 pub use current_head_precheck_effects::*;
+use tezos_messages::protocol::SupportedProtocol;
+
+use crate::State;
+
+/// Checks if block prechecking is supported for the block that is a successor of the block with `prev_block` hash.
+fn block_prechecking_possible(state: &State, prev_block: &BlockHash) -> bool {
+    state
+        .prechecker
+        .protocol_version_cache
+        .next_protocol_versions
+        .get(prev_block)
+        .map_or(false, |(_, supported_protocol)| match supported_protocol {
+            SupportedProtocol::Proto010 | SupportedProtocol::Proto011 => true,
+            _ => false,
+        })
+}

--- a/shell_automaton/src/mempool/mempool_actions.rs
+++ b/shell_automaton/src/mempool/mempool_actions.rs
@@ -25,6 +25,7 @@ pub struct MempoolRecvDoneAction {
     #[cfg_attr(feature = "fuzzing", field_mutator(SocketAddrMutator))]
     pub address: SocketAddr,
     pub block_hash: BlockHash,
+    pub prev_block_hash: BlockHash,
     pub message: Mempool,
     pub level: Level,
     pub timestamp: i64,

--- a/shell_automaton/src/mempool/mempool_reducer.rs
+++ b/shell_automaton/src/mempool/mempool_reducer.rs
@@ -435,7 +435,7 @@ pub fn mempool_reducer(state: &mut State, action: &ActionWithMeta) {
             message,
             level,
             timestamp,
-            proto: _,
+            ..
         }) => {
             mempool_state.first_current_head = false;
             if let Some(local_head_state) = &mempool_state.local_head_state {
@@ -995,7 +995,7 @@ fn should_skip_block_with_retry(
     }
     let protocol = state
         .protocol_version_cache
-        .protocol_versions
+        .next_protocol_versions
         .get(block_hash)
         .map(|(_, p)| p);
     protocol.map_or(false, |p| *p == SupportedProtocol::Proto011)

--- a/shell_automaton/src/prechecker/mod.rs
+++ b/shell_automaton/src/prechecker/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 mod prechecker_state;
+use crypto::hash::BlockHash;
 pub use prechecker_state::*;
 
 pub mod prechecker_actions;
@@ -14,3 +15,20 @@ pub use prechecker_effects::prechecker_effects;
 
 mod prechecker_validator;
 pub use prechecker_validator::*;
+use tezos_messages::protocol::SupportedProtocol;
+
+use crate::State;
+
+/// Checks if prechecking is enabled for the block that is a successor of the block with `prev_block` hash.
+pub(crate) fn prechecking_enabled(state: &State, prev_block: &BlockHash) -> bool {
+    !state.config.disable_endorsements_precheck
+        && state
+            .prechecker
+            .protocol_version_cache
+            .next_protocol_versions
+            .get(prev_block)
+            .map_or(false, |(_, supported_protocol)| match supported_protocol {
+                SupportedProtocol::Proto010 | SupportedProtocol::Proto011 => true,
+                _ => false,
+            })
+}

--- a/shell_automaton/src/prechecker/prechecker_reducer.rs
+++ b/shell_automaton/src/prechecker/prechecker_reducer.rs
@@ -45,11 +45,11 @@ pub fn prechecker_reducer(state: &mut State, action: &ActionWithMeta) {
             let cache = &mut state.prechecker.protocol_version_cache;
             let duration = cache.time;
             cache
-                .protocol_versions
+                .next_protocol_versions
                 .retain(|_, (timestamp, _)| action.id.duration_since(*timestamp) < duration);
             if let Ok(protocol_version) = value.next_protocol_hash().try_into() {
                 cache
-                    .protocol_versions
+                    .next_protocol_versions
                     .insert(key.clone(), (action.id, protocol_version));
             }
         }

--- a/shell_automaton/src/prechecker/prechecker_state.rs
+++ b/shell_automaton/src/prechecker/prechecker_state.rs
@@ -87,14 +87,16 @@ impl Default for SupportedProtocolState {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ProtocolVersionCache {
     pub time: Duration,
-    pub protocol_versions: BTreeMap<BlockHash, (ActionId, SupportedProtocol)>,
+    /// Mapping from block hash to next protocol, to be used to get protocol
+    /// for incoming current head basing on its predecessor.
+    pub next_protocol_versions: BTreeMap<BlockHash, (ActionId, SupportedProtocol)>,
 }
 
 impl Default for ProtocolVersionCache {
     fn default() -> ProtocolVersionCache {
         Self {
             time: Duration::from_secs(600),
-            protocol_versions: Default::default(),
+            next_protocol_versions: Default::default(),
         }
     }
 }

--- a/shell_automaton/src/rights/rights_state.rs
+++ b/shell_automaton/src/rights/rights_state.rs
@@ -267,3 +267,18 @@ pub struct ProtocolConstants {
     pub endorsers_per_block: u16,
     pub nonce_length: u8,
 }
+
+impl ProtocolConstants {
+    pub fn blocks_per_cycle(&self) -> Option<i32> {
+        Some(self.blocks_per_cycle)
+    }
+    pub fn preserved_cycles(&self) -> Option<u8> {
+        Some(self.preserved_cycles)
+    }
+    pub fn endorsers_per_block(&self) -> Option<u16> {
+        Some(self.endorsers_per_block)
+    }
+    pub fn nonce_length(&self) -> Option<u8> {
+        Some(self.nonce_length)
+    }
+}

--- a/shell_automaton/src/rights/utils.rs
+++ b/shell_automaton/src/rights/utils.rs
@@ -11,7 +11,7 @@ use storage::{
 };
 use tezos_messages::p2p::encoding::block_header::Level;
 
-use super::{Cycle, Delegate, ProtocolConstants};
+use super::{Cycle, Delegate};
 
 #[cfg_attr(feature = "fuzzing", derive(fuzzcheck::DefaultMutator))]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, thiserror::Error)]
@@ -141,7 +141,7 @@ impl TezosPRNG {
 }
 
 pub(super) fn random_owner(
-    constants: &ProtocolConstants,
+    nonce_length: u8,
     cycle_meta_data: &CycleData,
     rolls_map: &BTreeMap<i32, Delegate>,
     use_: &[u8],
@@ -150,7 +150,7 @@ pub(super) fn random_owner(
 ) -> Result<Delegate, TezosPRNGError> {
     let mut prng = TezosPRNG::initialize(
         cycle_meta_data.seed_bytes(),
-        constants.nonce_length.into(),
+        nonce_length.into(),
         use_,
         cycle_position,
         offset.into(),
@@ -167,14 +167,14 @@ pub(super) fn random_owner(
 }
 
 pub(super) fn endorser_rights_owner(
-    constants: &ProtocolConstants,
+    nonce_length: u8,
     cycle_meta_data: &CycleData,
     rolls_map: &BTreeMap<i32, Delegate>,
     cycle_position: i32,
     slot: u16,
 ) -> Result<Delegate, TezosPRNGError> {
     random_owner(
-        constants,
+        nonce_length,
         cycle_meta_data,
         rolls_map,
         b"endorsement",
@@ -184,14 +184,14 @@ pub(super) fn endorser_rights_owner(
 }
 
 pub(super) fn baking_rights_owner(
-    constants: &ProtocolConstants,
+    nonce_length: u8,
     cycle_meta_data: &CycleData,
     rolls_map: &BTreeMap<i32, Delegate>,
     cycle_position: i32,
     priority: u16,
 ) -> Result<Delegate, TezosPRNGError> {
     random_owner(
-        constants,
+        nonce_length,
         cycle_meta_data,
         rolls_map,
         b"baking",

--- a/tezos/messages/src/protocol/mod.rs
+++ b/tezos/messages/src/protocol/mod.rs
@@ -45,7 +45,9 @@ fn init() -> HashMap<String, SupportedProtocol> {
 }
 
 #[cfg_attr(feature = "fuzzing", derive(fuzzcheck::DefaultMutator))]
-#[derive(EnumIter, Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(
+    EnumIter, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
 pub enum SupportedProtocol {
     Proto001,
     Proto002,


### PR DESCRIPTION
Currently we don't support prechecking for the new protocol, but still there is a lot of actions that are executed and reporting errors (e.g. baking and endorsing rights calculation). We need to disable them basing on the block's protocol.