### PR TITLE
Mixed node python tests

### DIFF
--- a/tezos/python-tests/README.md
+++ b/tezos/python-tests/README.md
@@ -15,7 +15,7 @@ Examples:
 - `TO` = launch `light-node` followed by `tezos-node`, and repeat
 - `OOT` = launch two `tezos-node` followed by one `light-node` and repeat
 
-## Tests
+## Tests (THIS TABLE IS OUTDATED)
 
 |             Test              |Tezedge compatibility          |local  | drone  |               Description                                               | Modifications                            |       Comment
 |-------------------------------|-------------------------------|-------|--------|-------------------------------------------------------------------------|------------------------------------------|-------------------------------------------------|

--- a/tezos/python-tests/README.md
+++ b/tezos/python-tests/README.md
@@ -2,6 +2,19 @@
 
 Tezos python test framework run with the tezedge node
 
+## Mixed node tests
+
+By default tests will be executed using `light-node`, but it is possible to mix between `tezos-node` and `light-node` when running the tests.
+
+This is controlled by the `TEZOS_NODE_SEQUENCE` environment variable. It should be a sequence of `T` and `O` letters, specifying the order in which the nodes will be picked. The specified sequence will be cycled to make it infinite.
+
+Examples:
+
+- `T` = launch only `light-node`
+- `O` = launch only `tezos-node`
+- `TO` = launch `light-node` followed by `tezos-node`, and repeat
+- `OOT` = launch two `tezos-node` followed by one `light-node` and repeat
+
 ## Tests
 
 |             Test              |Tezedge compatibility          |local  | drone  |               Description                                               | Modifications                            |       Comment
@@ -12,7 +25,7 @@ Tezos python test framework run with the tezedge node
 | test_many_bakers              |           Full                |passing|passing |Run 5 bakers and num nodes, wait and check logs                          | None                                     | None|
 | test_many_nodes               |           Full                |passing|passing |Run many nodes, wait a while, run more nodes, check logs                 | None                                     | None|
 | test_mempool                  |           Full                |passing|passing |inject ops, check mempool before and after, bake blocks                  | None                                     | None                                         |
-| test_fork                     |           Full                |passing|passing |inject ops, check mempool before and after, bake blocks                  | None                                     | None          | 
+| test_fork                     |           Full                |passing|passing |inject ops, check mempool before and after, bake blocks                  | None                                     | None          |
 | test_voting                   |           Full                |failing|failing |Test voting protocol with manual baking, 4 blocks per voting period      | None                                     | Implement protocol injection |
 | test_tls                      |           ?                   |-      | -      |test client interaction (test_bootstrapped) with node tls                | None                                     | Implement tls in tezedge                     |
 | test_rpc                      |           ?                   |-      | -      |tests all rpcs in tezos node and protocol                                | None                                     | Implement all rpcs in tezedge                |


### PR DESCRIPTION
By default tests will be executed using `light-node`, but it is possible to mix between `tezos-node` and `light-node` when running the tests.

This is controlled by the `TEZOS_NODE_SEQUENCE` environment variable. It should be a sequence of `T` and `O` letters, specifying the order in which the nodes will be picked. The specified sequence will be cycled to make it infinite.

Examples:

- `T` = launch only `light-node`
- `O` = launch only `tezos-node`
- `TO` = launch `light-node` followed by `tezos-node`, and repeat
- `OOT` = launch two `tezos-node` followed by one `light-node` and repeat
