### PR TITLE
Allow None for pred metadata ops

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1935,7 +1935,6 @@ defs:
       - log_dir=/drone/src/python-test-logs/$${DRONE_STEP_NAME}_logs
       - mkdir -p $log_dir && echo "Logs are place on $${PYTHON_LOGS_SERVER_ADDRESS} - $${PYTHON_LOGS_SERVER_PATH}}"
       - poetry run pytest -s --log-dir=$log_dir --timeout=600 tests$${TEST_PROTO_DIR_SUFFIX}/$${PYTHON_TEST}
-    failure: ignore
 
 steps:
 
@@ -2110,6 +2109,7 @@ steps:
   <<: *python-test
   environment:
     PYTHON_TEST: test_per_block_votes.py
+  failure: ignore # TODO: remove once everything has been fixed
 
 - name: sapling-test
   <<: *python-test
@@ -2120,13 +2120,11 @@ steps:
   <<: *python-test
   environment:
     PYTHON_TEST: test_tenderbake.py
-  failure: ignore # TODO: remove once everything has been fixed
 
 - name: tenderbake-manual-bake-test
   <<: *python-test
   environment:
     PYTHON_TEST: test_tenderbake_manual_bake.py
-  failure: ignore # TODO: remove once everything has been fixed
 
 - name: tenderbake-long-dynamic-bake-test
   <<: *python-test
@@ -2138,13 +2136,11 @@ steps:
   <<: *python-test
   environment:
     PYTHON_TEST: test_tenderbake_bakers_restart.py
-  failure: ignore # TODO: remove once everything has been fixed
 
 - name: tenderbake-incremental-start-test
   <<: *python-test
   environment:
     PYTHON_TEST: test_tenderbake_incremental_start.py
-  failure: ignore # TODO: remove once everything has been fixed
 
 - name: basic-test
   <<: *python-test
@@ -2662,6 +2658,7 @@ steps:
   <<: *python-test
   environment:
     PYTHON_TEST: test_per_block_votes.py
+  failure: ignore # TODO: remove once everything has been fixed
 
 - name: sapling-test
   <<: *python-test
@@ -2672,13 +2669,11 @@ steps:
   <<: *python-test
   environment:
     PYTHON_TEST: test_tenderbake.py
-  failure: ignore # TODO: remove once everything has been fixed
 
 - name: tenderbake-manual-bake-test
   <<: *python-test
   environment:
     PYTHON_TEST: test_tenderbake_manual_bake.py
-  failure: ignore # TODO: remove once everything has been fixed
 
 - name: tenderbake-long-dynamic-bake-test
   <<: *python-test
@@ -2690,13 +2685,11 @@ steps:
   <<: *python-test
   environment:
     PYTHON_TEST: test_tenderbake_bakers_restart.py
-  failure: ignore # TODO: remove once everything has been fixed
 
 - name: tenderbake-incremental-start-test
   <<: *python-test
   environment:
     PYTHON_TEST: test_tenderbake_incremental_start.py
-  failure: ignore # TODO: remove once everything has been fixed
 
 - name: basic-test
   <<: *python-test

--- a/rpc/src/server/router.rs
+++ b/rpc/src/server/router.rs
@@ -403,7 +403,6 @@ pub fn create_routes(tezedge_is_enabled: bool, allow_unsafe: bool) -> PathTree<M
     );
 
     if allow_unsafe {
-        eprintln!("======= adding unsafe rpc");
         routes.handle(
             hash_set![Method::PATCH],
             "/dev/shell/automaton/bakers",

--- a/shell_automaton/src/baker/baker_state.rs
+++ b/shell_automaton/src/baker/baker_state.rs
@@ -65,7 +65,7 @@ pub struct ElectedBlock {
     pub(super) round: i32,
     pub(super) payload_hash: BlockPayloadHash,
     pub(super) block_metadata_hash: BlockMetadataHash,
-    pub(super) ops_metadata_hash: OperationMetadataListListHash,
+    pub(super) ops_metadata_hash: Option<OperationMetadataListListHash>,
     pub(super) operations: Vec<Vec<Operation>>,
     pub(super) non_consensus_op_hashes: Vec<OperationHash>,
 }

--- a/shell_automaton/src/baker/block_baker/baker_block_baker_reducer.rs
+++ b/shell_automaton/src/baker/block_baker/baker_block_baker_reducer.rs
@@ -1,9 +1,7 @@
 // Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use crypto::hash::{
-    BlockPayloadHash, HashTrait, HashType, OperationListHash, OperationMetadataListListHash,
-};
+use crypto::hash::{BlockPayloadHash, HashTrait, HashType, OperationListHash};
 use storage::BlockHeaderWithHash;
 use tezos_encoding::types::SizedBytes;
 use tezos_messages::p2p::encoding::block_header::BlockHeaderBuilder;
@@ -112,16 +110,7 @@ pub fn baker_block_baker_reducer(state: &mut State, action: &ActionWithMeta) {
                                 )
                                 .ok()
                             })?;
