### PR TITLE
Fix possible errors in RPC due to serde_json::Value conversions

### DIFF
--- a/monitoring/src/monitor.rs
+++ b/monitoring/src/monitor.rs
@@ -189,7 +189,7 @@ impl Receive<BroadcastSignal> for Monitor {
             if let Some(client) = client {
                 let res = match serde_json::to_value(msg) {
                     Ok(serialized) => {
-                        JsonRpcResponse::result(json_rpc_types::Version::V2, serialized.into(), id)
+                        JsonRpcResponse::result(json_rpc_types::Version::V2, serialized, id)
                     }
                     Err(_) => {
                         let error = json_rpc_types::Error::from_code(

--- a/monitoring/src/websocket/mod.rs
+++ b/monitoring/src/websocket/mod.rs
@@ -1,7 +1,6 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use rpc::ServiceResultBody;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::{mpsc, RwLock};
@@ -14,4 +13,4 @@ mod ws_server;
 pub use ws_manager::{WebsocketHandler, WebsocketHandlerMsg};
 
 type RpcClients = Arc<RwLock<HashMap<String, RpcClient>>>;
-pub type RpcClient = Option<mpsc::UnboundedSender<json_rpc_types::Response<ServiceResultBody, ()>>>;
+pub type RpcClient = Option<mpsc::UnboundedSender<json_rpc_types::Response<serde_json::Value, ()>>>;

--- a/monitoring/src/websocket/ws_json_rpc.rs
+++ b/monitoring/src/websocket/ws_json_rpc.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, pin::Pin};
 
 use rpc::{
     server::{parse_query_string, MethodHandler},
-    RpcServiceEnvironmentRef, ServiceResultBody,
+    RpcServiceEnvironmentRef,
 };
 use serde::{de::DeserializeOwned, Deserialize};
 use serde_json::Value;
@@ -19,7 +19,7 @@ pub struct PostRequestParams {
     pub body: Value,
 }
 
-pub type JsonRpcResponse = json_rpc_types::Response<ServiceResultBody, ()>;
+pub type JsonRpcResponse = json_rpc_types::Response<serde_json::Value, ()>;
 pub type JsonRpcError = json_rpc_types::Error<()>;
 
 /// Handles the json-rpc 2.0 requests and propagates it to the RPC handlers
@@ -58,7 +58,38 @@ pub async fn handle_request(
         );
 
         match Pin::from(fut).await {
-            Ok((_, resp)) => json_rpc_types::Response::result(req.jsonrpc, resp, req.id.clone()),
+            Ok(v) => {
+                let (_, body) = v.into_parts();
+                let body_bytes = match warp::hyper::body::to_bytes(body).await {
+                    Ok(body_bytes) => body_bytes,
+                    Err(_) => {
+                        let json_error = json_rpc_types::Error::with_custom_msg(
+                            json_rpc_types::ErrorCode::InternalError,
+                            "Failed to get bytes from hyper body",
+                        );
+                        return json_rpc_types::Response::error(
+                            req.jsonrpc,
+                            json_error,
+                            req.id.clone(),
+                        );
+                    }
+                };
+                let res = match serde_json::from_slice(&body_bytes) {
+                    Ok(res) => res,
+                    Err(_) => {
+                        let json_error = json_rpc_types::Error::with_custom_msg(
+                            json_rpc_types::ErrorCode::InternalError,
+                            "Failed to deserialize body bytes to json",
+                        );
+                        return json_rpc_types::Response::error(
+                            req.jsonrpc,
+                            json_error,
+                            req.id.clone(),
+                        );
+                    }
+                };
+                json_rpc_types::Response::result(req.jsonrpc, res, req.id.clone())
+            }
             Err(_) => {
                 let error =
                     json_rpc_types::Error::from_code(json_rpc_types::ErrorCode::InternalError);

--- a/monitoring/src/websocket/ws_json_rpc.rs
+++ b/monitoring/src/websocket/ws_json_rpc.rs
@@ -65,7 +65,7 @@ pub async fn handle_request(
                     Err(_) => {
                         let json_error = json_rpc_types::Error::with_custom_msg(
                             json_rpc_types::ErrorCode::InternalError,
-                            "Failed to get bytes from hyper body",
+                            "Failed to get bytes",
                         );
                         return json_rpc_types::Response::error(
                             req.jsonrpc,
@@ -79,7 +79,7 @@ pub async fn handle_request(
                     Err(_) => {
                         let json_error = json_rpc_types::Error::with_custom_msg(
                             json_rpc_types::ErrorCode::InternalError,
-                            "Failed to deserialize body bytes to json",
+                            "Failed to deserialize body",
                         );
                         return json_rpc_types::Response::error(
                             req.jsonrpc,

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -15,154 +15,82 @@ pub mod server;
 pub use server::rpc_server::{handle_notify_rpc_server_msg, RpcServer};
 pub use server::{RpcServiceEnvironment, RpcServiceEnvironmentRef};
 
-pub enum ServiceResultBody {
-    RawBytes(&'static [u8]),
-    RawString(String),
-    Json(serde_json::Value),
-}
-
-impl Default for ServiceResultBody {
-    fn default() -> Self {
-        Self::Json(Default::default())
-    }
-}
-
-impl From<serde_json::Value> for ServiceResultBody {
-    fn from(json: serde_json::Value) -> Self {
-        Self::Json(json)
-    }
-}
-
-impl From<String> for ServiceResultBody {
-    fn from(s: String) -> Self {
-        Self::RawString(s)
-    }
-}
-
-impl From<&'static [u8]> for ServiceResultBody {
-    fn from(raw: &'static [u8]) -> Self {
-        Self::RawBytes(raw)
-    }
-}
-
-impl serde::Serialize for ServiceResultBody {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        match self {
-            ServiceResultBody::Json(json) => json.serialize(serializer),
-            ServiceResultBody::RawBytes(raw) => {
-                let result = serde_json::value::RawValue::from_string(
-                    String::from_utf8_lossy(raw).to_string(),
-                );
-                match result {
-                    Ok(v) => v.serialize(serializer),
-                    Err(err) => Err(serde::ser::Error::custom(err)),
-                }
-            }
-            ServiceResultBody::RawString(s) => {
-                let result = serde_json::value::RawValue::from_string(s.clone());
-                match result {
-                    Ok(v) => v.serialize(serializer),
-                    Err(err) => Err(serde::ser::Error::custom(err)),
-                }
-            }
-        }
-    }
-}
-
 /// Crate level custom result
-pub type ServiceResult =
-    Result<(Response<Body>, ServiceResultBody), Box<dyn std::error::Error + Sync + Send>>;
+pub type ServiceResult = Result<Response<Body>, Box<dyn std::error::Error + Sync + Send>>;
 
 /// Generate options response with supported methods, headers
 pub(crate) fn options() -> ServiceResult {
-    Ok((
-        Response::builder()
-            .status(StatusCode::from_u16(200)?)
-            .header(hyper::header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
-            .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type")
-            .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "content-type")
-            .header(
-                hyper::header::ACCESS_CONTROL_ALLOW_HEADERS,
-                "x-requested-with",
-            )
-            .header(
-                hyper::header::ACCESS_CONTROL_ALLOW_METHODS,
-                "GET, POST, OPTIONS, PUT",
-            )
-            .body(Body::empty())?,
-        Default::default(),
-    ))
+    Ok(Response::builder()
+        .status(StatusCode::from_u16(200)?)
+        .header(hyper::header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+        .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type")
+        .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "content-type")
+        .header(
+            hyper::header::ACCESS_CONTROL_ALLOW_HEADERS,
+            "x-requested-with",
+        )
+        .header(
+            hyper::header::ACCESS_CONTROL_ALLOW_METHODS,
+            "GET, POST, OPTIONS, PUT",
+        )
+        .body(Body::empty())?)
 }
 
 /// Function to generate JSON response from serializable object
 pub fn make_json_response<T: serde::Serialize>(content: &T) -> ServiceResult {
-    let value = ServiceResultBody::Json(serde_json::to_value(content)?);
-    Ok((
-        Response::builder()
-            .header(hyper::header::CONTENT_TYPE, "application/json")
-            // TODO: add to config
-            .header(hyper::header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
-            .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type")
-            .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "content-type")
-            .header(
-                hyper::header::ACCESS_CONTROL_ALLOW_HEADERS,
-                "x-requested-with",
-            )
-            .header(
-                hyper::header::ACCESS_CONTROL_ALLOW_METHODS,
-                "GET, POST, OPTIONS, PUT",
-            )
-            .body(Body::from(serde_json::to_string(content)?))?,
-        value,
-    ))
+    Ok(Response::builder()
+        .header(hyper::header::CONTENT_TYPE, "application/json")
+        // TODO: add to config
+        .header(hyper::header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+        .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type")
+        .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "content-type")
+        .header(
+            hyper::header::ACCESS_CONTROL_ALLOW_HEADERS,
+            "x-requested-with",
+        )
+        .header(
+            hyper::header::ACCESS_CONTROL_ALLOW_METHODS,
+            "GET, POST, OPTIONS, PUT",
+        )
+        .body(Body::from(serde_json::to_string(content)?))?)
 }
 
 pub fn make_raw_response(raw: &'static [u8]) -> ServiceResult {
-    Ok((
-        Response::builder()
-            .header(hyper::header::CONTENT_TYPE, "application/json")
-            // TODO: add to config
-            .header(hyper::header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
-            .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type")
-            .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "content-type")
-            .header(
-                hyper::header::ACCESS_CONTROL_ALLOW_HEADERS,
-                "x-requested-with",
-            )
-            .header(
-                hyper::header::ACCESS_CONTROL_ALLOW_METHODS,
-                "GET, POST, OPTIONS, PUT",
-            )
-            .body(Body::from(raw))?,
-        raw.into(),
-    ))
+    Ok(Response::builder()
+        .header(hyper::header::CONTENT_TYPE, "application/json")
+        // TODO: add to config
+        .header(hyper::header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+        .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type")
+        .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "content-type")
+        .header(
+            hyper::header::ACCESS_CONTROL_ALLOW_HEADERS,
+            "x-requested-with",
+        )
+        .header(
+            hyper::header::ACCESS_CONTROL_ALLOW_METHODS,
+            "GET, POST, OPTIONS, PUT",
+        )
+        .body(Body::from(raw))?)
 }
 
 /// Produces a JSON response from an FFI RPC response
 pub fn make_response_with_status_and_json_string(status_code: u16, body: &str) -> ServiceResult {
-    let value = body.to_string().into();
-    Ok((
-        Response::builder()
-            .header(hyper::header::CONTENT_TYPE, "application/json")
-            // TODO: add to config
-            .header(hyper::header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
-            .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type")
-            .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "content-type")
-            .header(
-                hyper::header::ACCESS_CONTROL_ALLOW_HEADERS,
-                "x-requested-with",
-            )
-            .header(
-                hyper::header::ACCESS_CONTROL_ALLOW_METHODS,
-                "GET, POST, OPTIONS, PUT",
-            )
-            .status(status_code)
-            .body(Body::from(body.to_owned()))?,
-        value,
-    ))
+    Ok(Response::builder()
+        .header(hyper::header::CONTENT_TYPE, "application/json")
+        // TODO: add to config
+        .header(hyper::header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+        .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type")
+        .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "content-type")
+        .header(
+            hyper::header::ACCESS_CONTROL_ALLOW_HEADERS,
+            "x-requested-with",
+        )
+        .header(
+            hyper::header::ACCESS_CONTROL_ALLOW_METHODS,
+            "GET, POST, OPTIONS, PUT",
+        )
+        .status(status_code)
+        .body(Body::from(body.to_owned()))?)
 }
 
 /// Function to generate JSON response from a stream
@@ -171,23 +99,20 @@ pub(crate) fn make_json_stream_response<
 >(
     content: T,
 ) -> ServiceResult {
-    Ok((
-        Response::builder()
-            .header(hyper::header::CONTENT_TYPE, "application/json")
-            .header(hyper::header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
-            .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type")
-            .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "content-type")
-            .header(
-                hyper::header::ACCESS_CONTROL_ALLOW_HEADERS,
-                "x-requested-with",
-            )
-            .header(
-                hyper::header::ACCESS_CONTROL_ALLOW_METHODS,
-                "GET, POST, OPTIONS, PUT",
-            )
-            .body(Body::wrap_stream(content))?,
-        Default::default(),
-    ))
+    Ok(Response::builder()
+        .header(hyper::header::CONTENT_TYPE, "application/json")
+        .header(hyper::header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+        .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type")
+        .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "content-type")
+        .header(
+            hyper::header::ACCESS_CONTROL_ALLOW_HEADERS,
+            "x-requested-with",
+        )
+        .header(
+            hyper::header::ACCESS_CONTROL_ALLOW_METHODS,
+            "GET, POST, OPTIONS, PUT",
+        )
+        .body(Body::wrap_stream(content))?)
 }
 
 /// Returns result as a JSON response.
@@ -240,37 +165,31 @@ pub(crate) fn result_to_empty_json_response(
 
 /// Generate empty response
 pub(crate) fn empty() -> ServiceResult {
-    Ok((
-        Response::builder()
-            .status(StatusCode::from_u16(204)?)
-            .header(hyper::header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
-            .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type")
-            .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "content-type")
-            .header(
-                hyper::header::ACCESS_CONTROL_ALLOW_HEADERS,
-                "x-requested-with",
-            )
-            .body(Body::empty())?,
-        Default::default(),
-    ))
+    Ok(Response::builder()
+        .status(StatusCode::from_u16(204)?)
+        .header(hyper::header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+        .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type")
+        .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "content-type")
+        .header(
+            hyper::header::ACCESS_CONTROL_ALLOW_HEADERS,
+            "x-requested-with",
+        )
+        .body(Body::empty())?)
 }
 
 /// Generate 404 response
 pub(crate) fn not_found() -> ServiceResult {
-    Ok((
-        Response::builder()
-            .status(StatusCode::from_u16(404)?)
-            .header(hyper::header::CONTENT_TYPE, "text/plain")
-            .header(hyper::header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
-            .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type")
-            .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "content-type")
-            .header(
-                hyper::header::ACCESS_CONTROL_ALLOW_HEADERS,
-                "x-requested-with",
-            )
-            .body(Body::empty())?,
-        Default::default(),
-    ))
+    Ok(Response::builder()
+        .status(StatusCode::from_u16(404)?)
+        .header(hyper::header::CONTENT_TYPE, "text/plain")
+        .header(hyper::header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+        .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type")
+        .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "content-type")
+        .header(
+            hyper::header::ACCESS_CONTROL_ALLOW_HEADERS,
+            "x-requested-with",
+        )
+        .body(Body::empty())?)
 }
 
 /// Generate 500 error
@@ -290,20 +209,16 @@ pub(crate) fn handle_rpc_service_error(error: RpcServiceError) -> ServiceResult 
 
 /// Generate 500 error with message as body
 pub(crate) fn error_with_message(error_msg: String) -> ServiceResult {
-    let value = error_msg.clone().into();
-    Ok((
-        Response::builder()
-            .status(StatusCode::from_u16(500)?)
-            .header(hyper::header::CONTENT_TYPE, "text/plain")
-            .header(hyper::header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
-            .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type")
-            .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "content-type")
-            .header(
-                hyper::header::ACCESS_CONTROL_ALLOW_HEADERS,
-                "x-requested-with",
-            )
-            .header(hyper::header::TRANSFER_ENCODING, "chunked")
-            .body(Body::from(error_msg))?,
-        value,
-    ))
+    Ok(Response::builder()
+        .status(StatusCode::from_u16(500)?)
+        .header(hyper::header::CONTENT_TYPE, "text/plain")
+        .header(hyper::header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+        .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type")
+        .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "content-type")
+        .header(
+            hyper::header::ACCESS_CONTROL_ALLOW_HEADERS,
+            "x-requested-with",
+        )
+        .header(hyper::header::TRANSFER_ENCODING, "chunked")
+        .body(Body::from(error_msg))?)
 }

--- a/rpc/src/server/dev_handler.rs
+++ b/rpc/src/server/dev_handler.rs
@@ -299,21 +299,16 @@ pub async fn dev_shell_automaton_state_raw_get(
     let state = dev_services::get_shell_automaton_state_current(&env).await?;
     let contents = state.encode()?;
 
-    let contents_string = serde_json::to_value(&contents)?;
-
-    Ok((
-        Response::builder()
-            .header(hyper::header::CONTENT_TYPE, "application/octet-stream")
-            .header(hyper::header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
-            .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type")
-            .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "content-type")
-            .header(
-                hyper::header::ACCESS_CONTROL_ALLOW_METHODS,
-                "GET, POST, OPTIONS, PUT",
-            )
-            .body(Body::from(contents))?,
-        contents_string.into(),
-    ))
+    Ok(Response::builder()
+        .header(hyper::header::CONTENT_TYPE, "application/octet-stream")
+        .header(hyper::header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+        .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type")
+        .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "content-type")
+        .header(
+            hyper::header::ACCESS_CONTROL_ALLOW_METHODS,
+            "GET, POST, OPTIONS, PUT",
+        )
+        .body(Body::from(contents))?)
 }
 
 pub async fn dev_shell_automaton_actions_raw_get(
@@ -330,21 +325,17 @@ pub async fn dev_shell_automaton_actions_raw_get(
     .await?;
 
     let contents = actions.encode()?;
-    let contents_value = serde_json::to_value(&contents)?;
 
-    Ok((
-        Response::builder()
-            .header(hyper::header::CONTENT_TYPE, "application/octet-stream")
-            .header(hyper::header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
-            .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type")
-            .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "content-type")
-            .header(
-                hyper::header::ACCESS_CONTROL_ALLOW_METHODS,
-                "GET, POST, OPTIONS, PUT",
-            )
-            .body(Body::from(contents))?,
-        contents_value.into(),
-    ))
+    Ok(Response::builder()
+        .header(hyper::header::CONTENT_TYPE, "application/octet-stream")
+        .header(hyper::header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
+        .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type")
+        .header(hyper::header::ACCESS_CONTROL_ALLOW_HEADERS, "content-type")
+        .header(
+            hyper::header::ACCESS_CONTROL_ALLOW_METHODS,
+            "GET, POST, OPTIONS, PUT",
+        )
+        .body(Body::from(contents))?)
 }
 
 pub async fn dev_shell_automaton_storage_requests_get(

--- a/rpc/src/server/mod.rs
+++ b/rpc/src/server/mod.rs
@@ -31,7 +31,7 @@ use tezos_context_ipc_client::TezedgeContextClient;
 use tezos_messages::p2p::encoding::version::NetworkVersion;
 use url::Url;
 
-use crate::{error_with_message, not_found, options, ServiceResultBody};
+use crate::{error_with_message, not_found, options};
 
 mod dev_handler;
 mod openapi_handler;
@@ -135,8 +135,7 @@ pub type Params = Vec<(String, String)>;
 
 pub type Query = HashMap<String, Vec<String>>;
 
-pub type HResult =
-    Result<(Response<Body>, ServiceResultBody), Box<dyn std::error::Error + Sync + Send>>;
+pub type HResult = Result<Response<Body>, Box<dyn std::error::Error + Sync + Send>>;
 
 pub type Handler = Arc<
     dyn Fn(
@@ -234,7 +233,7 @@ pub fn spawn_server(
                         };
 
                         let result = match result {
-                            Ok((v, _)) => {
+                            Ok(v) => {
                                 let remote_addr = remote_addr;
                                 let req_method = req_method.clone();
                                 let normalized_path = normalized_path.clone();


### PR DESCRIPTION
Removed the old approach where the content was serialized as serde_json::Value and returned alongside the Response<Body> from the RPC handlers. Now we extract and deserialize the Response<Body> in the WebSocket RPC handler, so there is no need for additional conversions in the RPC crate. 

@tizoc This was causing additional errors for the stats RPCs uncovered yesterday by @binier . This approach also removes the concerns of performance regression in case of calling the hyper side (HTTP) of the RPCs (no additional serialization). 