### PR TITLE
Workaround for unimplemented panic in describe endpoint

### DIFF
--- a/rpc/src/server/router.rs
+++ b/rpc/src/server/router.rs
@@ -254,7 +254,7 @@ pub fn create_routes(tezedge_is_enabled: bool) -> PathTree<MethodHandler> {
 
     // Other Protocol rpcs - routed through ffi calls
     routes.handle(
-        hash_set![Method::GET, Method::POST, Method::OPTIONS, Method::PUT],
+        hash_set![Method::GET, Method::POST, Method::PUT],
         "/chains/:chain_id/blocks/:block_id/*any",
         protocol_handler::call_protocol_rpc,
     );

--- a/rpc/src/server/shell_handler.rs
+++ b/rpc/src/server/shell_handler.rs
@@ -812,7 +812,21 @@ pub async fn describe(
         {
             &Method::GET
         } else {
-            allowed_methods.iter().next().unwrap()
+            if path.contains(&"context".to_string())
+                && (path.contains(&"rank".to_string())
+                    || path.contains(&"big_map_get".to_string())
+                    || path.contains(&"seed".to_string()))
+            {
+                &Method::POST
+            } else {
+                if allowed_methods.contains(&Method::GET) {
+                    &Method::GET
+                } else {
+                    // FIXME: the topmost comment mentions that we get the "first element",
+                    // however this element is random in hash-sets.
+                    allowed_methods.iter().next().unwrap()
+                }
+            }
         }
     } else {
         return empty();


### PR DESCRIPTION
We lack a proper implementation for the _describe_ endpoint. The current implementation provides method information for dynamic endpoints by picking an element from a method list passed when registering the endpoint. This cause it to report incorrect methods for some endpoints in a aleatory fashion.

This fix is a workaround that adds a few more rules to properly handle some problematic cases and solves a _panic_ issue in particular.

A proper fix would require a full rewrite based on OpenAPI schema files that have to be keep up to date with protocol updates. 