### PR TITLE
Fix tezos-encoding `Dynamic` documentation + add further `derive`s for `Zarith` & `BigInt`

### DIFF
--- a/tezos/encoding/src/encoding.rs
+++ b/tezos/encoding/src/encoding.rs
@@ -1,4 +1,4 @@
-// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// Copyright (c) SimpleStaking, Viable Systems, Trili Tech and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
 //! Schema used for serialization and deserialization.
@@ -196,10 +196,10 @@ pub enum Encoding {
     /// Encoded as continuous binary representation.
     Tup(Vec<Encoding>),
     /// Is the collection of fields.
-    /// prefixed its length in bytes (4 Bytes), encoded as the concatenation of all the element in binary
+    /// prefixed its length in bytes (1 Bytes), encoded as the concatenation of all the element in binary
     ShortDynamic(Box<Encoding>),
     /// Is the collection of fields.
-    /// prefixed its length in bytes (1 Byte), encoded as the concatenation of all the element in binary
+    /// prefixed its length in bytes (4 Byte), encoded as the concatenation of all the element in binary
     Dynamic(Box<Encoding>),
     /// Is the collection of fields.
     /// prefixed its length in bytes (4 Bytes), encoded as the concatenation of all the element in binary

--- a/tezos/encoding/src/types.rs
+++ b/tezos/encoding/src/types.rs
@@ -1,4 +1,4 @@
-// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// Copyright (c) SimpleStaking, Viable Systems, Trili Tech and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
 //! Defines types of the intermediate data format.
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use crate::fuzzing::bigint::BigIntMutator;
 
 /// This is a wrapper for [num_bigint::BigInt] type.
-#[derive(PartialEq, Debug, Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BigInt(pub num_bigint::BigInt);
 
 impl From<num_bigint::BigInt> for BigInt {
@@ -47,7 +47,7 @@ impl From<&BigInt> for num_bigint::BigInt {
 }
 
 /// Zarith number
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Zarith(pub num_bigint::BigInt);
 
 impl From<num_bigint::BigInt> for Zarith {


### PR DESCRIPTION
# Overview
Thanks so much for these crates!  They've massively simplified interacting with tezos encodings from rust

- `Dynamic`/`ShortDynamic` docs *prefix length* look to be the wrong way round
- when using `Zarith` in encodings, wasn't able to auto-derive `PartialEq` & `Eq`, which are supported by `num_bigint`, so have added those derivations
- derive `Clone` for `BigInt`, which is really useful when writing tests involving `BigInt`