### PR TITLE
Adjusts disk measurements taken by `node_monitoring`

### DIFF
--- a/apps/deploy_monitoring/src/display_info.rs
+++ b/apps/deploy_monitoring/src/display_info.rs
@@ -81,7 +81,7 @@ impl fmt::Display for NodeInfo {
 }
 
 #[derive(Serialize, PartialEq, Clone, Debug, Default, CopyGetters)]
-pub struct OcamlDiskData {
+pub struct OCamlDiskData {
     #[get_copy = "pub(crate)"]
     debugger: u64,
 
@@ -89,25 +89,25 @@ pub struct OcamlDiskData {
     block_storage: u64,
 
     #[get_copy = "pub(crate)"]
-    context_irmin: u64,
+    context_storage: u64,
 }
 
-impl fmt::Display for OcamlDiskData {
+impl fmt::Display for OCamlDiskData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let total = self.block_storage + self.context_irmin;
+        let total = self.block_storage + self.context_storage;
         write!(
             f,
             "{} MB (total)\n\tBlock storage: {} MB\n\tContext: {} MB",
-            total, self.block_storage, self.context_irmin,
+            total, self.block_storage, self.context_storage,
         )
     }
 }
 
-impl OcamlDiskData {
-    pub fn new(debugger: u64, block_storage: u64, context_irmin: u64) -> Self {
+impl OCamlDiskData {
+    pub fn new(debugger: u64, block_storage: u64, context_storage: u64) -> Self {
         Self {
             block_storage,
-            context_irmin,
+            context_storage,
             debugger,
         }
     }
@@ -115,7 +115,7 @@ impl OcamlDiskData {
     pub fn to_megabytes(&self) -> Self {
         Self {
             block_storage: self.block_storage / 1024 / 1024,
-            context_irmin: self.context_irmin / 1024 / 1024,
+            context_storage: self.context_storage / 1024 / 1024,
             debugger: self.debugger / 1024 / 1024,
         }
     }
@@ -124,13 +124,13 @@ impl OcamlDiskData {
 #[derive(Serialize, PartialEq, Clone, Debug)]
 #[serde(untagged)]
 pub enum DiskData {
-    Ocaml(OcamlDiskData),
+    OCaml(OCamlDiskData),
     Tezedge(TezedgeDiskData),
 }
 
-impl From<OcamlDiskData> for DiskData {
-    fn from(data: OcamlDiskData) -> Self {
-        DiskData::Ocaml(data)
+impl From<OCamlDiskData> for DiskData {
+    fn from(data: OCamlDiskData) -> Self {
+        DiskData::OCaml(data)
     }
 }
 
@@ -146,8 +146,8 @@ impl fmt::Display for DiskData {
             DiskData::Tezedge(tezedge) => {
                 write!(f, "Tezedge node: {}", tezedge.to_megabytes(),)
             }
-            DiskData::Ocaml(ocaml) => {
-                write!(f, "\nOcaml node: {}", ocaml.to_megabytes(),)
+            DiskData::OCaml(ocaml) => {
+                write!(f, "\nOCaml node: {}", ocaml.to_megabytes(),)
             }
         }
     }
@@ -156,16 +156,13 @@ impl fmt::Display for DiskData {
 #[derive(Serialize, PartialEq, Clone, Debug, Default, CopyGetters)]
 pub struct TezedgeDiskData {
     #[get_copy = "pub(crate)"]
-    context_irmin: u64,
-
-    #[get_copy = "pub(crate)"]
-    context_merkle_rocksdb: u64,
+    context_storage: u64,
 
     #[get_copy = "pub(crate)"]
     block_storage: u64,
 
     #[get_copy = "pub(crate)"]
-    context_actions: u64,
+    context_stats: u64,
 
     #[get_copy = "pub(crate)"]
     main_db: u64,
@@ -177,24 +174,22 @@ pub struct TezedgeDiskData {
 impl fmt::Display for TezedgeDiskData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let TezedgeDiskData {
-            context_actions,
-            context_irmin,
-            context_merkle_rocksdb,
+            context_stats,
+            context_storage,
             block_storage,
             main_db,
             debugger,
         } = self;
 
         let total =
-            context_actions + context_irmin + context_merkle_rocksdb + block_storage + main_db;
+            context_stats + context_storage + block_storage + main_db;
         writeln!(
             f,
-            "{} MB (total)\n\tMain database: {} MB\n\tContex - irmin: {} MB\n\tContext - rust_merkel_tree: {} MB\n\tContext actions: {} MB\n\tBlock storage (commit log): {} MB\n\tDebugger: {} MB",
+            "{} MB (total)\n\tMain database: {} MB\n\tContext: {} MB\n\tContext stats: {} MB\n\tBlock storage (commit log): {} MB\n\tDebugger: {} MB",
             total,
             main_db,
-            context_irmin,
-            context_merkle_rocksdb,
-            context_actions,
+            context_storage,
+            context_stats,
             block_storage,
             debugger
         )
@@ -204,17 +199,15 @@ impl fmt::Display for TezedgeDiskData {
 impl TezedgeDiskData {
     pub fn new(
         debugger: u64,
-        context_irmin: u64,
-        context_merkle_rocksdb: u64,
+        context: u64,
         block_storage: u64,
-        context_actions: u64,
+        context_stats: u64,
         main_db: u64,
     ) -> Self {
         Self {
-            context_irmin,
-            context_merkle_rocksdb,
+            context_storage,
             block_storage,
-            context_actions,
+            context_stats,
             main_db,
             debugger,
         }
@@ -222,10 +215,9 @@ impl TezedgeDiskData {
 
     pub fn to_megabytes(&self) -> Self {
         Self {
-            context_irmin: self.context_irmin / 1024 / 1024,
-            context_merkle_rocksdb: self.context_merkle_rocksdb / 1024 / 1024,
+            context_storage: self.context_storage / 1024 / 1024,
             block_storage: self.block_storage / 1024 / 1024,
-            context_actions: self.context_actions / 1024 / 1024,
+            context_stats: self.context_stats / 1024 / 1024,
             main_db: self.main_db / 1024 / 1024,
             debugger: self.debugger / 1024 / 1024,
         }
@@ -243,7 +235,7 @@ impl fmt::Display for CpuData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(
             f,
-            "\nOcaml: {}%\nTezedge: \n\tNode: {}\n\tProtocol: {}",
+            "\nOCaml: {}%\nTezedge: \n\tNode: {}\n\tProtocol: {}",
             self.ocaml, self.tezedge, self.protocol_runners
         )
     }

--- a/apps/node_monitoring/src/configuration.rs
+++ b/apps/node_monitoring/src/configuration.rs
@@ -280,7 +280,7 @@ fn parse_nodes_args(
 ) -> Vec<Node> {
     let arg_string = match node_type {
         NodeType::Tezedge => "tezedge-nodes",
-        NodeType::Ocaml => "ocaml-nodes",
+        NodeType::OCaml => "ocaml-nodes",
     };
 
     if let Some(vals) = args.values_of(arg_string) {
@@ -392,7 +392,7 @@ impl DeployMonitoringEnvironment {
 
         let mut tezedge_nodes =
             parse_nodes_args(&args, &NodeType::Tezedge, proxy_port, debugger_path.clone());
-        let ocaml_nodes = parse_nodes_args(&args, &NodeType::Ocaml, proxy_port, debugger_path);
+        let ocaml_nodes = parse_nodes_args(&args, &NodeType::OCaml, proxy_port, debugger_path);
 
         // combine the nodes
         tezedge_nodes.extend(ocaml_nodes);

--- a/apps/node_monitoring/src/display_info.rs
+++ b/apps/node_monitoring/src/display_info.rs
@@ -85,7 +85,7 @@ impl fmt::Display for NodeInfo {
 
 #[derive(Serialize, PartialEq, Clone, Debug, Default, CopyGetters)]
 #[serde(rename_all = "camelCase")]
-pub struct OcamlDiskData {
+pub struct OCamlDiskData {
     #[get_copy = "pub(crate)"]
     debugger: u64,
 
@@ -93,25 +93,25 @@ pub struct OcamlDiskData {
     block_storage: u64,
 
     #[get_copy = "pub(crate)"]
-    context_irmin: u64,
+    context_storage: u64,
 }
 
-impl fmt::Display for OcamlDiskData {
+impl fmt::Display for OCamlDiskData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let total = self.block_storage + self.context_irmin;
+        let total = self.block_storage + self.context_storage;
         write!(
             f,
             "{} MB (total)\n\tBlock storage: {} MB\n\tContext: {} MB",
-            total, self.block_storage, self.context_irmin,
+            total, self.block_storage, self.context_storage,
         )
     }
 }
 
-impl OcamlDiskData {
-    pub fn new(debugger: u64, block_storage: u64, context_irmin: u64) -> Self {
+impl OCamlDiskData {
+    pub fn new(debugger: u64, block_storage: u64, context_storage: u64) -> Self {
         Self {
             block_storage,
-            context_irmin,
+            context_storage,
             debugger,
         }
     }
@@ -119,7 +119,7 @@ impl OcamlDiskData {
     pub fn to_megabytes(&self) -> Self {
         Self {
             block_storage: self.block_storage / 1024 / 1024,
-            context_irmin: self.context_irmin / 1024 / 1024,
+            context_storage: self.context_storage / 1024 / 1024,
             debugger: self.debugger / 1024 / 1024,
         }
     }
@@ -128,13 +128,13 @@ impl OcamlDiskData {
 #[derive(Serialize, PartialEq, Clone, Debug)]
 #[serde(untagged)]
 pub enum DiskData {
-    Ocaml(OcamlDiskData),
+    OCaml(OCamlDiskData),
     Tezedge(TezedgeDiskData),
 }
 
-impl From<OcamlDiskData> for DiskData {
-    fn from(data: OcamlDiskData) -> Self {
-        DiskData::Ocaml(data)
+impl From<OCamlDiskData> for DiskData {
+    fn from(data: OCamlDiskData) -> Self {
+        DiskData::OCaml(data)
     }
 }
 
@@ -158,15 +158,15 @@ impl TryFrom<DiskData> for TezedgeDiskData {
     }
 }
 
-impl TryFrom<DiskData> for OcamlDiskData {
+impl TryFrom<DiskData> for OCamlDiskData {
     type Error = ResourceMonitorError;
 
     fn try_from(data: DiskData) -> Result<Self, ResourceMonitorError> {
-        if let DiskData::Ocaml(disk) = data {
+        if let DiskData::OCaml(disk) = data {
             Ok(disk)
         } else {
             Err(ResourceMonitorError::DiskInfoError {
-                reason: "Cannot conver to OcamlDiskData".to_string(),
+                reason: "Cannot conver to OCamlDiskData".to_string(),
             })
         }
     }
@@ -178,8 +178,8 @@ impl fmt::Display for DiskData {
             DiskData::Tezedge(tezedge) => {
                 write!(f, "Tezedge node: {}", tezedge.to_megabytes(),)
             }
-            DiskData::Ocaml(ocaml) => {
-                write!(f, "\nOcaml node: {}", ocaml.to_megabytes(),)
+            DiskData::OCaml(ocaml) => {
+                write!(f, "\nOCaml node: {}", ocaml.to_megabytes(),)
             }
         }
     }
@@ -189,16 +189,13 @@ impl fmt::Display for DiskData {
 #[serde(rename_all = "camelCase")]
 pub struct TezedgeDiskData {
     #[get_copy = "pub(crate)"]
-    context_irmin: u64,
-
-    #[get_copy = "pub(crate)"]
-    context_merkle_rocksdb: u64,
+    context_storage: u64,
 
     #[get_copy = "pub(crate)"]
     block_storage: u64,
 
     #[get_copy = "pub(crate)"]
-    context_actions: u64,
+    context_stats: u64,
 
     #[get_copy = "pub(crate)"]
     main_db: u64,
@@ -210,24 +207,21 @@ pub struct TezedgeDiskData {
 impl fmt::Display for TezedgeDiskData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let TezedgeDiskData {
-            context_actions,
-            context_irmin,
-            context_merkle_rocksdb,
+            context_stats,
+            context_storage,
             block_storage,
             main_db,
             debugger,
         } = self;
 
-        let total =
-            context_actions + context_irmin + context_merkle_rocksdb + block_storage + main_db;
+        let total = context_stats + context_storage + block_storage + main_db;
         writeln!(
             f,
-            "{} MB (total)\n\tMain database: {} MB\n\tContex - irmin: {} MB\n\tContext - rust_merkel_tree: {} MB\n\tContext actions: {} MB\n\tBlock storage (commit log): {} MB\n\tDebugger: {} MB",
+            "{} MB (total)\n\tMain database: {} MB\n\tContext: {} MB\n\tContext stats: {} MB\n\tBlock storage (commit log): {} MB\n\tDebugger: {} MB",
             total,
             main_db,
-            context_irmin,
-            context_merkle_rocksdb,
-            context_actions,
+            context_storage,
+            context_stats,
             block_storage,
             debugger
         )
@@ -237,17 +231,15 @@ impl fmt::Display for TezedgeDiskData {
 impl TezedgeDiskData {
     pub fn new(
         debugger: u64,
-        context_irmin: u64,
-        context_merkle_rocksdb: u64,
+        context_storage: u64,
         block_storage: u64,
-        context_actions: u64,
+        context_stats: u64,
         main_db: u64,
     ) -> Self {
         Self {
-            context_irmin,
-            context_merkle_rocksdb,
+            context_storage,
             block_storage,
-            context_actions,
+            context_stats,
             main_db,
             debugger,
         }
@@ -255,10 +247,9 @@ impl TezedgeDiskData {
 
     pub fn to_megabytes(&self) -> Self {
         Self {
-            context_irmin: self.context_irmin / 1024 / 1024,
-            context_merkle_rocksdb: self.context_merkle_rocksdb / 1024 / 1024,
+            context_storage: self.context_storage / 1024 / 1024,
             block_storage: self.block_storage / 1024 / 1024,
-            context_actions: self.context_actions / 1024 / 1024,
+            context_stats: self.context_stats / 1024 / 1024,
             main_db: self.main_db / 1024 / 1024,
             debugger: self.debugger / 1024 / 1024,
         }
@@ -276,7 +267,7 @@ impl fmt::Display for CpuData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(
             f,
-            "\nOcaml: {}%\nTezedge: \n\tNode: {}\n\tProtocol: {}",
+            "\nOCaml: {}%\nTezedge: \n\tNode: {}\n\tProtocol: {}",
             self.ocaml, self.tezedge, self.protocol_runners
         )
     }

--- a/apps/node_monitoring/src/node.rs
+++ b/apps/node_monitoring/src/node.rs
@@ -16,7 +16,7 @@ use netinfo::{InoutType, NetStatistics};
 use sysinfo::{ProcessExt, System, SystemExt};
 
 use crate::display_info::NodeInfo;
-use crate::display_info::{DiskData, OcamlDiskData, TezedgeDiskData};
+use crate::display_info::{DiskData, OCamlDiskData, TezedgeDiskData};
 use crate::monitors::resource::{
     DiskReadWrite, NetworkStats, ProcessCpuUsage, ResourceMonitorError, ValidatorCpuStats,
     ValidatorIOStats, ValidatorMemoryStats,
@@ -26,7 +26,7 @@ const MILLIS_TO_SECONDS_CONVERSION_CONSTANT: u64 = 1000;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum NodeType {
-    Ocaml,
+    OCaml,
     Tezedge,
 }
 
@@ -94,10 +94,10 @@ impl Node {
     pub fn get_disk_data(&self) -> DiskData {
         let volume_path = self.volume_path.as_path().display();
         if self.node_type == NodeType::Tezedge {
-            // context actions DB is optional
-            let context_actions = dir::get_size(&format!(
+            // context stats DB is optional
+            let context_stats = dir::get_size(&format!(
                 "{}/{}",
-                volume_path, "bootstrap_db/context_actions"
+                volume_path, "context-stats-db"
             ))
             .unwrap_or(0);
 
@@ -115,10 +115,9 @@ impl Node {
             let disk_data = TezedgeDiskData::new(
                 debugger,
                 dir::get_size(&format!("{}/{}", volume_path, "context")).unwrap_or(0),
-                dir::get_size(&format!("{}/{}", volume_path, "bootstrap_db/context")).unwrap_or(0),
                 dir::get_size(&format!("{}/{}", volume_path, "bootstrap_db/block_storage"))
                     .unwrap_or(0),
-                context_actions,
+                context_stats,
                 dir::get_size(&format!("{}/{}", volume_path, "bootstrap_db/db")).unwrap_or(0),
             );
 
@@ -135,7 +134,7 @@ impl Node {
                 0
             };
 
-            DiskData::Ocaml(OcamlDiskData::new(
+            DiskData::OCaml(OCamlDiskData::new(
                 debugger,
                 dir::get_size(&format!("{}/{}", volume_path, "data/store")).unwrap_or(0),
                 dir::get_size(&format!("{}/{}", volume_path, "data/context")).unwrap_or(0),


### PR DESCRIPTION
Doesn't differentiate between context backends, always measures "context/"
Also replaces context-actions with context-stats-db