### PR TITLE
Flush database after block application

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2209,13 +2209,16 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "6.20.3"
-source = "git+https://github.com/tezedge/rust-rocksdb.git?tag=tezedge-v0.17.0-1#cba1d783f0ff40b433bc89efc136db0633490855"
+version = "0.6.1+6.28.2"
+source = "git+https://github.com/tezedge/rust-rocksdb.git?tag=tezedge-v2.3.0#eb39c8fe6de51411fe0b901151dea07dd2439396"
 dependencies = [
  "bindgen",
+ "bzip2-sys",
  "cc",
  "glob",
  "libc",
+ "libz-sys",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -3537,9 +3540,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a62eca5cacf2c8261128631bed9f045598d40bfbe4b29f5163f0f802f8f44a7"
+checksum = "620f4129485ff1a7128d184bc687470c21c7951b64779ebc9cfdad3dcd920290"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ members = [
 
 [patch.crates-io]
 ocaml-boxroot-sys = { git = "https://gitlab.com/bruno.deferrari/ocaml-boxroot.git", branch = "ocaml-410-headers" }
-librocksdb-sys = { git = "https://github.com/tezedge/rust-rocksdb.git", tag = "tezedge-v0.17.0-1" }
+librocksdb-sys = { git = "https://github.com/tezedge/rust-rocksdb.git", tag = "tezedge-v2.3.0" }
 
 [profile.fuzz]
 inherits = "release"

--- a/light_node/src/snapshot_command.rs
+++ b/light_node/src/snapshot_command.rs
@@ -280,6 +280,8 @@ pub fn snapshot_storage(
             .expect("Failed to store cycle eras data to new main storage");
     }
 
+    block_storage.flush().expect("Failed to flush data to disk");
+
     let head = new_chain_meta_storage.get_current_head(&chain_id).unwrap();
     info!(log, "Stored current head = {:?}", head);
 

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -15,7 +15,7 @@ getset = "0.1"
 hex = "0.4"
 itertools = "0.10"
 num_cpus = "1.13"
-rocksdb = {version = "0.17", features = ["snappy", "lz4", "zstd", "zlib"], default-features = false }
+rocksdb = {version = "0.18", features = ["snappy", "lz4", "zstd", "zlib"], default-features = false }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 slog = { version = "2.7", features = ["max_level_trace", "release_max_level_trace"] }

--- a/storage/src/block_meta_storage.rs
+++ b/storage/src/block_meta_storage.rs
@@ -591,7 +591,7 @@ impl KVStoreKeyValueSchema for BlockAdditionalData {
 pub fn merge_meta_value(
     _new_key: &[u8],
     existing_val: Option<&[u8]>,
-    operands: &mut MergeOperands,
+    operands: &MergeOperands,
 ) -> Option<Vec<u8>> {
     if let Some(val) = existing_val {
         if val.len() < LEN_FIXED_META {
@@ -601,7 +601,7 @@ pub fn merge_meta_value(
 
     let mut result = existing_val.map(|v| v.to_vec());
 
-    for op in operands {
+    for op in operands.iter() {
         match result {
             Some(ref mut val) => {
                 if op.len() < LEN_FIXED_META {

--- a/storage/src/database/rockdb_backend.rs
+++ b/storage/src/database/rockdb_backend.rs
@@ -164,6 +164,7 @@ impl TezedgeDatabaseBackendStore for RocksDBBackend {
 
     fn flush(&self) -> Result<usize, Error> {
         self.db.flush()?;
+        self.db.flush_wal(true)?;
         Ok(0)
     }
 

--- a/storage/src/database/tezedge_database.rs
+++ b/storage/src/database/tezedge_database.rs
@@ -61,6 +61,9 @@ pub trait KVStore<S: KeyValueSchema> {
     /// # Arguments
     /// * `batch` - WriteBatch containing all batched writes to be written to DB
     fn write_batch(&self, batch: Vec<(S::Key, S::Value)>) -> Result<(), Error>;
+
+    /// Flush data to disk
+    fn flush(&self) -> Result<(), Error>;
 }
 
 pub trait KVStoreWithSchemaIterator<S: KeyValueSchema> {
@@ -234,6 +237,11 @@ impl<S: KVStoreKeyValueSchema> KVStore<S> for TezedgeDatabase {
         }
 
         self.backend.write_batch(S::column_name(), generic_batch)?;
+        Ok(())
+    }
+
+    fn flush(&self) -> Result<(), Error> {
+        self.backend.flush()?;
         Ok(())
     }
 }

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -494,6 +494,9 @@ pub fn store_applied_block_result(
         Head::new(block_hash.clone(), block_metadata.level(), block_fitness),
     )?;
 
+    // Flush to disk
+    block_storage.flush()?;
+
     // return additional data for later use
     Ok(block_additional_data)
 }

--- a/storage/src/operations_meta_storage.rs
+++ b/storage/src/operations_meta_storage.rs
@@ -136,11 +136,11 @@ impl KVStoreKeyValueSchema for OperationsMetaStorage {
 pub fn merge_meta_value(
     _new_key: &[u8],
     existing_val: Option<&[u8]>,
-    operands: &mut MergeOperands,
+    operands: &MergeOperands,
 ) -> Option<Vec<u8>> {
     let mut result = existing_val.map(|v| v.to_vec());
 
-    for op in operands {
+    for op in operands.iter() {
         match result {
             Some(ref mut val) => {
                 debug_assert_eq!(

--- a/tezos/api/src/ffi.rs
+++ b/tezos/api/src/ffi.rs
@@ -531,6 +531,21 @@ impl From<TezosErrorTrace> for RestoreContextError {
 }
 
 #[cfg_attr(feature = "fuzzing", derive(fuzzcheck::DefaultMutator))]
+#[derive(Error, Serialize, Deserialize, Debug, Clone)]
+pub enum IntegrityCheckContextError {
+    #[error("OCaml failed to restore the context from a dump, message: {message}!")]
+    IntegrityError { message: String },
+}
+
+impl From<TezosErrorTrace> for IntegrityCheckContextError {
+    fn from(error: TezosErrorTrace) -> Self {
+        Self::IntegrityError {
+            message: error.trace_json,
+        }
+    }
+}
+
+#[cfg_attr(feature = "fuzzing", derive(fuzzcheck::DefaultMutator))]
 #[derive(Error, Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub enum ApplyBlockError {
     #[error("Incomplete operations, expected: {expected}, has actual: {actual}!")]

--- a/tezos/context/src/kv_store/persistent.rs
+++ b/tezos/context/src/kv_store/persistent.rs
@@ -666,6 +666,7 @@ hashes_file={:?}, in sizes.db={:?}",
         let strings_file = self.strings_file.try_clone()?;
         let big_strings_file = self.big_strings_file.try_clone()?;
         let commit_index_file = self.commit_index_file.try_clone()?;
+        let hashes_file = self.hashes.hashes_file.try_clone()?;
 
         // Spawn the deserializers
         let thread_shapes = std::thread::spawn(move || {
@@ -705,6 +706,8 @@ hashes_file={:?}, in sizes.db={:?}",
                     reason: format!("{:?}", e),
                 })??;
 
+        // `Hashes` needs to be re-created because the size of the file might have changed
+        self.hashes = Hashes::try_new(hashes_file);
         self.shapes = shapes;
         self.string_interner = string_interner;
         self.context_hashes = context_hashes.index;

--- a/tezos/context/src/persistent/file.rs
+++ b/tezos/context/src/persistent/file.rs
@@ -160,13 +160,29 @@ fn get_custom_flags() -> i32 {
     0
 }
 
+fn remove_file_when_empty(filepath: &Path) -> Result<(), std::io::Error> {
+    let metadata = std::fs::metadata(filepath)?;
+
+    if metadata.len() <= HEADER_LENGTH as u64 {
+        // The file might be empty or contains an old header
+        std::fs::remove_file(filepath)?;
+    }
+
+    Ok(())
+}
+
 impl<const T: TaggedFile> File<T> {
     pub fn try_new(base_path: &str, read_only: bool) -> Result<Self, OpenFileError> {
         std::fs::create_dir_all(&base_path)?;
 
         let file_type: FileType = T.into();
-        let append_mode = !matches!(file_type, FileType::Sizes);
+        let filepath = PathBuf::from(base_path).join(file_type.get_path());
 
+        if filepath.exists() && !read_only {
+            remove_file_when_empty(&filepath)?;
+        }
+
+        let append_mode = !matches!(file_type, FileType::Sizes);
         let mut options = OpenOptions::new();
 
         if read_only {
@@ -185,7 +201,7 @@ impl<const T: TaggedFile> File<T> {
                 .custom_flags(get_custom_flags());
         }
 
-        let mut file = options.open(PathBuf::from(base_path).join(file_type.get_path()))?;
+        let mut file = options.open(&filepath)?;
 
         // We use seek, in cases metadatas were not synchronized
         let offset = file.seek(SeekFrom::End(0))?;

--- a/tezos/conv/src/from_ocaml.rs
+++ b/tezos/conv/src/from_ocaml.rs
@@ -35,11 +35,11 @@ use tezos_api::ffi::{
     CommitGenesisResult, ComputePathError, ComputePathResponse, CycleRollsOwnerSnapshot,
     DumpContextError, Errored, FfiJsonEncoderError, ForkingTestchainData, GetDataError,
     GetLastContextHashesError, HelpersPreapplyError, HelpersPreapplyResponse,
-    InitProtocolContextResult, OperationClassification, PreFilterOperationError,
-    PreFilterOperationResponse, PreFilterOperationResult, PrevalidatorWrapper, ProtocolDataError,
-    ProtocolRpcError, ProtocolRpcResponse, Rational, RestoreContextError, RpcArgDesc, RpcMethod,
-    TezosErrorTrace, TezosStorageInitError, ValidateOperationError, ValidateOperationResponse,
-    ValidateOperationResult,
+    InitProtocolContextResult, IntegrityCheckContextError, OperationClassification,
+    PreFilterOperationError, PreFilterOperationResponse, PreFilterOperationResult,
+    PrevalidatorWrapper, ProtocolDataError, ProtocolRpcError, ProtocolRpcResponse, Rational,
+    RestoreContextError, RpcArgDesc, RpcMethod, TezosErrorTrace, TezosStorageInitError,
+    ValidateOperationError, ValidateOperationResponse, ValidateOperationResult,
 };
 use tezos_context_api::{
     ContextKvStoreConfiguration, TezosContextTezEdgeStorageConfiguration,
@@ -452,6 +452,8 @@ impl_from_ocaml_polymorphic_variant! {
             NodeMessage::DumpContextResponse(result),
         RestoreContextResponse(result: Result<(), OCamlTezosErrorTrace>) =>
             NodeMessage::RestoreContextResponse(result),
+        IntegrityCheckContextResponse(result: Result<(), OCamlTezosErrorTrace>) =>
+            NodeMessage::IntegrityCheckContextResponse(result),
 
         ContextGetLatestContextHashesResult(result: Result<OCamlList<OCamlContextHash>, OCamlTezosErrorTrace>) =>
             NodeMessage::ContextGetLatestContextHashesResult(result),
@@ -498,3 +500,4 @@ from_ocaml_tezos_error_trace!(ComputePathError, tezos_api::ffi::CallError);
 from_ocaml_tezos_error_trace!(DumpContextError);
 from_ocaml_tezos_error_trace!(GetLastContextHashesError);
 from_ocaml_tezos_error_trace!(RestoreContextError);
+from_ocaml_tezos_error_trace!(IntegrityCheckContextError);

--- a/tezos/conv/src/lib.rs
+++ b/tezos/conv/src/lib.rs
@@ -95,6 +95,7 @@ pub struct OCamlContextGetTreeByPrefixRequest {}
 // Dumps
 pub struct OCamlDumpContextRequest {}
 pub struct OCamlRestoreContextRequest {}
+pub struct OCamlIntegrityCheckContextRequest {}
 
 // Requests
 

--- a/tezos/conv/src/to_ocaml.rs
+++ b/tezos/conv/src/to_ocaml.rs
@@ -10,7 +10,7 @@ use crate::{
     OCamlContextGetKeyValuesByPrefixRequest, OCamlContextGetTreeByPrefixRequest,
     OCamlCycleRollsOwnerSnapshot, OCamlDumpContextRequest, OCamlGenesisChain,
     OCamlGenesisResultDataParams, OCamlHelpersPreapplyBlockRequest, OCamlInitProtocolContextParams,
-    OCamlJsonEncodeApplyBlockOperationsMetadataParams,
+    OCamlIntegrityCheckContextRequest, OCamlJsonEncodeApplyBlockOperationsMetadataParams,
     OCamlJsonEncodeApplyBlockResultMetadataParams, OCamlOperation, OCamlOperationShellHeader,
     OCamlPatchContext, OCamlProtocolMessage, OCamlProtocolOverrides, OCamlProtocolRpcRequest,
     OCamlRestoreContextRequest, OCamlRpcRequest, OCamlTezosContextConfiguration,
@@ -55,8 +55,9 @@ use tezos_messages::p2p::encoding::{
 use tezos_protocol_ipc_messages::{
     ContextGetKeyFromHistoryRequest, ContextGetKeyValuesByPrefixRequest,
     ContextGetTreeByPrefixRequest, DumpContextRequest, GenesisResultDataParams,
-    InitProtocolContextParams, JsonEncodeApplyBlockOperationsMetadataParams,
-    JsonEncodeApplyBlockResultMetadataParams, ProtocolMessage, RestoreContextRequest,
+    InitProtocolContextParams, IntegrityCheckContextRequest,
+    JsonEncodeApplyBlockOperationsMetadataParams, JsonEncodeApplyBlockResultMetadataParams,
+    ProtocolMessage, RestoreContextRequest,
 };
 
 // Hashes
@@ -503,6 +504,13 @@ impl_to_ocaml_record! {
     }
 }
 
+impl_to_ocaml_record! {
+    IntegrityCheckContextRequest => OCamlIntegrityCheckContextRequest {
+        context_path: String,
+        auto_repair: bool,
+    }
+}
+
 unsafe impl<'a> ToOCaml<OCamlBlockHeaderShellHeader> for FfiBlockHeaderShellHeader<'a> {
     fn to_ocaml<'gc>(&self, cr: &'gc mut OCamlRuntime) -> OCaml<'gc, OCamlBlockHeaderShellHeader> {
         ocaml_alloc_record! {
@@ -575,6 +583,7 @@ impl_to_ocaml_polymorphic_variant! {
         ProtocolMessage::ContextGetTreeByPrefix(req: OCamlContextGetTreeByPrefixRequest),
         ProtocolMessage::DumpContext(req: OCamlDumpContextRequest),
         ProtocolMessage::RestoreContext(req: OCamlRestoreContextRequest),
+        ProtocolMessage::IntegrityCheckContext(req: OCamlIntegrityCheckContextRequest),
         ProtocolMessage::ContextGetLatestContextHashes(req: OCamlInt),
         ProtocolMessage::GetContextRawBytes(req: OCamlProtocolRpcRequest),
         ProtocolMessage::GetEndorsingRights(req: OCamlProtocolRpcRequest),

--- a/tezos/interop/tests/integrity_check.rs
+++ b/tezos/interop/tests/integrity_check.rs
@@ -1,0 +1,37 @@
+// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use std::str::FromStr;
+
+use tezos_interop::apply_encoded_message;
+use tezos_protocol_ipc_messages::{IntegrityCheckContextRequest, NodeMessage, ProtocolMessage};
+
+#[test]
+fn test_integrity_check() {
+    let context_path = match std::env::var("IRMIN_INTEGRITY_CHECK_PATH") {
+        Ok(path) => path,
+        Err(_) => {
+            eprintln!("Irmin path not found, ignoring test");
+            return;
+        }
+    };
+
+    let auto_repair: bool = std::env::var("IRMIN_INTEGRITY_CHECK_AUTO_REPAIR")
+        .ok()
+        .and_then(|s| FromStr::from_str(s.as_str()).ok())
+        .unwrap_or(false);
+
+    let result = apply_encoded_message(ProtocolMessage::IntegrityCheckContext(
+        IntegrityCheckContextRequest {
+            context_path,
+            auto_repair,
+        },
+    ))
+    .unwrap();
+
+    eprintln!("Result={:?}", result);
+    assert!(matches!(
+        result,
+        NodeMessage::IntegrityCheckContextResponse(Ok(()))
+    ));
+}

--- a/tezos/protocol-ipc-messages/src/lib.rs
+++ b/tezos/protocol-ipc-messages/src/lib.rs
@@ -15,9 +15,9 @@ use tezos_api::ffi::{
     BeginConstructionRequest, CommitGenesisResult, ComputePathError, ComputePathRequest,
     ComputePathResponse, DumpContextError, FfiJsonEncoderError, GetDataError,
     GetLastContextHashesError, HelpersPreapplyBlockRequest, HelpersPreapplyError,
-    HelpersPreapplyResponse, InitProtocolContextResult, PreFilterOperationError,
-    PreFilterOperationResponse, PrevalidatorWrapper, ProtocolDataError, ProtocolRpcError,
-    ProtocolRpcRequest, ProtocolRpcResponse, RestoreContextError, RustBytes,
+    HelpersPreapplyResponse, InitProtocolContextResult, IntegrityCheckContextError,
+    PreFilterOperationError, PreFilterOperationResponse, PrevalidatorWrapper, ProtocolDataError,
+    ProtocolRpcError, ProtocolRpcRequest, ProtocolRpcResponse, RestoreContextError, RustBytes,
     TezosRuntimeConfiguration, TezosStorageInitError, ValidateOperationError,
     ValidateOperationRequest, ValidateOperationResponse,
 };
@@ -55,6 +55,7 @@ pub enum ProtocolMessage {
     GetCycleDelegates(ProtocolRpcRequest),
     DumpContext(DumpContextRequest),
     RestoreContext(RestoreContextRequest),
+    IntegrityCheckContext(IntegrityCheckContextRequest),
     ContextGetLatestContextHashes(i64),
     Ping,
     ShutdownCall,
@@ -90,6 +91,12 @@ pub struct RestoreContextRequest {
     pub expected_context_hash: ContextHash,
     pub restore_from_path: String,
     pub nb_context_elements: i64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct IntegrityCheckContextRequest {
+    pub context_path: String,
+    pub auto_repair: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -160,13 +167,13 @@ pub enum NodeMessage {
     ContextGetTreeByPrefixResult(Result<StringTreeObject, String>),
     DumpContextResponse(Result<i64, DumpContextError>),
     RestoreContextResponse(Result<(), RestoreContextError>),
+    IntegrityCheckContextResponse(Result<(), IntegrityCheckContextError>),
     ContextGetLatestContextHashesResult(Result<Vec<ContextHash>, GetLastContextHashesError>),
 
     // TODO: generic error response instead with error types?
     IpcResponseEncodingFailure(String),
 
     PingResult,
-
     ShutdownResult,
 }
 


### PR DESCRIPTION
- Call `rocksdb::DBWithThreadMode::flush_wal` after every block application, this flush the WAL buffer to disk.
  This requires updating `rockdb` to 0.18
- Use `File::sync_all` on the commit log, instead of `<File as io::Write>::flush`, because flush is a no-op: https://github.com/rust-lang/rust/blob/master/library/std/src/sys/unix/fs.rs#L990
- Fix reloading the context from disk. When the file `hashes.db` is truncated, take into account its new size
- Add the message `ProtocolMessage::IntegrityCheckContext`, to test the integrity of irmin