### PR TITLE
comment out GCOV counter reset calls

### DIFF
--- a/light_node/src/main.rs
+++ b/light_node/src/main.rs
@@ -476,7 +476,7 @@ fn set_gcov_handler() {
 
     extern "C" {
         fn __gcov_dump();
-        fn __gcov_reset();
+        //fn __gcov_reset();
     }
 
     std::thread::spawn(move || {
@@ -484,7 +484,7 @@ fn set_gcov_handler() {
             eprintln!("!!! SIGUSR2: saving coverage info...");
             unsafe {
                 __gcov_dump();
-                __gcov_reset();
+                //__gcov_reset();
             }
         }
     });

--- a/protocol_runner/src/dyncov.rs
+++ b/protocol_runner/src/dyncov.rs
@@ -20,12 +20,12 @@ ocaml_export! {
     fn protocol_runner_dump_gcov(rt, _arg: OCamlRef<()>) {
         extern "C" {
             fn __gcov_dump();
-            fn __gcov_reset();
+            //fn __gcov_reset();
         }
 
         unsafe {
             __gcov_dump();
-            __gcov_reset();
+            //__gcov_reset();
         }
 
         OCaml::unit()


### PR DESCRIPTION
Until now we always reset coverage counters every time we dump them (by signaling a SIGUSR2). So far this was a good way to know if fuzzers had issues getting stuck in some parts of the code, but reports only show coverage since last measurement instead of full coverage since the application started.

This commit comments out the counter reset call so we can see total coverage now. The original code is still there in case we need it in the future.