### PR TITLE
Sub implementation for Timestamp with saturation

### DIFF
--- a/shell_automaton/src/state.rs
+++ b/shell_automaton/src/state.rs
@@ -204,7 +204,7 @@ impl State {
         const SYNC_LATENCY: i64 = 150;
 
         let current_head_timestamp = match self.current_head.get() {
-            Some(v) => v.header.timestamp().i64(),
+            Some(v) => v.header.timestamp(),
             None => return false,
         };
 
@@ -212,7 +212,7 @@ impl State {
             .peers
             .handshaked_iter()
             .filter_map(|(_, peer)| peer.current_head.as_ref())
-            .map(|current_head| current_head_timestamp - current_head.header.timestamp().i64())
+            .map(|current_head| (current_head_timestamp - current_head.header.timestamp()).i64())
             .filter(|latency: &i64| latency.abs() < SYNC_LATENCY)
             .count();
 

--- a/tezos/messages/src/lib.rs
+++ b/tezos/messages/src/lib.rs
@@ -4,10 +4,10 @@
 #![cfg_attr(feature = "fuzzing", feature(no_coverage))]
 
 //! This crate provides definitions of tezos messages.
-
 use getset::Getters;
 use p2p::encoding::fitness::Fitness;
 use serde::{Deserialize, Serialize};
+use std::ops::Sub;
 use tezos_encoding::{
     enc::BinWriter,
     encoding::{Encoding, HasEncoding},
@@ -230,5 +230,13 @@ impl<'de> Deserialize<'de> for Timestamp {
         } else {
             Ok(Self(serde::Deserialize::deserialize(deserializer)?))
         }
+    }
+}
+
+impl Sub for Timestamp {
+    type Output = Self;
+
+    fn sub(self, other: Self) -> Self::Output {
+        Self::from(self.0.saturating_sub(other.i64()))
     }
 }


### PR DESCRIPTION
Fix integer overflow in timestamp.
Added `Sub` (with saturation) implementation for `Timestamp` so code can subtract `Timestamp` values without accessing the inner `i64`.  