### PR TITLE
Crypto: add tz4 support (hashes only)

### DIFF
--- a/crypto/src/hash.rs
+++ b/crypto/src/hash.rs
@@ -1,4 +1,4 @@
-// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// Copyright (c) SimpleStaking, Viable Systems, Trili Tech and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
 use std::convert::{TryFrom, TryInto};
@@ -29,6 +29,7 @@ mod prefix_bytes {
     pub const CONTRACT_TZ1_HASH: [u8; 3] = [6, 161, 159];
     pub const CONTRACT_TZ2_HASH: [u8; 3] = [6, 161, 161];
     pub const CONTRACT_TZ3_HASH: [u8; 3] = [6, 161, 164];
+    pub const CONTRACT_TZ4_HASH: [u8; 3] = [6, 161, 166];
     pub const PUBLIC_KEY_ED25519: [u8; 4] = [13, 15, 37, 217];
     pub const PUBLIC_KEY_SECP256K1: [u8; 4] = [3, 254, 226, 86];
     pub const PUBLIC_KEY_P256: [u8; 4] = [3, 178, 139, 127];
@@ -286,6 +287,7 @@ define_hash!(ContractKt1Hash);
 define_hash!(ContractTz1Hash);
 define_hash!(ContractTz2Hash);
 define_hash!(ContractTz3Hash);
+define_hash!(ContractTz4Hash);
 define_hash!(CryptoboxPublicKeyHash);
 define_hash!(PublicKeyEd25519);
 define_hash!(PublicKeySecp256k1);
@@ -329,6 +331,8 @@ pub enum HashType {
     ContractTz2Hash,
     // "\006\161\164" (* tz3(36) *)
     ContractTz3Hash,
+    // "\006\161\166" (* tz4(36) *)
+    ContractTz4Hash,
     // "\013\015\037\217" (* edpk(54) *)
     PublicKeyEd25519,
     // "\003\254\226\086" (* sppk(55) *)
@@ -367,6 +371,7 @@ impl HashType {
             HashType::ContractTz1Hash => &CONTRACT_TZ1_HASH,
             HashType::ContractTz2Hash => &CONTRACT_TZ2_HASH,
             HashType::ContractTz3Hash => &CONTRACT_TZ3_HASH,
+            HashType::ContractTz4Hash => &CONTRACT_TZ4_HASH,
             HashType::PublicKeyEd25519 => &PUBLIC_KEY_ED25519,
             HashType::PublicKeySecp256k1 => &PUBLIC_KEY_SECP256K1,
             HashType::PublicKeyP256 => &PUBLIC_KEY_P256,
@@ -398,7 +403,8 @@ impl HashType {
             HashType::ContractKt1Hash
             | HashType::ContractTz1Hash
             | HashType::ContractTz2Hash
-            | HashType::ContractTz3Hash => 20,
+            | HashType::ContractTz3Hash
+            | HashType::ContractTz4Hash => 20,
             HashType::PublicKeySecp256k1 | HashType::PublicKeyP256 => 33,
             HashType::SeedEd25519 => 32,
             HashType::Ed25519Signature | HashType::Signature => 64,
@@ -930,6 +936,16 @@ mod tests {
     }
 
     #[test]
+    fn test_encode_contract_tz4() -> Result<(), anyhow::Error> {
+        let decoded = HashType::ContractTz4Hash
+            .hash_to_b58check(&hex::decode("886fed9ede9a91bb73a84108d991422c80fc40a3")?)?;
+        let expected = "tz4MSfZsn6kMDczShy8PMeB628TNukn9hi2K";
+        assert_eq!(expected, decoded);
+
+        Ok(())
+    }
+
+    #[test]
     fn test_encode_contract_kt1() -> Result<(), anyhow::Error> {
         let decoded = HashType::ContractKt1Hash
             .hash_to_b58check(&hex::decode("42b419240509ddacd12839700b7f720b4aa55e4e")?)?;
@@ -1172,6 +1188,16 @@ mod tests {
         test!(tz2_hash, ContractTz2Hash, []);
 
         test!(tz3_hash, ContractTz3Hash, []);
+
+        test!(
+            tz4_hash,
+            ContractTz4Hash,
+            [
+                "tz4MSfZsn6kMDczShy8PMeB628TNukn9hi2K",
+                "tz4UGLdFGkjXEtED52TEfZiFrPDA4ShL77rS",
+                "tz4WnGDH3YteS9vc7V7Fz2FnYVnY9z2iFdyv"
+            ]
+        );
 
         test!(pk_hash, CryptoboxPublicKeyHash, []);
 

--- a/tezos/encoding/src/enc.rs
+++ b/tezos/encoding/src/enc.rs
@@ -1,4 +1,4 @@
-//! Copyright (c) SimpleStaking and Tezedge Contributors
+//! Copyright (c) SimpleStaking, Trili Tech and Tezedge Contributors
 //! SPDX-License-Identifier: MIT
 
 use std::convert::TryFrom;
@@ -268,6 +268,7 @@ encode_hash!(crypto::hash::ContractKt1Hash);
 encode_hash!(crypto::hash::ContractTz1Hash);
 encode_hash!(crypto::hash::ContractTz2Hash);
 encode_hash!(crypto::hash::ContractTz3Hash);
+encode_hash!(crypto::hash::ContractTz4Hash);
 encode_hash!(crypto::hash::CryptoboxPublicKeyHash);
 encode_hash!(crypto::hash::PublicKeyEd25519);
 encode_hash!(crypto::hash::PublicKeySecp256k1);

--- a/tezos/encoding/src/encoding.rs
+++ b/tezos/encoding/src/encoding.rs
@@ -329,6 +329,7 @@ hash_has_encoding!(ContractKt1Hash, CONTRACT_KT1HASH);
 hash_has_encoding!(ContractTz1Hash, CONTRACT_TZ1HASH);
 hash_has_encoding!(ContractTz2Hash, CONTRACT_TZ2HASH);
 hash_has_encoding!(ContractTz3Hash, CONTRACT_TZ3HASH);
+hash_has_encoding!(ContractTz4Hash, CONTRACT_TZ4HASH);
 hash_has_encoding!(CryptoboxPublicKeyHash, CRYPTOBOX_PUBLIC_KEY_HASH);
 hash_has_encoding!(PublicKeyEd25519, PUBLIC_KEY_ED25519);
 hash_has_encoding!(PublicKeySecp256k1, PUBLIC_KEY_SECP256K1);

--- a/tezos/encoding/src/nom.rs
+++ b/tezos/encoding/src/nom.rs
@@ -1,4 +1,4 @@
-// Copyright (c) SimpleStaking, Viable Systems and Tezedge Contributors
+// Copyright (c) SimpleStaking, Viable Systems, Trili Tech and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
 use crypto::hash::HashTrait;
@@ -255,6 +255,7 @@ hash_nom_reader!(ContractKt1Hash);
 hash_nom_reader!(ContractTz1Hash);
 hash_nom_reader!(ContractTz2Hash);
 hash_nom_reader!(ContractTz3Hash);
+hash_nom_reader!(ContractTz4Hash);
 hash_nom_reader!(CryptoboxPublicKeyHash);
 hash_nom_reader!(PublicKeyEd25519);
 hash_nom_reader!(PublicKeySecp256k1);


### PR DESCRIPTION
# Goal
Add support for `contract tz4` hashes in the `crypto` crate, primarily used in L2.  The prefixes are taken from [here](https://gitlab.com/tezos/tezos/-/blob/master/src/proto_alpha/lib_protocol/tx_rollup_prefixes.ml)

Planning to upstream support for `blst` public keys & signatures in a future PR (which back tz4 addresses)