### PR TITLE
Mempool prevalidator refactor

### DIFF
--- a/shell_automaton/src/action.rs
+++ b/shell_automaton/src/action.rs
@@ -55,7 +55,7 @@ use crate::peer::disconnection::{PeerDisconnectAction, PeerDisconnectedAction};
 
 use crate::peer::handshaking::*;
 
-use crate::mempool::PrevalidatorAction;
+use crate::mempool::validator::*;
 use crate::peers::add::multi::PeersAddMultiAction;
 use crate::peers::add::PeersAddIncomingPeerAction;
 use crate::peers::check::timeouts::{
@@ -482,14 +482,11 @@ pub enum Action {
     BootstrapFinished(BootstrapFinishedAction),
     BootstrapFromPeerCurrentHead(BootstrapFromPeerCurrentHeadAction),
 
-    Prevalidator(PrevalidatorAction),
-
     MempoolRecvDone(MempoolRecvDoneAction),
     MempoolGetOperations(MempoolGetOperationsAction),
     MempoolMarkOperationsAsPending(MempoolMarkOperationsAsPendingAction),
     MempoolOperationRecvDone(MempoolOperationRecvDoneAction),
     MempoolOperationInject(MempoolOperationInjectAction),
-    MempoolValidateStart(MempoolValidateStartAction),
     MempoolRpcRespond(MempoolRpcRespondAction),
     MempoolRegisterOperationsStream(MempoolRegisterOperationsStreamAction),
     MempoolUnregisterOperationsStreams(MempoolUnregisterOperationsStreamsAction),
@@ -499,9 +496,18 @@ pub enum Action {
     MempoolBroadcast(MempoolBroadcastAction),
     MempoolBroadcastDone(MempoolBroadcastDoneAction),
     MempoolGetPendingOperations(MempoolGetPendingOperationsAction),
-    MempoolFlush(MempoolFlushAction),
     MempoolOperationDecoded(MempoolOperationDecodedAction),
     MempoolRpcEndorsementsStatusGet(MempoolRpcEndorsementsStatusGetAction),
+    MempoolOperationValidateNext(MempoolOperationValidateNextAction),
+
+    MempoolValidatorInit(MempoolValidatorInitAction),
+    MempoolValidatorPending(MempoolValidatorPendingAction),
+    MempoolValidatorSuccess(MempoolValidatorSuccessAction),
+    MempoolValidatorReady(MempoolValidatorReadyAction),
+
+    MempoolValidatorValidateInit(MempoolValidatorValidateInitAction),
+    MempoolValidatorValidatePending(MempoolValidatorValidatePendingAction),
+    MempoolValidatorValidateSuccess(MempoolValidatorValidateSuccessAction),
 
     BlockInject(BlockInjectAction),
 

--- a/shell_automaton/src/block_applier/block_applier_effects.rs
+++ b/shell_automaton/src/block_applier/block_applier_effects.rs
@@ -235,10 +235,14 @@ where
                     let new_head = block.clone();
                     let protocol = block_additional_data.protocol_hash.clone();
                     let next_protocol = block_additional_data.next_protocol_hash.clone();
+                    let block_metadata_hash = block_additional_data.block_metadata_hash().clone();
+                    let ops_metadata_hash = block_additional_data.ops_metadata_hash().clone();
                     store.dispatch(CurrentHeadUpdateAction {
                         new_head,
                         protocol,
                         next_protocol,
+                        block_metadata_hash,
+                        ops_metadata_hash,
                     });
                 }
                 _ => return,

--- a/shell_automaton/src/current_head/current_head_actions.rs
+++ b/shell_automaton/src/current_head/current_head_actions.rs
@@ -3,9 +3,9 @@
 
 use std::sync::Arc;
 
-use crypto::hash::ProtocolHash;
 use serde::{Deserialize, Serialize};
 
+use crypto::hash::{BlockMetadataHash, OperationMetadataListListHash, ProtocolHash};
 use storage::BlockHeaderWithHash;
 
 use crate::protocol_runner::ProtocolRunnerState;
@@ -69,6 +69,9 @@ impl EnablingCondition<State> for CurrentHeadRehydrateErrorAction {
 pub struct CurrentHeadRehydrateSuccessAction {
     pub head: BlockHeaderWithHash,
     pub head_pred: Option<BlockHeaderWithHash>,
+
+    pub block_metadata_hash: Option<BlockMetadataHash>,
+    pub ops_metadata_hash: Option<OperationMetadataListListHash>,
 }
 
 impl EnablingCondition<State> for CurrentHeadRehydrateSuccessAction {
@@ -99,6 +102,9 @@ pub struct CurrentHeadUpdateAction {
     pub new_head: Arc<BlockHeaderWithHash>,
     pub protocol: ProtocolHash,
     pub next_protocol: ProtocolHash,
+
+    pub block_metadata_hash: Option<BlockMetadataHash>,
+    pub ops_metadata_hash: Option<OperationMetadataListListHash>,
 }
 
 impl EnablingCondition<State> for CurrentHeadUpdateAction {

--- a/shell_automaton/src/current_head/current_head_actions.rs
+++ b/shell_automaton/src/current_head/current_head_actions.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
-use crypto::hash::{BlockMetadataHash, OperationMetadataListListHash, ProtocolHash};
+use crypto::hash::{
+    BlockMetadataHash, BlockPayloadHash, OperationMetadataListListHash, ProtocolHash,
+};
 use storage::BlockHeaderWithHash;
 
 use crate::protocol_runner::ProtocolRunnerState;
@@ -102,7 +104,7 @@ pub struct CurrentHeadUpdateAction {
     pub new_head: Arc<BlockHeaderWithHash>,
     pub protocol: ProtocolHash,
     pub next_protocol: ProtocolHash,
-
+    pub payload_hash: Option<BlockPayloadHash>,
     pub block_metadata_hash: Option<BlockMetadataHash>,
     pub ops_metadata_hash: Option<OperationMetadataListListHash>,
 }

--- a/shell_automaton/src/current_head/current_head_effects.rs
+++ b/shell_automaton/src/current_head/current_head_effects.rs
@@ -46,10 +46,13 @@ where
             }
 
             match &content.response.result {
-                Ok(StorageResponseSuccess::CurrentHeadGetSuccess(head, pred)) => {
+                Ok(StorageResponseSuccess::CurrentHeadGetSuccess(head, pred, additional_data)) => {
                     store.dispatch(CurrentHeadRehydrateSuccessAction {
                         head: head.clone(),
                         head_pred: pred.clone(),
+
+                        block_metadata_hash: additional_data.block_metadata_hash().clone(),
+                        ops_metadata_hash: additional_data.ops_metadata_hash().clone(),
                     });
                 }
                 Err(StorageResponseError::CurrentHeadGetError(error)) => {

--- a/shell_automaton/src/current_head/current_head_reducer.rs
+++ b/shell_automaton/src/current_head/current_head_reducer.rs
@@ -29,16 +29,33 @@ pub fn current_head_reducer(state: &mut State, action: &ActionWithMeta) {
                 time: action.time_as_nanos(),
                 head: content.head.clone(),
                 head_pred: content.head_pred.clone(),
+                block_metadata_hash: content.block_metadata_hash.clone(),
+                ops_metadata_hash: content.ops_metadata_hash.clone(),
             };
         }
         Action::CurrentHeadRehydrated(_) => {
-            let (head, head_pred) = match &state.current_head {
-                CurrentHeadState::RehydrateSuccess {
-                    head, head_pred, ..
-                } => (head.clone(), head_pred.clone()),
-                _ => return,
+            let (head, head_pred, block_metadata_hash, ops_metadata_hash) =
+                match &state.current_head {
+                    CurrentHeadState::RehydrateSuccess {
+                        head,
+                        head_pred,
+                        block_metadata_hash,
+                        ops_metadata_hash,
+                        ..
+                    } => (
+                        head.clone(),
+                        head_pred.clone(),
+                        block_metadata_hash.clone(),
+                        ops_metadata_hash.clone(),
+                    ),
+                    _ => return,
+                };
+            state.current_head = CurrentHeadState::Rehydrated {
+                head,
+                head_pred,
+                block_metadata_hash,
+                ops_metadata_hash,
             };
-            state.current_head = CurrentHeadState::Rehydrated { head, head_pred };
         }
         Action::CurrentHeadUpdate(content) => {
             let head_pred = state
@@ -51,6 +68,9 @@ pub fn current_head_reducer(state: &mut State, action: &ActionWithMeta) {
             state.current_head = CurrentHeadState::Rehydrated {
                 head: content.new_head.as_ref().clone(),
                 head_pred,
+
+                block_metadata_hash: content.block_metadata_hash.clone(),
+                ops_metadata_hash: content.ops_metadata_hash.clone(),
             };
         }
         _ => {}

--- a/shell_automaton/src/current_head/current_head_reducer.rs
+++ b/shell_automaton/src/current_head/current_head_reducer.rs
@@ -53,6 +53,7 @@ pub fn current_head_reducer(state: &mut State, action: &ActionWithMeta) {
             state.current_head = CurrentHeadState::Rehydrated {
                 head,
                 head_pred,
+                payload_hash: None,
                 block_metadata_hash,
                 ops_metadata_hash,
             };
@@ -68,7 +69,7 @@ pub fn current_head_reducer(state: &mut State, action: &ActionWithMeta) {
             state.current_head = CurrentHeadState::Rehydrated {
                 head: content.new_head.as_ref().clone(),
                 head_pred,
-
+                payload_hash: content.payload_hash.clone(),
                 block_metadata_hash: content.block_metadata_hash.clone(),
                 ops_metadata_hash: content.ops_metadata_hash.clone(),
             };

--- a/shell_automaton/src/current_head/current_head_state.rs
+++ b/shell_automaton/src/current_head/current_head_state.rs
@@ -3,6 +3,7 @@
 
 use serde::{Deserialize, Serialize};
 
+use crypto::hash::{BlockHash, BlockMetadataHash, OperationMetadataListListHash};
 use storage::BlockHeaderWithHash;
 
 use crate::request::RequestId;
@@ -27,11 +28,19 @@ pub enum CurrentHeadState {
         time: u64,
         head: BlockHeaderWithHash,
         head_pred: Option<BlockHeaderWithHash>,
+
+        block_metadata_hash: Option<BlockMetadataHash>,
+        ops_metadata_hash: Option<OperationMetadataListListHash>,
     },
 
     Rehydrated {
         head: BlockHeaderWithHash,
         head_pred: Option<BlockHeaderWithHash>,
+
+        // Needed for mempool prevalidator's begin construction
+        // for prevalidation request.
+        block_metadata_hash: Option<BlockMetadataHash>,
+        ops_metadata_hash: Option<OperationMetadataListListHash>,
     },
 }
 
@@ -46,6 +55,10 @@ impl CurrentHeadState {
             Self::Rehydrated { head, .. } => Some(head),
             _ => None,
         }
+    }
+
+    pub fn get_hash(&self) -> Option<&BlockHash> {
+        self.get().map(|v| &v.hash)
     }
 
     pub fn get_pred(&self) -> Option<&BlockHeaderWithHash> {

--- a/shell_automaton/src/current_head/current_head_state.rs
+++ b/shell_automaton/src/current_head/current_head_state.rs
@@ -1,6 +1,7 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
+use crypto::hash::BlockPayloadHash;
 use serde::{Deserialize, Serialize};
 
 use crypto::hash::{BlockHash, BlockMetadataHash, OperationMetadataListListHash};
@@ -37,6 +38,7 @@ pub enum CurrentHeadState {
         head: BlockHeaderWithHash,
         head_pred: Option<BlockHeaderWithHash>,
 
+        payload_hash: Option<BlockPayloadHash>,
         // Needed for mempool prevalidator's begin construction
         // for prevalidation request.
         block_metadata_hash: Option<BlockMetadataHash>,
@@ -64,6 +66,13 @@ impl CurrentHeadState {
     pub fn get_pred(&self) -> Option<&BlockHeaderWithHash> {
         match self {
             Self::Rehydrated { head_pred, .. } => head_pred.as_ref(),
+            _ => None,
+        }
+    }
+
+    pub fn payload_hash(&self) -> Option<&BlockPayloadHash> {
+        match self {
+            Self::Rehydrated { payload_hash, .. } => payload_hash.as_ref(),
             _ => None,
         }
     }

--- a/shell_automaton/src/current_head_precheck/current_head_precheck_effects.rs
+++ b/shell_automaton/src/current_head_precheck/current_head_precheck_effects.rs
@@ -22,6 +22,9 @@ where
 {
     match &action.action {
         Action::PeerMessageReadSuccess(PeerMessageReadSuccessAction { message, .. }) => {
+            if !block_prechecking_enabled(store.state()) {
+                return;
+            }
             let current_head = if let PeerMessage::CurrentHead(current_head) = message.message() {
                 current_head
             } else {
@@ -45,6 +48,9 @@ where
             block_header,
             ..
         }) => {
+            if !block_prechecking_enabled(store.state()) {
+                return;
+            }
             store.dispatch(CurrentHeadReceivedAction {
                 block_hash: block_hash.clone(),
                 block_header: block_header.as_ref().clone(),

--- a/shell_automaton/src/current_head_precheck/mod.rs
+++ b/shell_automaton/src/current_head_precheck/mod.rs
@@ -33,3 +33,7 @@ fn block_prechecking_possible(state: &State, prev_block: &BlockHash) -> bool {
             )
         })
 }
+
+fn block_prechecking_enabled(state: &State) -> bool {
+    !state.config.disable_block_precheck
+}

--- a/shell_automaton/src/effects.rs
+++ b/shell_automaton/src/effects.rs
@@ -51,6 +51,7 @@ use crate::peers::graylist::peers_graylist_effects;
 use crate::peers::init::peers_init_effects;
 
 use crate::mempool::mempool_effects;
+use crate::mempool::validator::mempool_validator_effects;
 
 use crate::storage::blocks::genesis::check_applied::storage_blocks_genesis_check_applied_effects;
 use crate::storage::blocks::genesis::init::additional_data_put::storage_blocks_genesis_init_additional_data_put_effects;
@@ -156,6 +157,7 @@ pub fn effects<S: Service>(store: &mut Store<S>, action: &ActionWithMeta) {
     peers_graylist_effects(store, action);
 
     bootstrap_effects(store, action);
+    mempool_validator_effects(store, action);
     mempool_effects(store, action);
 
     storage_request_effects(store, action);

--- a/shell_automaton/src/logger/logger_effects.rs
+++ b/shell_automaton/src/logger/logger_effects.rs
@@ -19,7 +19,8 @@ pub fn logger_effects<S: Service>(store: &mut Store<S>, action: &ActionWithMeta)
             slog::info!(log, "CurrentHead Updated";
                 "level" => content.new_head.header.level(),
                 "hash" => content.new_head.hash.to_string(),
-                "fitness" => display_fitness(content.new_head.header.fitness()));
+                "fitness" => display_fitness(content.new_head.header.fitness()),
+                "payload_hash" => format!("{:?}", content.payload_hash.as_ref()));
             slog::debug!(log, "CurrentHead Updated - full header";
                 "new_head" => slog::FnValue(|_| format!("{:?}", content.new_head)));
         }

--- a/shell_automaton/src/mempool/mempool_actions.rs
+++ b/shell_automaton/src/mempool/mempool_actions.rs
@@ -69,6 +69,7 @@ impl EnablingCondition<State> for MempoolMarkOperationsAsPendingAction {
 #[cfg_attr(feature = "fuzzing", derive(fuzzcheck::DefaultMutator))]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MempoolOperationRecvDoneAction {
+    pub hash: OperationHash,
     pub operation: Operation,
 }
 
@@ -83,7 +84,7 @@ impl EnablingCondition<State> for MempoolOperationRecvDoneAction {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MempoolOperationInjectAction {
     pub operation: Operation,
-    pub operation_hash: OperationHash,
+    pub hash: OperationHash,
     pub rpc_id: RpcId,
     pub injected_timestamp: u64,
 }

--- a/shell_automaton/src/mempool/mempool_actions.rs
+++ b/shell_automaton/src/mempool/mempool_actions.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 
 use crypto::hash::{BlockHash, ChainId, OperationHash};
-use tezos_api::ffi::{PrevalidatorWrapper, ValidateOperationResponse};
 use tezos_messages::p2p::encoding::block_header::BlockHeader;
 use tezos_messages::p2p::encoding::{mempool::Mempool, operation::Operation};
 
@@ -34,8 +33,7 @@ pub struct MempoolRecvDoneAction {
 
 impl EnablingCondition<State> for MempoolRecvDoneAction {
     fn is_enabled(&self, state: &State) -> bool {
-        let _ = state;
-        true
+        state.mempool.running_since.is_some()
     }
 }
 
@@ -109,20 +107,6 @@ pub struct BlockInjectAction {
 
 impl EnablingCondition<State> for BlockInjectAction {
     fn is_enabled(&self, _state: &State) -> bool {
-        true
-    }
-}
-
-#[cfg_attr(feature = "fuzzing", derive(fuzzcheck::DefaultMutator))]
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct MempoolValidateStartAction {
-    pub operation: Operation,
-}
-
-impl EnablingCondition<State> for MempoolValidateStartAction {
-    fn is_enabled(&self, state: &State) -> bool {
-        // TODO(vlad):
-        let _ = state;
         true
     }
 }
@@ -275,20 +259,6 @@ impl EnablingCondition<State> for MempoolOperationDecodedAction {
     }
 }
 
-#[cfg_attr(feature = "fuzzing", derive(fuzzcheck::DefaultMutator))]
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct MempoolFlushAction {}
-
-impl EnablingCondition<State> for MempoolFlushAction {
-    fn is_enabled(&self, state: &State) -> bool {
-        if let Some(state) = &state.mempool.local_head_state {
-            state.prevalidator_ready
-        } else {
-            false
-        }
-    }
-}
-
 // RPC
 
 pub(super) trait MempoolOperationMatcher {
@@ -386,19 +356,12 @@ impl EnablingCondition<State> for MempoolRpcEndorsementsStatusGetAction {
     }
 }
 
-// Prevalidator
 #[cfg_attr(feature = "fuzzing", derive(fuzzcheck::DefaultMutator))]
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum PrevalidatorAction {
-    Error(String),
-    PrevalidatorReady(PrevalidatorWrapper),
-    PrevalidatorForMempoolReady(PrevalidatorWrapper),
-    OperationValidated(ValidateOperationResponse),
-}
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct MempoolOperationValidateNextAction {}
 
-impl EnablingCondition<State> for PrevalidatorAction {
+impl EnablingCondition<State> for MempoolOperationValidateNextAction {
     fn is_enabled(&self, state: &State) -> bool {
-        let _ = state;
-        true
+        !state.mempool.pending_operations.is_empty() && state.mempool.validator.is_ready()
     }
 }

--- a/shell_automaton/src/mempool/mempool_effects.rs
+++ b/shell_automaton/src/mempool/mempool_effects.rs
@@ -71,7 +71,7 @@ where
         Action::MempoolOperationValidateNext(_) => {
             let mempool_state = &store.state().mempool;
 
-            let (op_hash, op_content) = match mempool_state.pending_operations.iter().nth(0) {
+            let (op_hash, op_content) = match mempool_state.pending_operations.iter().next() {
                 Some(v) => (v.0.clone(), v.1.clone()),
                 None => return,
             };

--- a/shell_automaton/src/mempool/mempool_reducer.rs
+++ b/shell_automaton/src/mempool/mempool_reducer.rs
@@ -398,7 +398,6 @@ pub fn mempool_reducer(state: &mut State, action: &ActionWithMeta) {
                             .operations_state
                             .insert(hash.clone(), MempoolOperation::received(level, action));
                     }
-
                 }
                 // of course peer knows about it, because he sent us it
                 peer.seen_operations.insert(hash);
@@ -419,8 +418,7 @@ pub fn mempool_reducer(state: &mut State, action: &ActionWithMeta) {
                 return;
             }
 
-            if !state.config.disable_endorsements_precheck
-                && prechecking_enabled(&state.prechecker, operation.branch())
+            if prechecking_enabled(&state.prechecker, operation.branch())
                 && matches!(
                     OperationKind::from_operation_content_raw(operation.data().as_ref()),
                     OperationKind::Preendorsement | OperationKind::Endorsement
@@ -461,12 +459,12 @@ pub fn mempool_reducer(state: &mut State, action: &ActionWithMeta) {
                 .injecting_rpc_ids
                 .insert(operation_hash.clone(), *rpc_id);
 
-            let is_consensus_operation = matches!(
-                OperationKind::from_operation_content_raw(operation.data().as_ref()),
-                OperationKind::Preendorsement | OperationKind::Endorsement
-            );
-
-            if is_consensus_operation {
+            if prechecking_enabled(&state.prechecker, operation.branch())
+                && matches!(
+                    OperationKind::from_operation_content_raw(operation.data().as_ref()),
+                    OperationKind::Preendorsement | OperationKind::Endorsement
+                )
+            {
                 mempool_state
                     .prechecking_operations
                     .insert(operation_hash.clone());

--- a/shell_automaton/src/mempool/mempool_state.rs
+++ b/shell_automaton/src/mempool/mempool_state.rs
@@ -2,16 +2,13 @@
 // SPDX-License-Identifier: MIT
 
 use std::{
-    collections::{BTreeMap, HashMap, HashSet, VecDeque},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
     net::SocketAddr,
 };
 
 use serde::{Deserialize, Serialize};
 
-use crypto::hash::{
-    BlockHash, BlockMetadataHash, CryptoboxPublicKeyHash, OperationHash,
-    OperationMetadataListListHash,
-};
+use crypto::hash::{BlockHash, CryptoboxPublicKeyHash, OperationHash};
 use tezos_api::ffi::{Applied, Errored};
 use tezos_messages::p2p::encoding::{
     block_header::{BlockHeader, Level},
@@ -53,6 +50,7 @@ pub struct MempoolState {
     pub(super) pending_full_content: HashSet<OperationHash>,
     // operations that passed basic checks, sent to protocol validator
     pub(super) pending_operations: HashMap<OperationHash, Operation>,
+    pub(super) prechecking_operations: BTreeSet<OperationHash>,
     pub validated_operations: ValidatedOperations,
     // track ttl
     pub(super) level_to_operation: BTreeMap<i32, Vec<OperationHash>>,

--- a/shell_automaton/src/mempool/mempool_state.rs
+++ b/shell_automaton/src/mempool/mempool_state.rs
@@ -12,7 +12,7 @@ use crypto::hash::{
     BlockHash, BlockMetadataHash, CryptoboxPublicKeyHash, OperationHash,
     OperationMetadataListListHash,
 };
-use tezos_api::ffi::{Applied, Errored, PrevalidatorWrapper};
+use tezos_api::ffi::{Applied, Errored};
 use tezos_messages::p2p::encoding::{
     block_header::{BlockHeader, Level},
     operation::Operation,
@@ -22,6 +22,8 @@ use crate::{
     prechecker::OperationDecodedContents, rights::Slot, service::rpc_service::RpcId, ActionWithMeta,
 };
 
+use super::validator::MempoolValidatorState;
+
 /// https://gitlab.com/tezedge/tezos/-/blob/v12.2/src/lib_shell/prevalidator.ml#L219
 ///
 /// Bound for the refused (refused, branch_refused, branch_delayed, outdated)
@@ -29,12 +31,13 @@ use crate::{
 /// bound is reached and we add operation, oldest one will be removed.
 pub const MAX_REFUSED_OPERATIONS: usize = 2048;
 
-#[derive(Default, Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct MempoolState {
+    pub validator: MempoolValidatorState,
+
     // TODO(vlad): instant
     pub running_since: Option<()>,
     //
-    pub prevalidator: Option<PrevalidatorWrapper>,
     // performing rpc
     pub(super) injecting_rpc_ids: HashMap<OperationHash, RpcId>,
     // performed rpc
@@ -74,11 +77,6 @@ impl MempoolState {
 pub struct HeadState {
     pub header: BlockHeader,
     pub hash: BlockHash,
-    // prevalidator for the head is created
-    pub prevalidator_ready: bool,
-
-    pub metadata_hash: Option<BlockMetadataHash>,
-    pub ops_metadata_hash: Option<OperationMetadataListListHash>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/shell_automaton/src/mempool/mod.rs
+++ b/shell_automaton/src/mempool/mod.rs
@@ -1,6 +1,8 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
+pub mod validator;
+
 mod mempool_state;
 pub use self::mempool_state::*;
 

--- a/shell_automaton/src/mempool/validator/mempool_validator_actions.rs
+++ b/shell_automaton/src/mempool/validator/mempool_validator_actions.rs
@@ -1,0 +1,104 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use serde::{Deserialize, Serialize};
+
+use crypto::hash::OperationHash;
+use tezos_api::ffi::PrevalidatorWrapper;
+use tezos_messages::p2p::encoding::prelude::Operation;
+
+use crate::{EnablingCondition, State};
+
+use super::{MempoolValidatorState, MempoolValidatorValidateResult};
+
+#[cfg_attr(feature = "fuzzing", derive(fuzzcheck::DefaultMutator))]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct MempoolValidatorInitAction {}
+
+impl EnablingCondition<State> for MempoolValidatorInitAction {
+    fn is_enabled(&self, state: &State) -> bool {
+        state.protocol_runner.is_ready() && state.current_head.get().is_some()
+    }
+}
+
+#[cfg_attr(feature = "fuzzing", derive(fuzzcheck::DefaultMutator))]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct MempoolValidatorPendingAction {}
+
+impl EnablingCondition<State> for MempoolValidatorPendingAction {
+    fn is_enabled(&self, state: &State) -> bool {
+        matches!(&state.mempool.validator, MempoolValidatorState::Init { .. })
+    }
+}
+
+#[cfg_attr(feature = "fuzzing", derive(fuzzcheck::DefaultMutator))]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct MempoolValidatorSuccessAction {
+    pub prevalidator: PrevalidatorWrapper,
+}
+
+impl EnablingCondition<State> for MempoolValidatorSuccessAction {
+    fn is_enabled(&self, state: &State) -> bool {
+        match &state.mempool.validator {
+            MempoolValidatorState::Pending { block_hash, .. } => {
+                &self.prevalidator.predecessor == block_hash
+            }
+            _ => false,
+        }
+    }
+}
+
+#[cfg_attr(feature = "fuzzing", derive(fuzzcheck::DefaultMutator))]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct MempoolValidatorReadyAction {}
+
+impl EnablingCondition<State> for MempoolValidatorReadyAction {
+    fn is_enabled(&self, state: &State) -> bool {
+        matches!(
+            &state.mempool.validator,
+            MempoolValidatorState::Success { .. }
+        )
+    }
+}
+
+#[cfg_attr(feature = "fuzzing", derive(fuzzcheck::DefaultMutator))]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct MempoolValidatorValidateInitAction {
+    pub op_hash: OperationHash,
+    pub op_content: Operation,
+}
+
+impl EnablingCondition<State> for MempoolValidatorValidateInitAction {
+    fn is_enabled(&self, state: &State) -> bool {
+        state.mempool.validator.is_ready() && !state.mempool.validator.validate_is_pending()
+    }
+}
+
+#[cfg_attr(feature = "fuzzing", derive(fuzzcheck::DefaultMutator))]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct MempoolValidatorValidatePendingAction {}
+
+impl EnablingCondition<State> for MempoolValidatorValidatePendingAction {
+    fn is_enabled(&self, state: &State) -> bool {
+        state.mempool.validator.validate_is_init()
+    }
+}
+
+#[cfg_attr(feature = "fuzzing", derive(fuzzcheck::DefaultMutator))]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct MempoolValidatorValidateSuccessAction {
+    pub op_hash: OperationHash,
+    pub result: MempoolValidatorValidateResult,
+    pub protocol_preapply_start: f64,
+    pub protocol_preapply_end: f64,
+}
+
+impl EnablingCondition<State> for MempoolValidatorValidateSuccessAction {
+    fn is_enabled(&self, state: &State) -> bool {
+        state
+            .mempool
+            .validator
+            .validate_pending_op_hash()
+            .map_or(false, |hash| hash == &self.op_hash)
+    }
+}

--- a/shell_automaton/src/mempool/validator/mempool_validator_effects.rs
+++ b/shell_automaton/src/mempool/validator/mempool_validator_effects.rs
@@ -1,0 +1,130 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use tezos_api::ffi::{BeginConstructionRequest, ValidateOperationRequest};
+
+use crate::current_head::CurrentHeadState;
+use crate::service::protocol_runner_service::ProtocolRunnerResult;
+use crate::service::ProtocolRunnerService;
+use crate::{Action, ActionWithMeta, Service, Store};
+
+use super::{
+    MempoolValidatorPendingAction, MempoolValidatorReadyAction, MempoolValidatorSuccessAction,
+    MempoolValidatorValidatePendingAction, MempoolValidatorValidateResult,
+    MempoolValidatorValidateSuccessAction,
+};
+
+pub fn mempool_validator_effects<S>(store: &mut Store<S>, action: &ActionWithMeta)
+where
+    S: Service,
+{
+    match &action.action {
+        Action::MempoolValidatorInit(_) => {
+            let chain_id = store.state().config.chain_id.clone();
+            let req = match &store.state().current_head {
+                CurrentHeadState::Rehydrated {
+                    head,
+                    block_metadata_hash,
+                    ops_metadata_hash,
+                    ..
+                } => BeginConstructionRequest {
+                    chain_id,
+                    predecessor: (*head.header).clone(),
+                    predecessor_hash: head.hash.clone(),
+                    protocol_data: None,
+                    predecessor_block_metadata_hash: block_metadata_hash.clone(),
+                    predecessor_ops_metadata_hash: ops_metadata_hash.clone(),
+                },
+                _ => return,
+            };
+            store
+                .service()
+                .prevalidator()
+                .begin_construction_for_prevalidation(req);
+
+            store.dispatch(MempoolValidatorPendingAction {});
+        }
+        Action::MempoolValidatorSuccess(_) => {
+            store.dispatch(MempoolValidatorReadyAction {});
+        }
+        Action::MempoolValidatorValidateInit(content) => {
+            let prevalidator = match &store.state().mempool.validator.prevalidator() {
+                Some(v) => (*v).clone(),
+                None => return,
+            };
+            let validate_req = ValidateOperationRequest {
+                prevalidator,
+                operation: content.op_content.clone(),
+            };
+            store
+                .service()
+                .prevalidator()
+                .validate_operation_for_prevalidation(validate_req);
+            store.dispatch(MempoolValidatorValidatePendingAction {});
+        }
+        Action::ProtocolRunnerResponse(resp) => match &resp.result {
+            ProtocolRunnerResult::BeginConstruction((_, Err(err))) => {
+                slog::warn!(&store.state().log, "Prevalidator error: {}", err);
+            }
+            ProtocolRunnerResult::ValidateOperation((_, Err(err))) => {
+                slog::warn!(&store.state().log, "Prevalidator validation error: {}", err);
+            }
+            ProtocolRunnerResult::BeginConstruction((_, Ok(res))) => {
+                store.dispatch(MempoolValidatorSuccessAction {
+                    prevalidator: res.clone(),
+                });
+            }
+            ProtocolRunnerResult::ValidateOperation((_, Ok(res))) => {
+                if !store
+                    .state()
+                    .mempool
+                    .validator
+                    .prevalidator_matches(&res.prevalidator)
+                {
+                    slog::debug!(&store.state().log, "Got stale operation validation result";
+                        "validated_for" => res.prevalidator.predecessor.to_base58_check(),
+                        "current_mempool_head" => format!("{:?}", store.state().current_head.get_hash()));
+                    return;
+                }
+                let (op_hash, result) = {
+                    if let Some(data) = res.result.applied.first() {
+                        (
+                            data.hash.clone(),
+                            MempoolValidatorValidateResult::Applied(data.clone()),
+                        )
+                    } else if let Some(data) = res.result.refused.first() {
+                        (
+                            data.hash.clone(),
+                            MempoolValidatorValidateResult::Refused(data.clone()),
+                        )
+                    } else if let Some(data) = res.result.branch_refused.first() {
+                        (
+                            data.hash.clone(),
+                            MempoolValidatorValidateResult::BranchRefused(data.clone()),
+                        )
+                    } else if let Some(data) = res.result.branch_delayed.first() {
+                        (
+                            data.hash.clone(),
+                            MempoolValidatorValidateResult::BranchDelayed(data.clone()),
+                        )
+                    } else if let Some(data) = res.result.outdated.first() {
+                        (
+                            data.hash.clone(),
+                            MempoolValidatorValidateResult::Outdated(data.clone()),
+                        )
+                    } else {
+                        return;
+                    }
+                };
+                store.dispatch(MempoolValidatorValidateSuccessAction {
+                    op_hash,
+                    result,
+                    protocol_preapply_start: res.validate_operation_started_at,
+                    protocol_preapply_end: res.validate_operation_ended_at,
+                });
+            }
+            _ => (),
+        },
+        _ => {}
+    }
+}

--- a/shell_automaton/src/mempool/validator/mempool_validator_reducer.rs
+++ b/shell_automaton/src/mempool/validator/mempool_validator_reducer.rs
@@ -1,0 +1,106 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use crate::{Action, ActionWithMeta, State};
+
+use super::{MempoolValidatorState, MempoolValidatorValidateState};
+
+pub fn mempool_validator_reducer(state: &mut State, action: &ActionWithMeta) {
+    match &action.action {
+        Action::MempoolValidatorInit(_) => {
+            state.mempool.validator = MempoolValidatorState::Init {
+                time: action.time_as_nanos(),
+            };
+        }
+        Action::MempoolValidatorPending(_) => {
+            let block_hash = match state.current_head.get() {
+                Some(v) => v.hash.clone(),
+                None => return,
+            };
+            state.mempool.validator = MempoolValidatorState::Pending {
+                time: action.time_as_nanos(),
+                block_hash,
+            };
+        }
+        Action::MempoolValidatorSuccess(content) => {
+            match &state.mempool.validator {
+                MempoolValidatorState::Pending {
+                    time, block_hash, ..
+                } => {
+                    let dur = action.time_as_nanos() - time;
+                    slog::info!(&state.log, "Constructed prevalidator";
+                        "block_hash" => block_hash.to_base58_check(),
+                        "duration" => format!("{}ms", dur / 1_000_000));
+                }
+                _ => {}
+            }
+            state.mempool.validator = MempoolValidatorState::Success {
+                time: action.time_as_nanos(),
+                prevalidator: content.prevalidator.clone(),
+            };
+        }
+        Action::MempoolValidatorReady(_) => {
+            let prevalidator = match state.mempool.validator.prevalidator() {
+                Some(v) => v.clone(),
+                None => return,
+            };
+            state.mempool.validator = MempoolValidatorState::Ready {
+                time: action.time_as_nanos(),
+                prevalidator,
+                validate: MempoolValidatorValidateState::Idle {
+                    time: action.time_as_nanos(),
+                },
+            };
+        }
+        Action::MempoolValidatorValidateInit(content) => {
+            let validate = match &mut state.mempool.validator {
+                MempoolValidatorState::Ready { validate, .. } => validate,
+                _ => return,
+            };
+            *validate = MempoolValidatorValidateState::Init {
+                time: action.time_as_nanos(),
+                op_hash: content.op_hash.clone(),
+                op_content: content.op_content.clone(),
+            };
+        }
+        Action::MempoolValidatorValidatePending(_) => {
+            let validate = match &mut state.mempool.validator {
+                MempoolValidatorState::Ready { validate, .. } => validate,
+                _ => return,
+            };
+            match validate {
+                MempoolValidatorValidateState::Init {
+                    op_hash,
+                    op_content,
+                    ..
+                } => {
+                    *validate = MempoolValidatorValidateState::Pending {
+                        time: action.time_as_nanos(),
+                        op_hash: op_hash.clone(),
+                        op_content: op_content.clone(),
+                    };
+                }
+                _ => return,
+            }
+        }
+        Action::MempoolValidatorValidateSuccess(content) => {
+            let validate = match &mut state.mempool.validator {
+                MempoolValidatorState::Ready { validate, .. } => validate,
+                _ => return,
+            };
+            match validate {
+                MempoolValidatorValidateState::Pending { op_hash, .. } => {
+                    *validate = MempoolValidatorValidateState::Success {
+                        time: action.time_as_nanos(),
+                        op_hash: op_hash.clone(),
+                        result: content.result.clone(),
+                        protocol_preapply_start: content.protocol_preapply_start,
+                        protocol_preapply_end: content.protocol_preapply_end,
+                    };
+                }
+                _ => return,
+            }
+        }
+        _ => {}
+    }
+}

--- a/shell_automaton/src/mempool/validator/mempool_validator_reducer.rs
+++ b/shell_automaton/src/mempool/validator/mempool_validator_reducer.rs
@@ -80,7 +80,7 @@ pub fn mempool_validator_reducer(state: &mut State, action: &ActionWithMeta) {
                         op_content: op_content.clone(),
                     };
                 }
-                _ => return,
+                _ => (),
             }
         }
         Action::MempoolValidatorValidateSuccess(content) => {
@@ -98,7 +98,7 @@ pub fn mempool_validator_reducer(state: &mut State, action: &ActionWithMeta) {
                         protocol_preapply_end: content.protocol_preapply_end,
                     };
                 }
-                _ => return,
+                _ => (),
             }
         }
         _ => {}

--- a/shell_automaton/src/mempool/validator/mempool_validator_state.rs
+++ b/shell_automaton/src/mempool/validator/mempool_validator_state.rs
@@ -1,0 +1,145 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use serde::{Deserialize, Serialize};
+
+use crypto::hash::{BlockHash, OperationHash};
+use tezos_api::ffi::{Applied, Errored, PrevalidatorWrapper};
+use tezos_messages::p2p::encoding::prelude::Operation;
+
+#[cfg_attr(feature = "fuzzing", derive(fuzzcheck::DefaultMutator))]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum MempoolValidatorValidateResult {
+    Applied(Applied),
+    Refused(Errored),
+    BranchRefused(Errored),
+    BranchDelayed(Errored),
+    Outdated(Errored),
+}
+
+impl MempoolValidatorValidateResult {
+    pub fn is_applied(&self) -> bool {
+        matches!(self, Self::Applied(_))
+    }
+
+    pub fn as_result(&self) -> Result<&Applied, &Errored> {
+        match self {
+            Self::Applied(applied) => Ok(applied),
+            Self::Refused(errored)
+            | Self::BranchRefused(errored)
+            | Self::BranchDelayed(errored)
+            | Self::Outdated(errored) => Err(errored),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum MempoolValidatorValidateState {
+    Idle {
+        time: u64,
+    },
+    Init {
+        time: u64,
+        op_hash: OperationHash,
+        op_content: Operation,
+    },
+    Pending {
+        time: u64,
+        op_hash: OperationHash,
+        op_content: Operation,
+    },
+    Success {
+        time: u64,
+        op_hash: OperationHash,
+        result: MempoolValidatorValidateResult,
+        protocol_preapply_start: f64,
+        protocol_preapply_end: f64,
+    },
+}
+
+impl MempoolValidatorValidateState {
+    pub fn is_init(&self) -> bool {
+        matches!(self, Self::Init { .. })
+    }
+
+    pub fn is_pending(&self) -> bool {
+        matches!(self, Self::Pending { .. })
+    }
+
+    pub fn pending_op_hash(&self) -> Option<&OperationHash> {
+        match self {
+            Self::Pending { op_hash, .. } => Some(op_hash),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum MempoolValidatorState {
+    Idle {
+        time: u64,
+    },
+    Init {
+        time: u64,
+    },
+    Pending {
+        time: u64,
+        block_hash: BlockHash,
+    },
+    Success {
+        time: u64,
+        prevalidator: PrevalidatorWrapper,
+    },
+    Ready {
+        time: u64,
+        prevalidator: PrevalidatorWrapper,
+        validate: MempoolValidatorValidateState,
+    },
+}
+
+impl MempoolValidatorState {
+    pub fn is_ready(&self) -> bool {
+        match self {
+            Self::Ready { .. } => true,
+            _ => false,
+        }
+    }
+
+    pub fn prevalidator(&self) -> Option<&PrevalidatorWrapper> {
+        match self {
+            Self::Success { prevalidator, .. } => Some(prevalidator),
+            Self::Ready { prevalidator, .. } => Some(prevalidator),
+            _ => None,
+        }
+    }
+
+    pub fn prevalidator_matches(&self, other: &PrevalidatorWrapper) -> bool {
+        self.prevalidator()
+            .map_or(false, |p| p.predecessor == other.predecessor)
+    }
+
+    pub fn validate(&self) -> Option<&MempoolValidatorValidateState> {
+        match self {
+            Self::Ready { validate, .. } => Some(validate),
+            _ => None,
+        }
+    }
+
+    pub fn validate_is_init(&self) -> bool {
+        self.validate().map_or(false, |v| v.is_init())
+    }
+
+    pub fn validate_is_pending(&self) -> bool {
+        self.validate().map_or(false, |v| v.is_pending())
+    }
+
+    pub fn validate_pending_op_hash(&self) -> Option<&OperationHash> {
+        self.validate().and_then(|v| v.pending_op_hash())
+    }
+}
+
+impl Default for MempoolValidatorState {
+    fn default() -> Self {
+        Self::Idle { time: 0 }
+    }
+}

--- a/shell_automaton/src/mempool/validator/mod.rs
+++ b/shell_automaton/src/mempool/validator/mod.rs
@@ -1,0 +1,14 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+mod mempool_validator_actions;
+pub use mempool_validator_actions::*;
+
+mod mempool_validator_state;
+pub use mempool_validator_state::*;
+
+mod mempool_validator_reducer;
+pub use mempool_validator_reducer::*;
+
+mod mempool_validator_effects;
+pub use mempool_validator_effects::*;

--- a/shell_automaton/src/peer/message/read/peer_message_read_effects.rs
+++ b/shell_automaton/src/peer/message/read/peer_message_read_effects.rs
@@ -14,6 +14,7 @@ use crate::bootstrap::{
     BootstrapPeerBlockHeaderGetSuccessAction, BootstrapPeerBlockOperationsReceivedAction,
     BootstrapPeerCurrentBranchReceivedAction,
 };
+use crate::mempool::MempoolRecvDoneAction;
 use crate::peer::binary_message::read::PeerBinaryMessageReadInitAction;
 use crate::peer::message::read::PeerMessageReadErrorAction;
 use crate::peer::message::write::PeerMessageWriteInitAction;
@@ -218,9 +219,18 @@ where
                             Ok(v) => v,
                             Err(_) => return,
                         };
+                    let block_hash = current_head.hash.clone();
                     store.dispatch(PeerCurrentHeadUpdateAction {
                         address: content.address,
                         current_head,
+                    });
+
+                    let message = msg.current_mempool().clone();
+                    store.dispatch(MempoolRecvDoneAction {
+                        address: content.address,
+                        block_hash,
+                        block_header: msg.current_block_header().clone(),
+                        message,
                     });
                 }
                 PeerMessage::CurrentBranch(msg) => {

--- a/shell_automaton/src/prechecker/mod.rs
+++ b/shell_automaton/src/prechecker/mod.rs
@@ -17,23 +17,19 @@ mod prechecker_validator;
 pub use prechecker_validator::*;
 use tezos_messages::{p2p::encoding::block_header::BlockHeader, protocol::SupportedProtocol};
 
-use crate::State;
-
 /// Checks if prechecking is enabled for the block that is a successor of the block with `prev_block` hash.
-pub(crate) fn prechecking_enabled(state: &State, prev_block: &BlockHash) -> bool {
-    !state.config.disable_endorsements_precheck
-        && state
-            .prechecker
-            .protocol_cache
-            .get(prev_block)
-            .map_or(false, |(_, _, next_protocol)| {
-                matches!(
-                    SupportedProtocol::try_from(next_protocol),
-                    Ok(SupportedProtocol::Proto010)
-                        | Ok(SupportedProtocol::Proto011)
-                        | Ok(SupportedProtocol::Proto012)
-                )
-            })
+pub(crate) fn prechecking_enabled(state: &PrecheckerState, prev_block: &BlockHash) -> bool {
+    state
+        .protocol_cache
+        .get(prev_block)
+        .map_or(false, |(_, _, next_protocol)| {
+            matches!(
+                SupportedProtocol::try_from(next_protocol),
+                Ok(SupportedProtocol::Proto010)
+                    | Ok(SupportedProtocol::Proto011)
+                    | Ok(SupportedProtocol::Proto012)
+            )
+        })
 }
 
 pub(super) fn protocol_for_block(

--- a/shell_automaton/src/prechecker/prechecker_actions.rs
+++ b/shell_automaton/src/prechecker/prechecker_actions.rs
@@ -57,6 +57,19 @@ pub enum PrecheckerPrecheckOperationResponse {
     Error(PrecheckerResponseError),
 }
 
+impl PrecheckerPrecheckOperationResponse {
+    pub(crate) fn operation_hash(&self) -> Option<&OperationHash> {
+        match self {
+            PrecheckerPrecheckOperationResponse::Applied(applied) => Some(&applied.hash),
+            PrecheckerPrecheckOperationResponse::Refused(refused) => Some(&refused.hash),
+            PrecheckerPrecheckOperationResponse::Prevalidate(prevalidate) => {
+                Some(&prevalidate.hash)
+            }
+            PrecheckerPrecheckOperationResponse::Error(_) => None,
+        }
+    }
+}
+
 #[cfg_attr(feature = "fuzzing", derive(fuzzcheck::DefaultMutator))]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct PrecheckerApplied {
@@ -102,6 +115,7 @@ impl PrecheckerErrored {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct PrecheckerPrevalidate {
     pub hash: OperationHash,
+    pub operation: Operation,
 }
 
 impl PrecheckerPrecheckOperationResponseAction {
@@ -133,11 +147,11 @@ impl PrecheckerPrecheckOperationResponseAction {
         }
     }
 
-    #[allow(dead_code)]
-    pub(super) fn prevalidate(operation_hash: &OperationHash) -> Self {
+    pub(super) fn prevalidate(operation: Operation, hash: OperationHash) -> Self {
         Self {
             response: PrecheckerPrecheckOperationResponse::Prevalidate(PrecheckerPrevalidate {
-                hash: operation_hash.clone(),
+                operation,
+                hash,
             }),
         }
     }

--- a/shell_automaton/src/prechecker/prechecker_actions.rs
+++ b/shell_automaton/src/prechecker/prechecker_actions.rs
@@ -54,7 +54,7 @@ pub enum PrecheckerPrecheckOperationResponse {
     /// Prechecker cannot decide if the operation is correct. Protocol based prevalidator is needed.
     Prevalidate(PrecheckerPrevalidate),
     /// Error occurred while prechecking the operation.
-    Error(PrecheckerResponseError),
+    Error(PrecheckerResponseError, Option<OperationHash>),
 }
 
 impl PrecheckerPrecheckOperationResponse {
@@ -65,7 +65,7 @@ impl PrecheckerPrecheckOperationResponse {
             PrecheckerPrecheckOperationResponse::Prevalidate(prevalidate) => {
                 Some(&prevalidate.hash)
             }
-            PrecheckerPrecheckOperationResponse::Error(_) => None,
+            PrecheckerPrecheckOperationResponse::Error(_, hash) => hash.as_ref(),
         }
     }
 }
@@ -156,12 +156,12 @@ impl PrecheckerPrecheckOperationResponseAction {
         }
     }
 
-    pub(super) fn error<E>(error: E) -> Self
+    pub(super) fn error<E>(error: E, operation: Option<OperationHash>) -> Self
     where
         E: Into<PrecheckerResponseError>,
     {
         Self {
-            response: PrecheckerPrecheckOperationResponse::Error(error.into()),
+            response: PrecheckerPrecheckOperationResponse::Error(error.into(), operation),
         }
     }
 }

--- a/shell_automaton/src/prechecker/prechecker_effects.rs
+++ b/shell_automaton/src/prechecker/prechecker_effects.rs
@@ -135,7 +135,7 @@ where
                         };
                         store.dispatch(PrecheckerDecodeOperationAction {
                             key: key.clone(),
-                            protocol: protocol.clone(),
+                            protocol,
                         });
                     }
                     PrecheckerOperationState::Applied { .. } => {

--- a/shell_automaton/src/prechecker/prechecker_effects.rs
+++ b/shell_automaton/src/prechecker/prechecker_effects.rs
@@ -445,12 +445,14 @@ where
             }
         }
         Action::PrecheckerProtocolNeeded(PrecheckerProtocolNeededAction { key, .. }) => {
-            if let Some(PrecheckerOperationState::ProtocolNeeded { .. }) =
-                prechecker_state_operations.get(key).map(|op| &op.state)
-            {
-                store.dispatch(PrecheckerPrecheckOperationResponseAction::prevalidate(
-                    &key.operation,
-                ));
+            if let Some(op) = prechecker_state_operations.get(key) {
+                if matches!(op.state, PrecheckerOperationState::ProtocolNeeded {}) {
+                    let operation = op.operation.clone();
+                    store.dispatch(PrecheckerPrecheckOperationResponseAction::prevalidate(
+                        operation,
+                        key.operation.clone(),
+                    ));
+                }
             }
             store.dispatch(PrecheckerPruneOperationAction { key: key.clone() });
         }
@@ -492,33 +494,35 @@ where
             store.dispatch(PrecheckerPruneOperationAction { key: key.clone() });
         }
         Action::PrecheckerError(PrecheckerErrorAction { key, error }) => {
-            if let Some(PrecheckerOperationState::Error { .. }) =
-                prechecker_state_operations.get(key).map(|op| &op.state)
-            {
-                match error {
-                    PrecheckerError::EndorsingRights(err) => {
-                        error!(log, "Getting endorsing rights failed"; "operation" => key.to_string(), "error" => err.to_string());
-                        store.dispatch(PrecheckerPrecheckOperationResponseAction::error(
-                            err.clone(),
-                        ));
-                    }
-                    PrecheckerError::UnsupportedProtocol(_) => {
-                        store.dispatch(PrecheckerPrecheckOperationResponseAction::prevalidate(
-                            &key.operation,
-                        ));
-                    }
+            if let Some(op) = prechecker_state_operations.get(key) {
+                if matches!(op.state, PrecheckerOperationState::Error { .. }) {
+                    match error {
+                        PrecheckerError::EndorsingRights(err) => {
+                            error!(log, "Getting endorsing rights failed"; "operation" => key.to_string(), "error" => err.to_string());
+                            store.dispatch(PrecheckerPrecheckOperationResponseAction::error(
+                                err.clone(),
+                            ));
+                        }
+                        PrecheckerError::UnsupportedProtocol(_) => {
+                            let operation = op.operation.clone();
+                            store.dispatch(PrecheckerPrecheckOperationResponseAction::prevalidate(
+                                operation,
+                                key.operation.clone(),
+                            ));
+                        }
 
-                    PrecheckerError::Storage(err) => {
-                        store.dispatch(PrecheckerPrecheckOperationResponseAction::error(
-                            err.clone(),
-                        ));
-                    }
-                    PrecheckerError::MissingBlockHeader(_)
-                    | PrecheckerError::MissingProtocol(_)
-                    | PrecheckerError::OperationContentsDecode(_) => {
-                        store.dispatch(PrecheckerPrecheckOperationResponseAction::error(
-                            error.clone(),
-                        ));
+                        PrecheckerError::Storage(err) => {
+                            store.dispatch(PrecheckerPrecheckOperationResponseAction::error(
+                                err.clone(),
+                            ));
+                        }
+                        PrecheckerError::MissingBlockHeader(_)
+                        | PrecheckerError::MissingProtocol(_)
+                        | PrecheckerError::OperationContentsDecode(_) => {
+                            store.dispatch(PrecheckerPrecheckOperationResponseAction::error(
+                                error.clone(),
+                            ));
+                        }
                     }
                 }
             }

--- a/shell_automaton/src/prechecker/prechecker_effects.rs
+++ b/shell_automaton/src/prechecker/prechecker_effects.rs
@@ -66,7 +66,7 @@ where
             let binary_encoding = match operation.as_bytes() {
                 Ok(bytes) => bytes,
                 Err(err) => {
-                    store.dispatch(PrecheckerPrecheckOperationResponseAction::error(err));
+                    store.dispatch(PrecheckerPrecheckOperationResponseAction::error(err, None));
                     return;
                 }
             };
@@ -74,14 +74,14 @@ where
             let hash = match blake2b::digest_256(&binary_encoding) {
                 Ok(hash) => hash,
                 Err(err) => {
-                    store.dispatch(PrecheckerPrecheckOperationResponseAction::error(err));
+                    store.dispatch(PrecheckerPrecheckOperationResponseAction::error(err, None));
                     return;
                 }
             };
             let key = match hash.try_into() {
                 Ok(hash) => Key { operation: hash },
                 Err(err) => {
-                    store.dispatch(PrecheckerPrecheckOperationResponseAction::error(err));
+                    store.dispatch(PrecheckerPrecheckOperationResponseAction::error(err, None));
                     return;
                 }
             };
@@ -501,6 +501,7 @@ where
                             error!(log, "Getting endorsing rights failed"; "operation" => key.to_string(), "error" => err.to_string());
                             store.dispatch(PrecheckerPrecheckOperationResponseAction::error(
                                 err.clone(),
+                                Some(key.operation.clone()),
                             ));
                         }
                         PrecheckerError::UnsupportedProtocol(_) => {
@@ -514,6 +515,7 @@ where
                         PrecheckerError::Storage(err) => {
                             store.dispatch(PrecheckerPrecheckOperationResponseAction::error(
                                 err.clone(),
+                                Some(key.operation.clone()),
                             ));
                         }
                         PrecheckerError::MissingBlockHeader(_)
@@ -521,6 +523,7 @@ where
                         | PrecheckerError::OperationContentsDecode(_) => {
                             store.dispatch(PrecheckerPrecheckOperationResponseAction::error(
                                 error.clone(),
+                                Some(key.operation.clone()),
                             ));
                         }
                     }

--- a/shell_automaton/src/protocol_runner/protocol_runner_state.rs
+++ b/shell_automaton/src/protocol_runner/protocol_runner_state.rs
@@ -37,3 +37,9 @@ pub enum ProtocolRunnerState {
     /// Shutdown successfully completed
     ShutdownSuccess,
 }
+
+impl ProtocolRunnerState {
+    pub fn is_ready(&self) -> bool {
+        matches!(self, Self::Ready(_))
+    }
+}

--- a/shell_automaton/src/reducer.rs
+++ b/shell_automaton/src/reducer.rs
@@ -37,6 +37,7 @@ use crate::peers::graylist::peers_graylist_reducer;
 use crate::peers::remove::peers_remove_reducer;
 
 use crate::mempool::mempool_reducer;
+use crate::mempool::validator::mempool_validator_reducer;
 
 use crate::prechecker::prechecker_reducer;
 use crate::rights::rights_reducer;
@@ -119,6 +120,7 @@ pub fn reducer(state: &mut State, action: &ActionWithMeta) {
         peers_check_timeouts_reducer,
         peers_graylist_reducer,
         bootstrap_reducer,
+        mempool_validator_reducer,
         mempool_reducer,
         rights_reducer,
         current_head_precheck_reducer,

--- a/shell_automaton/src/rpc/rpc_effects.rs
+++ b/shell_automaton/src/rpc/rpc_effects.rs
@@ -191,7 +191,7 @@ pub fn rpc_effects<S: Service>(store: &mut Store<S>, action: &ActionWithMeta) {
                         let injected_timestamp = store.monotonic_to_time(injected);
                         store.dispatch(MempoolOperationInjectAction {
                             operation,
-                            operation_hash,
+                            hash: operation_hash,
                             rpc_id,
                             injected_timestamp,
                         });

--- a/shell_automaton/testing/tests/bootstrap/test_fork.rs
+++ b/shell_automaton/testing/tests/bootstrap/test_fork.rs
@@ -74,7 +74,7 @@ fn data(chain_level: Level) -> (Cluster, Vec<BlockHeaderWithHash>) {
     state.current_head = CurrentHeadState::Rehydrated {
         head: chain.last().unwrap().clone(),
         head_pred: chain.iter().rev().nth(1).cloned(),
-
+        payload_hash: None,
         block_metadata_hash: None,
         ops_metadata_hash: None,
     };

--- a/shell_automaton/testing/tests/bootstrap/test_fork.rs
+++ b/shell_automaton/testing/tests/bootstrap/test_fork.rs
@@ -74,6 +74,9 @@ fn data(chain_level: Level) -> (Cluster, Vec<BlockHeaderWithHash>) {
     state.current_head = CurrentHeadState::Rehydrated {
         head: chain.last().unwrap().clone(),
         head_pred: chain.iter().rev().nth(1).cloned(),
+
+        block_metadata_hash: None,
+        ops_metadata_hash: None,
     };
     state.bootstrap = BootstrapState::Finished {
         time: 0,
@@ -82,10 +85,6 @@ fn data(chain_level: Level) -> (Cluster, Vec<BlockHeaderWithHash>) {
     state.mempool.local_head_state = Some(HeadState {
         header: (*chain.last().unwrap().header).clone(),
         hash: chain.last().unwrap().hash.clone(),
-        prevalidator_ready: true,
-
-        metadata_hash: None,
-        ops_metadata_hash: None,
     });
 
     (Cluster::new(state, initial_time), chain)

--- a/shell_automaton/testing/tests/p2p_requests/test_get_current_branch.rs
+++ b/shell_automaton/testing/tests/p2p_requests/test_get_current_branch.rs
@@ -70,6 +70,7 @@ fn data(current_head_level: Level) -> (Cluster, Vec<BlockHeaderWithHash>) {
     state.current_head = CurrentHeadState::Rehydrated {
         head: chain.last().unwrap().clone(),
         head_pred: chain.iter().rev().nth(1).cloned(),
+        payload_hash: None,
         block_metadata_hash: None,
         ops_metadata_hash: None,
     };

--- a/shell_automaton/testing/tests/p2p_requests/test_get_current_branch.rs
+++ b/shell_automaton/testing/tests/p2p_requests/test_get_current_branch.rs
@@ -70,6 +70,8 @@ fn data(current_head_level: Level) -> (Cluster, Vec<BlockHeaderWithHash>) {
     state.current_head = CurrentHeadState::Rehydrated {
         head: chain.last().unwrap().clone(),
         head_pred: chain.iter().rev().nth(1).cloned(),
+        block_metadata_hash: None,
+        ops_metadata_hash: None,
     };
 
     (Cluster::new(state, initial_time), chain)

--- a/shell_automaton/tests/action_fuzz.rs
+++ b/shell_automaton/tests/action_fuzz.rs
@@ -15,7 +15,7 @@ use shell_automaton::block_applier;
 use shell_automaton::current_head_precheck;
 use shell_automaton::fuzzing::state_singleton::FUZZER_STATE;
 use shell_automaton::mempool::mempool_actions;
-use shell_automaton::mempool::PrevalidatorAction;
+use shell_automaton::mempool::validator as mempool_validator;
 use shell_automaton::peers::init::PeersInitAction;
 use shell_automaton::prechecker::prechecker_actions;
 use shell_automaton::protocol_runner;
@@ -843,7 +843,6 @@ enum MempoolActionTest {
     TestMempoolMarkOperationsAsPendingAction(mempool_actions::MempoolMarkOperationsAsPendingAction),
     TestMempoolOperationRecvDoneAction(mempool_actions::MempoolOperationRecvDoneAction),
     TestMempoolOperationInjectAction(mempool_actions::MempoolOperationInjectAction),
-    TestMempoolValidateStartAction(mempool_actions::MempoolValidateStartAction),
     TestMempoolRpcRespondAction(mempool_actions::MempoolRpcRespondAction),
     TestMempoolRegisterOperationsStreamAction(
         mempool_actions::MempoolRegisterOperationsStreamAction,
@@ -857,12 +856,19 @@ enum MempoolActionTest {
     TestMempoolBroadcastAction(mempool_actions::MempoolBroadcastAction),
     TestMempoolBroadcastDoneAction(mempool_actions::MempoolBroadcastDoneAction),
     TestMempoolGetPendingOperationsAction(mempool_actions::MempoolGetPendingOperationsAction),
-    TestMempoolFlushAction(mempool_actions::MempoolFlushAction),
     TestMempoolOperationDecodedAction(mempool_actions::MempoolOperationDecodedAction),
     TestMempoolRpcEndorsementsStatusGetAction(
         mempool_actions::MempoolRpcEndorsementsStatusGetAction,
     ),
     TestMempoolBlockInjectAction(mempool_actions::BlockInjectAction),
+    TestMempoolOperationValidateNext(mempool_actions::MempoolOperationValidateNextAction),
+    TestMempoolValidatorInit(mempool_validator::MempoolValidatorInitAction),
+    TestMempoolValidatorPending(mempool_validator::MempoolValidatorPendingAction),
+    TestMempoolValidatorSuccess(mempool_validator::MempoolValidatorSuccessAction),
+    TestMempoolValidatorReady(mempool_validator::MempoolValidatorReadyAction),
+    TestMempoolValidatorValidateInit(mempool_validator::MempoolValidatorValidateInitAction),
+    TestMempoolValidatorValidatePending(mempool_validator::MempoolValidatorValidatePendingAction),
+    TestMempoolValidatorValidateSuccess(mempool_validator::MempoolValidatorValidateSuccessAction),
 }
 
 impl MempoolActionTest {
@@ -873,7 +879,6 @@ impl MempoolActionTest {
             Self::TestMempoolMarkOperationsAsPendingAction(a) => a.into(),
             Self::TestMempoolOperationRecvDoneAction(a) => a.into(),
             Self::TestMempoolOperationInjectAction(a) => a.into(),
-            Self::TestMempoolValidateStartAction(a) => a.into(),
             Self::TestMempoolRpcRespondAction(a) => a.into(),
             Self::TestMempoolRegisterOperationsStreamAction(a) => a.into(),
             Self::TestMempoolUnregisterOperationsStreamsAction(a) => a.into(),
@@ -883,10 +888,17 @@ impl MempoolActionTest {
             Self::TestMempoolBroadcastAction(a) => a.into(),
             Self::TestMempoolBroadcastDoneAction(a) => a.into(),
             Self::TestMempoolGetPendingOperationsAction(a) => a.into(),
-            Self::TestMempoolFlushAction(a) => a.into(),
             Self::TestMempoolOperationDecodedAction(a) => a.into(),
             Self::TestMempoolRpcEndorsementsStatusGetAction(a) => a.into(),
             Self::TestMempoolBlockInjectAction(a) => a.into(),
+            Self::TestMempoolOperationValidateNext(a) => a.into(),
+            Self::TestMempoolValidatorInit(a) => a.into(),
+            Self::TestMempoolValidatorPending(a) => a.into(),
+            Self::TestMempoolValidatorSuccess(a) => a.into(),
+            Self::TestMempoolValidatorReady(a) => a.into(),
+            Self::TestMempoolValidatorValidateInit(a) => a.into(),
+            Self::TestMempoolValidatorValidatePending(a) => a.into(),
+            Self::TestMempoolValidatorValidateSuccess(a) => a.into(),
         }
     }
 }
@@ -1021,7 +1033,6 @@ enum ControlActionTest {
     TestP2pServerEvent(P2pServerEvent),
     TestP2pPeerEvent(P2pPeerEvent),
     TestWakeupEvent(WakeupEvent),
-    TestProtocolAction(PrevalidatorAction),
     TestShutdownInitAction(ShutdownInitAction),
     TestShutdownPendingAction(ShutdownPendingAction),
     TestShutdownSuccessAction(ShutdownSuccessAction),
@@ -1045,7 +1056,6 @@ impl ControlActionTest {
             Self::TestP2pServerEvent(a) => a.into(),
             Self::TestP2pPeerEvent(a) => a.into(),
             Self::TestWakeupEvent(a) => a.into(),
-            Self::TestProtocolAction(a) => a.into(),
             Self::TestShutdownInitAction(a) => a.into(),
             Self::TestShutdownPendingAction(a) => a.into(),
             Self::TestShutdownSuccessAction(a) => a.into(),

--- a/tezos/api/src/ffi.rs
+++ b/tezos/api/src/ffi.rs
@@ -179,6 +179,7 @@ pub struct BeginApplicationResponse {
     pub result: String,
 }
 
+// TODO: check if all the field are needed.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct BeginConstructionRequest {
     pub chain_id: ChainId,


### PR DESCRIPTION
- Move prevalidation logic to separate module.
- Send operations for prevalidation 1by1 from state machine, instead of handling them in service. This makes operation validation cancellation logic no longer necessary and simplifies the logic.

WIP: will break operation prechecker logic as prechecking will not be triggered.