### PR TITLE
Increase action stats for blocks history size to 20k blocks 

### DIFF
--- a/rpc/src/server/dev_handler.rs
+++ b/rpc/src/server/dev_handler.rs
@@ -391,7 +391,7 @@ pub async fn dev_shell_automaton_actions_stats_for_blocks_get(
         v.iter()
             .flat_map(|s| s.split(","))
             .filter_map(|s| s.parse().ok())
-            .take(6)
+            .take(64)
             .collect::<BTreeSet<_>>()
     });
     make_json_response(

--- a/shell_automaton/src/rpc/rpc_effects.rs
+++ b/shell_automaton/src/rpc/rpc_effects.rs
@@ -130,13 +130,19 @@ pub fn rpc_effects<S: Service>(store: &mut Store<S>, action: &ActionWithMeta) {
                             .service()
                             .statistics()
                             .map(|s| {
+                                let smallest_level = level_filter
+                                    .as_ref()
+                                    .and_then(|levels| levels.iter().cloned().next())
+                                    .unwrap_or(0);
                                 s.action_kind_stats_for_blocks()
                                     .iter()
+                                    .take_while(|s| s.block_level + 2 > smallest_level)
                                     .filter(|s| {
                                         level_filter
                                             .as_ref()
                                             .map_or(true, |levels| levels.contains(&s.block_level))
                                     })
+                                    .take(64)
                                     .cloned()
                                     .collect()
                             })

--- a/shell_automaton/src/service/statistics_service/mod.rs
+++ b/shell_automaton/src/service/statistics_service/mod.rs
@@ -218,7 +218,7 @@ pub struct ActionStatsForBlocks {
 
 impl ActionStatsForBlocks {
     fn current_head_update(&mut self, time: u64, block: &BlockHeaderWithHash) {
-        while self.kind_stats.len() >= 120 {
+        while self.kind_stats.len() >= 20000 {
             self.kind_stats.pop_back();
         }
         self.kind_stats.push_front(ActionKindStatsForBlock {


### PR DESCRIPTION
Now we will maintain action statistics for latest 20k blocks.