### PR TITLE
Fix protocol-runner initialization with irmin

### DIFF
--- a/shell_automaton/src/protocol_runner/latest_context_hashes/protocol_runner_latest_context_hashes_effects.rs
+++ b/shell_automaton/src/protocol_runner/latest_context_hashes/protocol_runner_latest_context_hashes_effects.rs
@@ -22,11 +22,13 @@ pub fn protocol_runner_latest_context_hashes_effects<S>(
                 .get_latest_context_hashes(count);
             store.dispatch(ProtocolRunnerLatestContextHashesPendingAction { token });
         }
-        Action::ProtocolRunnerLatestContextHashesSuccess(_) => {
+        Action::ProtocolRunnerLatestContextHashesSuccess(content) => {
+            slog::info!(&store.state().log, "Found context's latest commits";
+                         "context_hashes" => format!("{:?}", content.latest_context_hashes));
             store.dispatch(ProtocolRunnerReadyAction {});
         }
         Action::ProtocolRunnerLatestContextHashesError(content) => {
-            slog::error!(&store.state().log, "failed to get context's latest commits";
+            slog::error!(&store.state().log, "Failed to get context's latest commits";
                          "error" => format!("{:?}", content.error));
             store.dispatch(ProtocolRunnerReadyAction {});
         }

--- a/shell_automaton/src/protocol_runner/protocol_runner_actions.rs
+++ b/shell_automaton/src/protocol_runner/protocol_runner_actions.rs
@@ -2,12 +2,15 @@
 // SPDX-License-Identifier: MIT
 
 use serde::{Deserialize, Serialize};
+use tezos_context_api::TezosContextStorageConfiguration;
 
 use crate::protocol_runner::latest_context_hashes::ProtocolRunnerLatestContextHashesState;
 use crate::protocol_runner::ProtocolRunnerState;
 use crate::service::protocol_runner_service::ProtocolRunnerResult;
 use crate::storage::blocks::genesis::init::StorageBlocksGenesisInitState;
 use crate::{EnablingCondition, State};
+
+use super::init::ProtocolRunnerInitState;
 
 #[cfg_attr(feature = "fuzzing", derive(fuzzcheck::DefaultMutator))]
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -31,7 +34,13 @@ impl EnablingCondition<State> for ProtocolRunnerReadyAction {
                 ProtocolRunnerLatestContextHashesState::Success { .. }
                     | ProtocolRunnerLatestContextHashesState::Error { .. }
             )
-        )
+        ) || (matches!(
+            state.config.protocol_runner.storage,
+            TezosContextStorageConfiguration::IrminOnly(..)
+        ) && matches!(
+            &state.protocol_runner,
+            ProtocolRunnerState::Init(ProtocolRunnerInitState::Success { .. })
+        ))
     }
 }
 

--- a/shell_automaton/src/protocol_runner/protocol_runner_reducer.rs
+++ b/shell_automaton/src/protocol_runner/protocol_runner_reducer.rs
@@ -4,6 +4,7 @@
 use crate::protocol_runner::latest_context_hashes::ProtocolRunnerLatestContextHashesState;
 use crate::{Action, ActionWithMeta, State};
 
+use super::init::ProtocolRunnerInitState;
 use super::{ProtocolRunnerReadyState, ProtocolRunnerState};
 
 pub fn protocol_runner_reducer(state: &mut State, action: &ActionWithMeta) {
@@ -22,6 +23,9 @@ pub fn protocol_runner_reducer(state: &mut State, action: &ActionWithMeta) {
                         ..
                     },
                 ) => (genesis_commit_hash.clone(), latest_context_hashes.clone()),
+                ProtocolRunnerState::Init(ProtocolRunnerInitState::Success {
+                    genesis_commit_hash,
+                }) => (genesis_commit_hash.clone(), Vec::new()),
                 _ => return,
             };
 

--- a/tezos/context/src/gc/worker.rs
+++ b/tezos/context/src/gc/worker.rs
@@ -333,7 +333,8 @@ fn replace_context_with_snapshot(path_context: &str, path_snapshot: &str) -> Res
 
     // Exchange `path_context` with `path_snapshot` atomically
     let result = unsafe {
-        libc::renameat2(
+        libc::syscall(
+            libc::SYS_renameat2,
             libc::AT_FDCWD,
             cstr_snapshot,
             libc::AT_FDCWD,


### PR DESCRIPTION
- Fix protocol-runner initialization with irmin
  Do not get latest context hashes with irmin-only storage. Irmin doesn't support that feature
- Use libc::syscall instead of libc::renameat2
  This handle when the wrapper is not available in the used libc
