### PR TITLE
Log block header download progress

### DIFF
--- a/shell_automaton/src/action.rs
+++ b/shell_automaton/src/action.rs
@@ -201,15 +201,7 @@ where
     }
 }
 
-#[derive(
-    EnumKind,
-    strum_macros::AsRefStr,
-    strum_macros::IntoStaticStr,
-    Serialize,
-    Deserialize,
-    Debug,
-    Clone,
-)]
+#[derive(EnumKind, Serialize, Deserialize, Debug, Clone)]
 #[enum_kind(
     ActionKind,
     derive(

--- a/shell_automaton/src/bootstrap/bootstrap_state.rs
+++ b/shell_automaton/src/bootstrap/bootstrap_state.rs
@@ -484,6 +484,9 @@ pub enum BootstrapState {
         time: u64,
         timeouts_last_check: Option<u64>,
 
+        last_logged: u64,
+        last_logged_downloaded_count: usize,
+
         /// Level of the last(highest) block in the main_chain.
         main_chain_last_level: Level,
 

--- a/shell_automaton/tests/connection_threshold.rs
+++ b/shell_automaton/tests/connection_threshold.rs
@@ -257,7 +257,7 @@ fn dump_graph(name: &str, graph: state_explorer::Graph<ActionWithMeta, Connected
                         r#"State_{} -> State_{}[label="{}"]"#,
                         i,
                         state,
-                        graph.actions[action].action.as_ref()
+                        graph.actions[action].action.kind()
                     )?;
                 }
             }


### PR DESCRIPTION
Downloading/Syncing block headers can take some time, especially in case of slow network, so log progress to terminal to show current state of downloading block headers.