-                            let ops_metadata_hash = state
-                                .current_head
-                                .ops_metadata_hash()
-                                .cloned()
-                                .or_else(|| {
-                                    OperationMetadataListListHash::try_from_bytes(
-                                        &[0; HashType::OperationMetadataListListHash.size()],
-                                    )
-                                    .ok()
-                                })?;
+                            let ops_metadata_hash = state.current_head.ops_metadata_hash().cloned();
                             Some(ElectedBlock {
                                 block,
                                 round: 0,
@@ -277,7 +266,7 @@ pub fn baker_block_baker_reducer(state: &mut State, action: &ActionWithMeta) {
                         round,
                         payload_hash: payload_hash?.clone(),
                         block_metadata_hash: block_metadata_hash?.clone(),
-                        ops_metadata_hash: ops_metadata_hash?.clone(),
+                        ops_metadata_hash: ops_metadata_hash.cloned(),
                         operations: vec![],
                         non_consensus_op_hashes: vec![],
                     });
@@ -378,7 +367,7 @@ pub fn baker_block_baker_reducer(state: &mut State, action: &ActionWithMeta) {
                                 predecessor_header: p.pred_header.clone(),
                                 predecessor_max_operations_ttl,
                                 pred_block_metadata_hash: p.pred_block_metadata_hash.clone(),
-                                pred_ops_metadata_hash: p.pred_ops_metadata_hash.clone(),
+                                pred_ops_metadata_hash: Some(p.pred_ops_metadata_hash.clone()),
                             })
                             .or_else(|| {
                                 let current_head = &state.current_head;
@@ -398,8 +387,8 @@ pub fn baker_block_baker_reducer(state: &mut State, action: &ActionWithMeta) {
                                         .pred_block_metadata_hash()?
                                         .clone(),
                                     pred_ops_metadata_hash: current_head
-                                        .pred_ops_metadata_hash()?
-                                        .clone(),
+                                        .pred_ops_metadata_hash()
+                                        .cloned(),
                                 })
                             });
                         match built_block {

--- a/shell_automaton/src/baker/block_baker/baker_block_baker_state.rs
+++ b/shell_automaton/src/baker/block_baker/baker_block_baker_state.rs
@@ -238,7 +238,7 @@ pub struct BuiltBlock {
     pub predecessor_header: BlockHeader,
     pub predecessor_max_operations_ttl: i32,
     pub pred_block_metadata_hash: BlockMetadataHash,
-    pub pred_ops_metadata_hash: OperationMetadataListListHash,
+    pub pred_ops_metadata_hash: Option<OperationMetadataListListHash>,
 }
 
 impl BuiltBlock {
@@ -284,7 +284,7 @@ pub struct BlockPreapplyRequest {
     pub operations: Vec<Vec<Operation>>,
     pub predecessor_header: BlockHeader,
     pub predecessor_block_metadata_hash: BlockMetadataHash,
-    pub predecessor_ops_metadata_hash: OperationMetadataListListHash,
+    pub predecessor_ops_metadata_hash: Option<OperationMetadataListListHash>,
     pub predecessor_max_operations_ttl: i32,
 }
 
@@ -297,7 +297,7 @@ impl From<BlockPreapplyRequest> for tezos_api::ffi::PreapplyBlockRequest {
             operations: req.operations.clone(),
             predecessor_header: req.predecessor_header.clone(),
             predecessor_block_metadata_hash: Some(req.predecessor_block_metadata_hash.clone()),
-            predecessor_ops_metadata_hash: Some(req.predecessor_ops_metadata_hash.clone()),
+            predecessor_ops_metadata_hash: req.predecessor_ops_metadata_hash.clone(),
             predecessor_max_operations_ttl: req.predecessor_max_operations_ttl,
         }
     }


### PR DESCRIPTION
When using protocol activation block as predecessor (with validation_pass = 0), its ops metadata hash should be None, to match Ocaml behavior.